### PR TITLE
do not register more tools after starting the server

### DIFF
--- a/main.go
+++ b/main.go
@@ -917,11 +917,6 @@ func main() {
 		panic(err)
 	}
 
-	err = server.Serve()
-	if err != nil {
-		panic(err)
-	}
-
 	type SubmitUserFeedbackParams struct {
 		Message string `json:"message" jsonschema:"required,description=Feedback message regarding using the Vantage MCP Server"`
 	}
@@ -945,6 +940,11 @@ func main() {
 		content := mcp_golang.NewTextContent("User feedback submitted successfully.")
 		return mcp_golang.NewToolResponse(content), nil
 	})
+	if err != nil {
+		panic(err)
+	}
+
+	err = server.Serve()
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Using git bisect I found that https://github.com/vantage-sh/vantage-mcp-server/pull/26 introduced the issue of Claude having it's annoying Zod Error output on startup.

![Screenshot 2025-04-29 at 11 23 29 PM](https://github.com/user-attachments/assets/43d17963-3db9-4455-92e3-524c6147d218)

That PR is totally fine, I didn't see anything wrong with it, except that it did define the tool after the server was started. When I make staring the server the last action then Claude does not have it's issue.

MCP allows for a server to add/remove tools at runtime, so it seems that we were doing that and Claude doesn't handle it well. I've moved the server start to the end to keep it happy.