### PR TITLE
fix: Replace square brackets with underscores in JSON struct tags

### DIFF
--- a/main.go
+++ b/main.go
@@ -323,14 +323,14 @@ func main() {
 		EndDate                    string   `json:"end_date" jsonschema:"optional,description=End date to filter costs by, format=YYYY-MM-DD"`
 		WorkspaceToken             string   `json:"workspace_token" jsonschema:"required,description=Workspace token to filter costs by"`
 		DateBin                    string   `json:"date_bin" jsonschema:"required,description=Date binning for returned costs, default to month unless user says otherwise, allowed values: day, week, month"`
-		SettingsIncludeCredits     bool     `json:"settings[include_credits]" jsonschema:"optional,description=Results will include credits, defaults to false"`
-		SettingsIncludeRefunds     bool     `json:"settings[include_refunds]" jsonschema:"optional,description=Results will include refunds, defaults to false"`
-		SettingsIncludeDiscounts   *bool    `json:"settings[include_discounts]" jsonschema:"optional,description=Results will include discounts, defaults to true"`
-		SettingsIncludeTax         *bool    `json:"settings[include_tax]" jsonschema:"optional,description=Results will include tax, defaults to true"`
-		SettingsAmortize           *bool    `json:"settings[amortize]" jsonschema:"optional,description=Results will amortize, defaults to true"`
-		SettingsUnallocated        bool     `json:"settings[unallocated]" jsonschema:"optional,description=Results will show unallocated costs, defaults to false"`
-		SettingsAggregateBy        string   `json:"settings[aggregate_by]" jsonschema:"optional,description=Results will aggregate by cost or usage, defaults to cost"`
-		SettingsShowPreviousPeriod *bool    `json:"settings[show_previous_period]" jsonschema:"optional,description=Results will show previous period costs or usage comparison, defaults to true"`
+		SettingsIncludeCredits     bool     `json:"settings_include_credits" jsonschema:"optional,description=Results will include credits, defaults to false"`
+		SettingsIncludeRefunds     bool     `json:"settings_include_refunds" jsonschema:"optional,description=Results will include refunds, defaults to false"`
+		SettingsIncludeDiscounts   *bool    `json:"settings_include_discounts" jsonschema:"optional,description=Results will include discounts, defaults to true"`
+		SettingsIncludeTax         *bool    `json:"settings_include_tax" jsonschema:"optional,description=Results will include tax, defaults to true"`
+		SettingsAmortize           *bool    `json:"settings_amortize" jsonschema:"optional,description=Results will amortize, defaults to true"`
+		SettingsUnallocated        bool     `json:"settings_unallocated" jsonschema:"optional,description=Results will show unallocated costs, defaults to false"`
+		SettingsAggregateBy        string   `json:"settings_aggregate_by" jsonschema:"optional,description=Results will aggregate by cost or usage, defaults to cost"`
+		SettingsShowPreviousPeriod *bool    `json:"settings_show_previous_period" jsonschema:"optional,description=Results will show previous period costs or usage comparison, defaults to true"`
 		Groupings                  []string `json:"groupings" jsonschema:"optional,description=Group the results by specific field(s). Defaults to provider, service, account_id. Valid groupings: account_id, billing_account_id, charge_type, cost_category, cost_subcategory, provider, region, resource_id, service, tagged, tag:<tag_value>. Leave Groupings blank unless explicitly asked for."`
 	}
 


### PR DESCRIPTION
## Summary
- Fixes MCP schema validation error by replacing square brackets in JSON struct tags with underscores
- The MCP specification requires property keys to match pattern `^[a-zA-Z0-9_.-]{1,64}$` which excludes square brackets
- Updates 8 JSON struct tags in QueryCostsParams for settings fields

## Changes Made
- `settings[include_credits]` → `settings_include_credits`  
- `settings[include_refunds]` → `settings_include_refunds`
- `settings[include_discounts]` → `settings_include_discounts`
- `settings[include_tax]` → `settings_include_tax`
- `settings[amortize]` → `settings_amortize`
- `settings[unallocated]` → `settings_unallocated`
- `settings[aggregate_by]` → `settings_aggregate_by`
- `settings[show_previous_period]` → `settings_show_previous_period`

## Test plan
- [x] Verified Go code compiles without errors
- [x] Confirmed changes only affect MCP schema generation, not Vantage API calls
- [x] API integration remains unchanged as it uses Go struct field names via setter methods

Fixes #43