### PR TITLE
feat: Assert the BearerToken is read-only.

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 golang 1.22.5
-nodejs 23.11.0
+nodejs 23.10.0

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/go-openapi/runtime v0.26.0
 	github.com/go-openapi/strfmt v0.21.7
 	github.com/metoro-io/mcp-golang v0.8.0
-	github.com/vantage-sh/vantage-go v0.0.58
+	github.com/vantage-sh/vantage-go v0.0.59
 )
 
 require (


### PR DESCRIPTION
# Ticket
https://linear.app/vantage-sh/issue/FIN-235/throw-error-if-api-token-is-not-read-only

# Changes
Consuming the updated `/v2/me` endpoint, verify the BearerToken is read-only.

# Visuals
![Screenshot 2025-04-14 at 4 16 05 PM](https://github.com/user-attachments/assets/4bff7562-e180-4cac-9665-70d1427d3e4b)
