### PR TITLE
feat: Log to a file configured by env.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 costs-mcp-server
+*.log

--- a/inspect.sh
+++ b/inspect.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+echo building the server...
+go build -o costs-mcp-server
+npx @modelcontextprotocol/inspector@0.8.0 -e MCP_LOG_FILE=application.log -e VANTAGE_BEARER_TOKEN=$VANTAGE_BEARER_TOKEN ./costs-mcp-server


### PR DESCRIPTION
Using MCP_LOG_FILE in the environment, log to that file when it is present, otherwise do not log at all. No logging to STDIO regardless.