### PR TITLE
feat: Allow 'query-costs' tool to pass 'groupings' to API.

### DIFF
--- a/main.go
+++ b/main.go
@@ -331,7 +331,7 @@ func main() {
 		SettingsUnallocated        bool     `json:"settings[unallocated]" jsonschema:"optional,description=Results will show unallocated costs, defaults to false"`
 		SettingsAggregateBy        string   `json:"settings[aggregate_by]" jsonschema:"optional,description=Results will aggregate by cost or usage, defaults to cost"`
 		SettingsShowPreviousPeriod *bool    `json:"settings[show_previous_period]" jsonschema:"optional,description=Results will show previous period costs or usage comparison, defaults to true"`
-		Groupings                  []string `json:"groupings" jsonschema:"optional,description=Group the results by specific field(s). Defaults to provider, service, account_id. Valid groupings: account_id, billing_account_id, charge_type, cost_category, cost_subcategory, provider, region, resource_id, service, tagged, tag:<tag_value>."`
+		Groupings                  []string `json:"groupings" jsonschema:"optional,description=Group the results by specific field(s). Defaults to provider, service, account_id. Valid groupings: account_id, billing_account_id, charge_type, cost_category, cost_subcategory, provider, region, resource_id, service, tagged, tag:<tag_value>. Leave Groupings blank unless explicitly asked for."`
 	}
 
 	type QueryCostsResults struct {


### PR DESCRIPTION
Testing with the inspector showed the API respond differently to different groupings. Generally the more groupings provided, the more entries returned.

Claude:
<img width="642" height="660" alt="Screenshot 2025-08-11 at 3 08 59 PM" src="https://github.com/user-attachments/assets/09eb51a2-dc06-422b-a565-049ec2bb059b" />
<img width="716" height="604" alt="Screenshot 2025-08-11 at 3 09 19 PM" src="https://github.com/user-attachments/assets/b8eb2501-37e2-40b7-951c-5036488735fa" />
