### PR TITLE
Feat: Allow Costs results to be binned by day/week/month.

### DIFF
--- a/main.go
+++ b/main.go
@@ -331,7 +331,8 @@ func main() {
 	}
 
 	type QueryCostsResults struct {
-		Costs     []*models.Cost   `json:"cost_reports"`
+		Notes     string           `json:"notes" jsonschema:"optional,description=Notes about the results"`
+		Costs     []*models.Cost   `json:"costs"`
 		TotalCost interface{}      `json:"total_costs" jsonschema:"optional,description=Total costs"`
 		PageData  McpResponseLinks `json:"page_data"`
 	}
@@ -394,6 +395,15 @@ func main() {
 		result := QueryCostsResults{}
 		result.Costs = apiResponse.GetPayload().Costs
 		result.TotalCost = apiResponse.GetPayload().TotalCost
+		switch *getCostsParams.DateBin {
+		case "day":
+			result.Notes = "Costs records represent one day."
+		case "week":
+			result.Notes = "Costs records represent one week, the accrued_at field is the first day of the week. If your date range is less than one week, this record includes only data for that date range, not the full week."
+		default:
+			result.Notes = "Costs records represent one month, the accrued_at field is the first day of the month. If your date range is less than one month, this record includes only data for that date range, not the full month."
+		}
+
 		links, ok := apiResponse.GetPayload().Links.(map[string]interface{})
 		if !ok {
 			return nil, fmt.Errorf("Error asserting Links to map[string]interface{}")
@@ -426,8 +436,9 @@ func main() {
 	}
 
 	type ListCostsResults struct {
+		Notes     string           `json:"notes" jsonschema:"optional,description=Notes about the results"`
 		TotalCost interface{}      `json:"total_costs" jsonschema:"optional,description=Total costs"`
-		Costs     []*models.Cost   `json:"cost_reports"`
+		Costs     []*models.Cost   `json:"costs"`
 		PageData  McpResponseLinks `json:"page_data"`
 	}
 
@@ -475,6 +486,14 @@ func main() {
 		result := ListCostsResults{}
 		result.Costs = apiResponse.GetPayload().Costs
 		result.TotalCost = apiResponse.GetPayload().TotalCost
+		switch *getCostsParams.DateBin {
+		case "day":
+			result.Notes = "Costs records represent one day."
+		case "week":
+			result.Notes = "Costs records represent one week, the accrued_at field is the first day of the week. If your date range is less than one week, this record includes only data for that date range, not the full week."
+		default:
+			result.Notes = "Costs records represent one month, the accrued_at field is the first day of the month. If your date range is less than one month, this record includes only data for that date range, not the full month."
+		}
 		links, ok := apiResponse.GetPayload().Links.(map[string]interface{})
 		if !ok {
 			return nil, fmt.Errorf("Error asserting Links to map[string]interface{}")

--- a/main.go
+++ b/main.go
@@ -114,7 +114,7 @@ func main() {
 
 	bearerTokenMgr := NewBearerTokenMgr()
 
-	log.Printf("Server Starting, OS: %s, Arch: %s", goruntime.GOOS, goruntime.GOARCH)
+	log.Printf("Server Starting, Version: %s, OS: %s, Arch: %s", Version, goruntime.GOOS, goruntime.GOARCH)
 
 	done := make(chan struct{})
 	server := mcp_golang.NewServer(stdio.NewStdioServerTransport())
@@ -327,11 +327,13 @@ func main() {
 		StartDate      string `json:"start_date" jsonschema:"optional,description=Start date to filter costs by, format=YYYY-MM-DD"`
 		EndDate        string `json:"end_date" jsonschema:"optional,description=End date to filter costs by, format=YYYY-MM-DD"`
 		WorkspaceToken string `json:"workspace_token" jsonschema:"required,description=Workspace token to filter costs by"`
+		DateBin        string `json:"date_bin" jsonschema:"required,description=Date binning for returned costs, default to month unless user says otherwise, allowed values: day, week, month"`
 	}
 
 	type QueryCostsResults struct {
-		Costs    []*models.Cost   `json:"cost_reports"`
-		PageData McpResponseLinks `json:"page_data"`
+		Costs     []*models.Cost   `json:"cost_reports"`
+		TotalCost interface{}      `json:"total_costs" jsonschema:"optional,description=Total costs"`
+		PageData  McpResponseLinks `json:"page_data"`
 	}
 
 	queryCostsDescription := `
@@ -357,6 +359,12 @@ func main() {
 	A user can have more than one provider account. They can filter on provider accounts if they supply you with the account id. Example: (costs.provider = 'aws' AND costs.provider_account_id = '1000000717')
 	You can also combine top-level queries to find for two providers: ((costs.provider = 'datadog') OR (costs.provider = 'azure'))
 	Some cost providers operate in a specific region, you can filter using the costs.region field. Example: (costs.provider = 'aws' AND costs.region = 'us-east-1')
+
+	The DateBin parameter will let you get the information with fewer returned results. 
+	When DateBin=day you get a record for each service spend on that day. For DateBin=week you get one entry per week, 
+	with the accrued_at field set to the first day of the week, but the spend item represents spend for a full week. 
+	Same with DateBin=month, each record returned covers a month of data. This lets you get answers with processing fewer 
+	records. Only use day/week if needed, otherwise DateBin=month is preferred, and month is the value set if you pass no value for DateBin.
 	`
 
 	registerVantageTool(server, *bearerTokenMgr, "query-costs", queryCostsDescription, func(params QueryCostsParams) (*mcp_golang.ToolResponse, error) {
@@ -371,6 +379,12 @@ func main() {
 		getCostsParams.SetEndDate(&params.EndDate)
 		getCostsParams.SetPage(&params.Page)
 		getCostsParams.SetLimit(&limit)
+		if params.DateBin != "" {
+			getCostsParams.SetDateBin(&params.DateBin)
+		} else {
+			defaultDateBin := "month"
+			getCostsParams.SetDateBin(&defaultDateBin)
+		}
 
 		apiResponse, err := client.GetCosts(getCostsParams, bearerTokenMgr.AuthInfo())
 		if err != nil {
@@ -379,6 +393,7 @@ func main() {
 
 		result := QueryCostsResults{}
 		result.Costs = apiResponse.GetPayload().Costs
+		result.TotalCost = apiResponse.GetPayload().TotalCost
 		links, ok := apiResponse.GetPayload().Links.(map[string]interface{})
 		if !ok {
 			return nil, fmt.Errorf("Error asserting Links to map[string]interface{}")
@@ -407,16 +422,24 @@ func main() {
 		CostReportToken string `json:"cost_report_token" jsonschema:"required,description=Cost report to limit costs to"`
 		StartDate       string `json:"start_date" jsonschema:"optional,description=Start date to filter costs by, format=YYYY-MM-DD"`
 		EndDate         string `json:"end_date" jsonschema:"optional,description=End date to filter costs by, format=YYYY-MM-DD"`
+		DateBin         string `json:"date_bin" jsonschema:"required,description=Date binning for returned costs, default to month unless user says otherwise, allowed values: day, week, month"`
 	}
 
 	type ListCostsResults struct {
-		Costs    []*models.Cost   `json:"cost_reports"`
-		PageData McpResponseLinks `json:"page_data"`
+		TotalCost interface{}      `json:"total_costs" jsonschema:"optional,description=Total costs"`
+		Costs     []*models.Cost   `json:"cost_reports"`
+		PageData  McpResponseLinks `json:"page_data"`
 	}
 
 	listCostsDescription := `
 	List the cost items inside a report. The Token of a Report must be provided. Use the page value of 1 to start.
 	The report token can be used to link the user to the report in the Vantage Web UI. Build the link like this: https://console.vantage.sh/go/<CostReportToken>
+	
+	The DateBin parameter will let you get the information with fewer returned results. 
+	When DateBin=day you get a record for each service spend on that day. For DateBin=week you get one entry per week, 
+	with the accrued_at field set to the first day of the week, but the spend item represents spend for a full week. 
+	Same with DateBin=month, each record returned covers a month of data. This lets you get answers with processing fewer 
+	records. Only use day/week if needed, otherwise DateBin=month is preferred, and month is the value set if you pass no value for DateBin.
 	`
 
 	registerVantageTool(server, *bearerTokenMgr, "list-costs", listCostsDescription, func(params ListCostsParams) (*mcp_golang.ToolResponse, error) {
@@ -437,6 +460,13 @@ func main() {
 		if params.EndDate != "" {
 			getCostsParams.SetEndDate(&params.EndDate)
 		}
+		if params.DateBin != "" {
+			getCostsParams.SetDateBin(&params.DateBin)
+		} else {
+			defaultDateBin := "month"
+			getCostsParams.SetDateBin(&defaultDateBin)
+		}
+
 		apiResponse, err := client.GetCosts(getCostsParams, bearerTokenMgr.AuthInfo())
 		if err != nil {
 			return nil, fmt.Errorf("error fetching costs: %+v", err)
@@ -444,6 +474,7 @@ func main() {
 
 		result := ListCostsResults{}
 		result.Costs = apiResponse.GetPayload().Costs
+		result.TotalCost = apiResponse.GetPayload().TotalCost
 		links, ok := apiResponse.GetPayload().Links.(map[string]interface{})
 		if !ok {
 			return nil, fmt.Errorf("Error asserting Links to map[string]interface{}")


### PR DESCRIPTION
# Ticket
https://linear.app/vantage-sh/issue/FIN-294/change-default-costs-grouping-by-month

# Changes
The `list-costs` and `query-costs` tool now allow `date_bin` to be passed, for either day/week/month grouping of cost spending data. LLM is instructed to use `month` as default unless the user asks otherwise. 

# Notes
when I play with this in Claude, it got confused about the results when binning wasn't `day`. I added more text to the description to try and make it clear whats going on and that helped, but can't be 100% sure it really understands.

# Visuals

Here it does one query for 4 days of data, but the default binning was `month` and so all the returned results only had a date set to the first day. Claude thought that meant it had to query for the other days explicitly. 

![Screenshot 2025-04-29 at 2 04 44 PM](https://github.com/user-attachments/assets/d7c48c76-a847-4e6f-97c5-4e30cf542182)

Here it sets the DateBin param itself to `day` and it got the results it wanted on the first try.

![Screenshot 2025-04-29 at 2 18 43 PM](https://github.com/user-attachments/assets/f40dab4c-f893-48b7-8ffd-ae1ab4af2407)

Since updating the description of DateBin I haven't seen claude pass either week or month as a parameter, it likes to see results per-day. 
