### PR TITLE
Wrapping tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,11 @@ vantage-mcp-server: $(SRC)
 inspect: vantage-mcp-server
 	@npx @modelcontextprotocol/inspector@0.8.0 -e MCP_LOG_FILE=application.log -e VANTAGE_BEARER_TOKEN=${VANTAGE_BEARER_TOKEN} ./vantage-mcp-server
 
-vantage-mcp-server-macos: $(src)
+vantage-mcp-server-macos: $(SRC)
 	GOOS=darwin GOARCH=arm64 go build -o vantage-mcp-server-macos
-vantage-mcp-server-linux: $(src)
+vantage-mcp-server-linux: $(SRC)
 	GOOS=linux GOARCH=amd64 go build -o vantage-mcp-server-linux
-vantage-mcp-server-windows: $(src)
+vantage-mcp-server-windows.exe: $(SRC)
 	GOOS=windows GOARCH=amd64 go build -o vantage-mcp-server-windows.exe
 
-build-all: vantage-mcp-server-macos vantage-mcp-server-linux vantage-mcp-server-windows
+build-all: vantage-mcp-server-macos vantage-mcp-server-linux vantage-mcp-server-windows.exe

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,18 @@
+# Common dependencies
+SRC := *.go go.mod go.sum
 
-vantage-mcp-server: *.go go.mod go.sum
+# Default target
+vantage-mcp-server: $(SRC)
 	go build -o vantage-mcp-server
 
 inspect: vantage-mcp-server
 	@npx @modelcontextprotocol/inspector@0.8.0 -e MCP_LOG_FILE=application.log -e VANTAGE_BEARER_TOKEN=${VANTAGE_BEARER_TOKEN} ./vantage-mcp-server
 
-vantage-mcp-server-macos: *.go go.mod go.sum
+vantage-mcp-server-macos: $(src)
 	GOOS=darwin GOARCH=arm64 go build -o vantage-mcp-server-macos
-vantage-mcp-server-linux: *.go go.mod go.sum
+vantage-mcp-server-linux: $(src)
 	GOOS=linux GOARCH=amd64 go build -o vantage-mcp-server-linux
-vantage-mcp-server-windows: *.go go.mod go.sum
+vantage-mcp-server-windows: $(src)
 	GOOS=windows GOARCH=amd64 go build -o vantage-mcp-server-windows.exe
 
 build-all: vantage-mcp-server-macos vantage-mcp-server-linux vantage-mcp-server-windows

--- a/bearer_token_mgr.go
+++ b/bearer_token_mgr.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/go-openapi/runtime"
+	"github.com/go-openapi/strfmt"
+	meClient "github.com/vantage-sh/vantage-go/vantagev2/vantage/me"
+)
+
+type BearerTokenMgr struct {
+	BearerToken string
+	IsReadOnly  bool
+	authInfo    runtime.ClientAuthInfoWriter
+}
+
+// constructor
+func NewBearerTokenMgr() *BearerTokenMgr {
+	b := &BearerTokenMgr{
+		BearerToken: "",
+		IsReadOnly:  false,
+		authInfo:    nil,
+	}
+	bearerToken, _ := os.LookupEnv("VANTAGE_BEARER_TOKEN")
+	if bearerToken == "" {
+		log.Printf("VANTAGE_BEARER_TOKEN not found, please create a read-only Service Token or Personal Access Token at https://console.vantage.sh/settings/access_tokens")
+		return b
+	}
+	b.BearerToken = bearerToken
+	client := meClient.NewClientWithBearerToken("api.vantage.sh", "/v2", "https", bearerToken)
+	response, err := client.GetMe(meClient.NewGetMeParams(), b.AuthInfo())
+	if err != nil {
+		return b
+	}
+	payload := response.GetPayload()
+	if payload == nil {
+		return b
+	}
+
+	if len(payload.BearerToken.Scope) == 1 && payload.BearerToken.Scope[0] == "read" {
+		b.IsReadOnly = true
+	}
+	return b
+}
+
+func (b *BearerTokenMgr) AuthInfo() runtime.ClientAuthInfoWriter {
+	if b.authInfo != nil {
+		return b.authInfo
+	}
+	b.authInfo = runtime.ClientAuthInfoWriterFunc(func(req runtime.ClientRequest, reg strfmt.Registry) error {
+		if err := req.SetHeaderParam("Authorization", fmt.Sprintf("Bearer %s", b.BearerToken)); err != nil {
+			return err
+		}
+
+		if err := req.SetHeaderParam("User-Agent", fmt.Sprintf("vantage-mcp-server/%s", Version)); err != nil {
+			return err
+		}
+
+		return nil
+	})
+	return b.authInfo
+}

--- a/main.go
+++ b/main.go
@@ -11,7 +11,6 @@ import (
 	goruntime "runtime"
 	"strconv"
 
-	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 	mcp_golang "github.com/metoro-io/mcp-golang"
 	"github.com/metoro-io/mcp-golang/transport/stdio"
@@ -37,58 +36,6 @@ type McpResponseLinks struct {
 var NO_NEXT_PAGE = McpResponseLinks{
 	NextPage:    0,
 	HasNextPage: false,
-}
-
-type BearerTokenMgr struct {
-	BearerToken string
-	IsReadOnly  bool
-	authInfo    runtime.ClientAuthInfoWriter
-}
-
-func NewBearerTokenMgr() *BearerTokenMgr {
-	b := &BearerTokenMgr{
-		BearerToken: "",
-		IsReadOnly:  false,
-		authInfo:    nil,
-	}
-	bearerToken, _ := os.LookupEnv("VANTAGE_BEARER_TOKEN")
-	if bearerToken == "" {
-		log.Printf("VANTAGE_BEARER_TOKEN not found, please create a read-only Service Token or Personal Access Token at https://console.vantage.sh/settings/access_tokens")
-		return b
-	}
-	b.BearerToken = bearerToken
-	client := meClient.NewClientWithBearerToken("api.vantage.sh", "/v2", "https", bearerToken)
-	response, err := client.GetMe(meClient.NewGetMeParams(), b.AuthInfo())
-	if err != nil {
-		return b
-	}
-	payload := response.GetPayload()
-	if payload == nil {
-		return b
-	}
-
-	if len(payload.BearerToken.Scope) == 1 && payload.BearerToken.Scope[0] == "read" {
-		b.IsReadOnly = true
-	}
-	return b
-}
-
-func (b *BearerTokenMgr) AuthInfo() runtime.ClientAuthInfoWriter {
-	if b.authInfo != nil {
-		return b.authInfo
-	}
-	b.authInfo = runtime.ClientAuthInfoWriterFunc(func(req runtime.ClientRequest, reg strfmt.Registry) error {
-		if err := req.SetHeaderParam("Authorization", fmt.Sprintf("Bearer %s", b.BearerToken)); err != nil {
-			return err
-		}
-
-		if err := req.SetHeaderParam("User-Agent", fmt.Sprintf("vantage-mcp-server/%s", Version)); err != nil {
-			return err
-		}
-
-		return nil
-	})
-	return b.authInfo
 }
 
 // Given the "next" URL from the API response, this function will return a
@@ -133,13 +80,14 @@ func setupLogger() {
 	}
 	logFile, err := os.OpenFile(logFilename, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0666)
 	if err != nil {
-		panic(fmt.Sprintf("Failed to open log file %s: %+v", err))
+		panic(fmt.Sprintf("Failed to open log file: %+v", err))
 	}
 	log.SetOutput(logFile)
 }
 
-func registerVantageTool[P any](server *mcp_golang.Server, bearerToken BearerTokenMgr, name string, description string, givenHandler func(params P) (*mcp_golang.ToolResponse, error)) {
-	server.RegisterTool(name, description, func(params P) (*mcp_golang.ToolResponse, error) {
+// run code that is common to all tools
+func registerVantageTool[ParamType any](server *mcp_golang.Server, bearerToken BearerTokenMgr, name string, description string, givenHandler func(params ParamType) (*mcp_golang.ToolResponse, error)) {
+	server.RegisterTool(name, description, func(params ParamType) (*mcp_golang.ToolResponse, error) {
 		log.Printf("invoked - tool - %s %+v", name, params)
 		if bearerToken.BearerToken == "" {
 			return nil, fmt.Errorf("VANTAGE_BEARER_TOKEN not found, please create a read-only Service Token or Personal Access Token at https://console.vantage.sh/settings/access_tokens")

--- a/main.go
+++ b/main.go
@@ -110,7 +110,7 @@ func main() {
 
 	setupLogger()
 
-	bearerToken := NewBearerTokenMgr()
+	bearerTokenMgr := NewBearerTokenMgr()
 
 	log.Printf("Server Starting, OS: %s, Arch: %s", goruntime.GOOS, goruntime.GOARCH)
 
@@ -153,14 +153,14 @@ func main() {
 	List of cost providers available to query for a given Workspace. Can be used to filter costs down to a specific provider in VQL queries.
 	`
 
-	registerVantageTool(server, *bearerToken, "list-cost-providers", listCostProvidersDescription, func(params ListCostProvidersParams) (*mcp_golang.ToolResponse, error) {
+	registerVantageTool(server, *bearerTokenMgr, "list-cost-providers", listCostProvidersDescription, func(params ListCostProvidersParams) (*mcp_golang.ToolResponse, error) {
 
-		client := costProvidersClient.NewClientWithBearerToken("api.vantage.sh", "/v2", "https", bearerToken.BearerToken)
+		client := costProvidersClient.NewClientWithBearerToken("api.vantage.sh", "/v2", "https", bearerTokenMgr.BearerToken)
 
 		getCostProvidersParams := costProvidersClient.NewGetCostProvidersParams()
 		getCostProvidersParams.SetWorkspaceToken(&params.WorkspaceToken)
 
-		apiResponse, err := client.GetCostProviders(getCostProvidersParams, bearerToken.AuthInfo())
+		apiResponse, err := client.GetCostProviders(getCostProvidersParams, bearerTokenMgr.AuthInfo())
 		if err != nil {
 			return nil, fmt.Errorf("Error fetching cost providers: %+v", err)
 		}
@@ -190,13 +190,13 @@ func main() {
 	List of cost services available to query for a given Workspace. Can be used to filter costs down to a specific service in VQL queries.
 	`
 
-	registerVantageTool(server, *bearerToken, "list-cost-services", listCostServicesDescription, func(params ListCostServicesParams) (*mcp_golang.ToolResponse, error) {
-		client := costServicesClient.NewClientWithBearerToken("api.vantage.sh", "/v2", "https", bearerToken.BearerToken)
+	registerVantageTool(server, *bearerTokenMgr, "list-cost-services", listCostServicesDescription, func(params ListCostServicesParams) (*mcp_golang.ToolResponse, error) {
+		client := costServicesClient.NewClientWithBearerToken("api.vantage.sh", "/v2", "https", bearerTokenMgr.BearerToken)
 
 		getCostServicesParams := costServicesClient.NewGetCostServicesParams()
 		getCostServicesParams.SetWorkspaceToken(&params.WorkspaceToken)
 
-		apiResponse, err := client.GetCostServices(getCostServicesParams, bearerToken.AuthInfo())
+		apiResponse, err := client.GetCostServices(getCostServicesParams, bearerTokenMgr.AuthInfo())
 		if err != nil {
 			return nil, fmt.Errorf("Error fetching cost services: %+v", err)
 		}
@@ -230,16 +230,16 @@ func main() {
 	The 'token' of a report is a unique identifier for the report. It can be used to generate a link to the report in the Vantage Web UI. If a user wants to see a report, you can link them like this: https://console.vantage.sh/go/<token>
 	`
 
-	registerVantageTool(server, *bearerToken, "list-cost-reports", listCostReportsDescription, func(params ListCostReportsParams) (*mcp_golang.ToolResponse, error) {
+	registerVantageTool(server, *bearerTokenMgr, "list-cost-reports", listCostReportsDescription, func(params ListCostReportsParams) (*mcp_golang.ToolResponse, error) {
 
-		client := costs.NewClientWithBearerToken("api.vantage.sh", "/v2", "https", bearerToken.BearerToken)
+		client := costs.NewClientWithBearerToken("api.vantage.sh", "/v2", "https", bearerTokenMgr.BearerToken)
 		var limit int32 = 128
 
 		getCostReportParams := costs.NewGetCostReportsParams()
 		getCostReportParams.SetLimit(&limit)
 		getCostReportParams.SetPage(&params.Page)
 
-		apiResponse, err := client.GetCostReports(getCostReportParams, bearerToken.AuthInfo())
+		apiResponse, err := client.GetCostReports(getCostReportParams, bearerTokenMgr.AuthInfo())
 		if err != nil {
 			return nil, fmt.Errorf("Error fetching cost reports: %+v", err)
 		}
@@ -281,14 +281,14 @@ func main() {
 	Integrations are the cost providers that Vantage is configured to connect to and pull cost data from.
 	If a user wants to see their providers in the Vantage Web UI, they can visit https://console.vantage.sh/settings/integrations
 	`
-	registerVantageTool(server, *bearerToken, "list-cost-integrations", listCostIntegrationsDescription, func(params ListCostIntegrations) (*mcp_golang.ToolResponse, error) {
+	registerVantageTool(server, *bearerTokenMgr, "list-cost-integrations", listCostIntegrationsDescription, func(params ListCostIntegrations) (*mcp_golang.ToolResponse, error) {
 
-		client := integrations.NewClientWithBearerToken("api.vantage.sh", "/v2", "https", bearerToken.BearerToken)
+		client := integrations.NewClientWithBearerToken("api.vantage.sh", "/v2", "https", bearerTokenMgr.BearerToken)
 		getAccountsParams := integrations.NewGetIntegrationsParams()
 		getAccountsParams.SetPage(&params.Page)
 		var limit int32 = 128
 		getAccountsParams.SetLimit(&limit)
-		apiResponse, err := client.GetIntegrations(getAccountsParams, bearerToken.AuthInfo())
+		apiResponse, err := client.GetIntegrations(getAccountsParams, bearerTokenMgr.AuthInfo())
 		if err != nil {
 			return nil, fmt.Errorf("error fetching integrations endpoint to populate accounts: %+v", err)
 		}
@@ -356,9 +356,9 @@ func main() {
 	Some cost providers operate in a specific region, you can filter using the costs.region field. Example: (costs.provider = 'aws' AND costs.region = 'us-east-1')
 	`
 
-	registerVantageTool(server, *bearerToken, "query-costs", queryCostsDescription, func(params QueryCostsParams) (*mcp_golang.ToolResponse, error) {
+	registerVantageTool(server, *bearerTokenMgr, "query-costs", queryCostsDescription, func(params QueryCostsParams) (*mcp_golang.ToolResponse, error) {
 
-		client := costs.NewClientWithBearerToken("api.vantage.sh", "/v2", "https", bearerToken.BearerToken)
+		client := costs.NewClientWithBearerToken("api.vantage.sh", "/v2", "https", bearerTokenMgr.BearerToken)
 		var limit int32 = 2000
 
 		getCostsParams := costs.NewGetCostsParams()
@@ -369,7 +369,7 @@ func main() {
 		getCostsParams.SetPage(&params.Page)
 		getCostsParams.SetLimit(&limit)
 
-		apiResponse, err := client.GetCosts(getCostsParams, bearerToken.AuthInfo())
+		apiResponse, err := client.GetCosts(getCostsParams, bearerTokenMgr.AuthInfo())
 		if err != nil {
 			return nil, fmt.Errorf("Error fetching costs: %+v", err)
 		}
@@ -414,9 +414,9 @@ func main() {
 	The report token can be used to link the user to the report in the Vantage Web UI. Build the link like this: https://console.vantage.sh/go/<CostReportToken>
 	`
 
-	registerVantageTool(server, *bearerToken, "list-costs", listCostsDescription, func(params ListCostsParams) (*mcp_golang.ToolResponse, error) {
+	registerVantageTool(server, *bearerTokenMgr, "list-costs", listCostsDescription, func(params ListCostsParams) (*mcp_golang.ToolResponse, error) {
 
-		client := costs.NewClientWithBearerToken("api.vantage.sh", "/v2", "https", bearerToken.BearerToken)
+		client := costs.NewClientWithBearerToken("api.vantage.sh", "/v2", "https", bearerTokenMgr.BearerToken)
 
 		// We keep this purposefully small to avoid overwhelming the LLM client with data, which can result in network errors.
 		// Sadly, this has the side effect of increasing the chance the user's API token is rate-limited.
@@ -427,7 +427,7 @@ func main() {
 		getCostsParams.SetCostReportToken(&params.CostReportToken)
 		getCostsParams.SetPage(&params.Page)
 
-		apiResponse, err := client.GetCosts(getCostsParams, bearerToken.AuthInfo())
+		apiResponse, err := client.GetCosts(getCostsParams, bearerTokenMgr.AuthInfo())
 		if err != nil {
 			return nil, fmt.Errorf("Error fetching costs: %+v", err)
 		}
@@ -464,11 +464,11 @@ func main() {
 	Get data that is available to the current auth token. This includes the list of Workspaces they have access to.
 	`
 
-	registerVantageTool(server, *bearerToken, "get-myself", getMyselfDescription, func(params MyselfParams) (*mcp_golang.ToolResponse, error) {
+	registerVantageTool(server, *bearerTokenMgr, "get-myself", getMyselfDescription, func(params MyselfParams) (*mcp_golang.ToolResponse, error) {
 
-		client := meClient.NewClientWithBearerToken("api.vantage.sh", "/v2", "https", bearerToken.BearerToken)
+		client := meClient.NewClientWithBearerToken("api.vantage.sh", "/v2", "https", bearerTokenMgr.BearerToken)
 		getMyselfParams := meClient.NewGetMeParams()
-		response, err := client.GetMe(getMyselfParams, bearerToken.AuthInfo())
+		response, err := client.GetMe(getMyselfParams, bearerTokenMgr.AuthInfo())
 		if err != nil {
 			log.Printf("Error fetching myself: %+v", err)
 			return nil, fmt.Errorf("Error fetching myself: %+v", err)
@@ -500,9 +500,9 @@ func main() {
 	The report token can be used to link the user to the report in the Vantage Web UI. Build the link like this: https://console.vantage.sh/go/<CostReportToken>
 	`
 
-	registerVantageTool(server, *bearerToken, "list-anomalies", listAnomaliesDescription, func(params ListAnomaliesParams) (*mcp_golang.ToolResponse, error) {
+	registerVantageTool(server, *bearerTokenMgr, "list-anomalies", listAnomaliesDescription, func(params ListAnomaliesParams) (*mcp_golang.ToolResponse, error) {
 
-		client := anomaliesClient.NewClientWithBearerToken("api.vantage.sh", "/v2", "https", bearerToken.BearerToken)
+		client := anomaliesClient.NewClientWithBearerToken("api.vantage.sh", "/v2", "https", bearerTokenMgr.BearerToken)
 		var limit int32 = 128
 
 		getAnomaliesParams := anomaliesClient.NewGetAnomalyAlertsParams()
@@ -529,7 +529,7 @@ func main() {
 			getAnomaliesParams.SetEndDate(&endDate)
 		}
 
-		response, err := client.GetAnomalyAlerts(getAnomaliesParams, bearerToken.AuthInfo())
+		response, err := client.GetAnomalyAlerts(getAnomaliesParams, bearerTokenMgr.AuthInfo())
 		if err != nil {
 			return nil, fmt.Errorf("Error fetching anomalies: %+v", err)
 		}
@@ -563,16 +563,16 @@ func main() {
 	`
 
 	// TODO(nel): can tags be exposed as a resource instead? Would need MCP clients to support pagination.
-	registerVantageTool(server, *bearerToken, "list-tags", listTagsDescription, func(params ListTagsParams) (*mcp_golang.ToolResponse, error) {
+	registerVantageTool(server, *bearerTokenMgr, "list-tags", listTagsDescription, func(params ListTagsParams) (*mcp_golang.ToolResponse, error) {
 
-		client := tagsClient.NewClientWithBearerToken("api.vantage.sh", "/v2", "https", bearerToken.BearerToken)
+		client := tagsClient.NewClientWithBearerToken("api.vantage.sh", "/v2", "https", bearerTokenMgr.BearerToken)
 		var limit int32 = 128
 
 		getTagsParams := tagsClient.NewGetTagsParams()
 		getTagsParams.SetLimit(&limit)
 		getTagsParams.SetPage(&params.Page)
 
-		apiResponse, err := client.GetTags(getTagsParams, bearerToken.AuthInfo())
+		apiResponse, err := client.GetTags(getTagsParams, bearerTokenMgr.AuthInfo())
 		if err != nil {
 			return nil, fmt.Errorf("error fetching tags: %+v", err)
 		}
@@ -610,9 +610,9 @@ func main() {
 
 	listTagValuesDescription := `Tags can have many values. Use this tool to find the values and service providers that are associated with a tag.`
 
-	registerVantageTool(server, *bearerToken, "list-tag-values", listTagValuesDescription, func(params ListTagValuesParams) (*mcp_golang.ToolResponse, error) {
+	registerVantageTool(server, *bearerTokenMgr, "list-tag-values", listTagValuesDescription, func(params ListTagValuesParams) (*mcp_golang.ToolResponse, error) {
 
-		client := tagsClient.NewClientWithBearerToken("api.vantage.sh", "/v2", "https", bearerToken.BearerToken)
+		client := tagsClient.NewClientWithBearerToken("api.vantage.sh", "/v2", "https", bearerTokenMgr.BearerToken)
 		var limit int32 = 128
 
 		getTagValuesParams := tagsClient.NewGetTagValuesParams()
@@ -620,7 +620,7 @@ func main() {
 		getTagValuesParams.SetPage(&params.Page)
 		getTagValuesParams.SetKey(params.Key)
 
-		response, err := client.GetTagValues(getTagValuesParams, bearerToken.AuthInfo())
+		response, err := client.GetTagValues(getTagValuesParams, bearerTokenMgr.AuthInfo())
 		if err != nil {
 			return nil, fmt.Errorf("Error fetching tags: %+v", err)
 		}
@@ -655,9 +655,9 @@ func main() {
 	listUnitCostsDescription := `
    Retrieve the unit costs for a given CostReport, with optional paging, date filters, and ordering.
    `
-	registerVantageTool(server, *bearerToken, "list-unit-costs", listUnitCostsDescription, func(params ListUnitCostsParams) (*mcp_golang.ToolResponse, error) {
+	registerVantageTool(server, *bearerTokenMgr, "list-unit-costs", listUnitCostsDescription, func(params ListUnitCostsParams) (*mcp_golang.ToolResponse, error) {
 
-		client := unitCostsClient.NewClientWithBearerToken("api.vantage.sh", "/v2", "https", bearerToken.BearerToken)
+		client := unitCostsClient.NewClientWithBearerToken("api.vantage.sh", "/v2", "https", bearerTokenMgr.BearerToken)
 		getParams := unitCostsClient.NewGetUnitCostsParams()
 		var limit int32 = 64
 		getParams.SetLimit(&limit)
@@ -677,7 +677,7 @@ func main() {
 		if params.Order != "" {
 			getParams.SetOrder(&params.Order)
 		}
-		apiResp, err := client.GetUnitCosts(getParams, bearerToken.AuthInfo())
+		apiResp, err := client.GetUnitCosts(getParams, bearerTokenMgr.AuthInfo())
 		if err != nil {
 			return nil, fmt.Errorf("Error fetching unit costs: %+v", err)
 		}
@@ -719,15 +719,15 @@ func main() {
     Submit feedback on using the Vantage MCP Server. Ask the user if they'd like to provide feedback any time you sense they might be frustrated.
     Stop suggesting if they say they're not interested in providing feedback.
     `
-	registerVantageTool(server, *bearerToken, "submit-user-feedback", submitFeedbackDescription, func(params SubmitUserFeedbackParams) (*mcp_golang.ToolResponse, error) {
+	registerVantageTool(server, *bearerTokenMgr, "submit-user-feedback", submitFeedbackDescription, func(params SubmitUserFeedbackParams) (*mcp_golang.ToolResponse, error) {
 
-		client := userFeedbackClient.NewClientWithBearerToken("api.vantage.sh", "/v2", "https", bearerToken.BearerToken)
+		client := userFeedbackClient.NewClientWithBearerToken("api.vantage.sh", "/v2", "https", bearerTokenMgr.BearerToken)
 		createUserFeedbackParams := userFeedbackClient.NewCreateUserFeedbackParams()
 		createUserFeedbackParams.SetCreateUserFeedback(&models.CreateUserFeedback{
 			Message: &params.Message,
 		})
 
-		_, err := client.CreateUserFeedback(createUserFeedbackParams, bearerToken.AuthInfo())
+		_, err := client.CreateUserFeedback(createUserFeedbackParams, bearerTokenMgr.AuthInfo())
 		if err != nil {
 			return nil, fmt.Errorf("Error submitting user feedback: %+v", err)
 		}


### PR DESCRIPTION
# Changes
- Introduce a wrapper function that can run common code every time a Tool is invoked. It checks that the bearer token is read-only and it logs that the tool was called with the input parameters
- Make a BearerTokenMgr module to help with the above

# Wishful Thinking
It's a bummer that almost each API endpoint gets a different client object to talk to it, I don't see a great way to build one client for all tools to use and share it. 