### PR TITLE
mcp-golang v0.16.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ vantage-mcp-server: $(SRC)
 	go build -o vantage-mcp-server
 
 inspect: vantage-mcp-server
-	@npx @modelcontextprotocol/inspector@0.8.0 -e MCP_LOG_FILE=application.log -e VANTAGE_BEARER_TOKEN=${VANTAGE_BEARER_TOKEN} ./vantage-mcp-server
+	@npx @modelcontextprotocol/inspector@0.16.5 -e MCP_LOG_FILE=application.log -e VANTAGE_BEARER_TOKEN=${VANTAGE_BEARER_TOKEN} ./vantage-mcp-server
 
 vantage-mcp-server-macos: $(SRC)
 	GOOS=darwin GOARCH=arm64 go build -o vantage-mcp-server-macos

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.5
 require (
 	github.com/go-openapi/runtime v0.26.0
 	github.com/go-openapi/strfmt v0.21.7
-	github.com/metoro-io/mcp-golang v0.14.0
+	github.com/metoro-io/mcp-golang v0.16.0
 	github.com/vantage-sh/vantage-go v0.0.74
 )
 

--- a/go.sum
+++ b/go.sum
@@ -126,8 +126,8 @@ github.com/markbates/oncer v0.0.0-20181203154359-bf2de49a0be2/go.mod h1:Ld9puTsI
 github.com/markbates/safe v1.0.1/go.mod h1:nAqgmRi7cY2nqMc92/bSEeQA+R4OheNU2T1kNSCBdG0=
 github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9Y=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
-github.com/metoro-io/mcp-golang v0.14.0 h1:fGWESeN2iaTHzDxQQH1lmrIacdWKmHheEDGlja7dJMs=
-github.com/metoro-io/mcp-golang v0.14.0/go.mod h1:ifLP9ZzKpN1UqFWNTpAHOqSvNkMK6b7d1FSZ5Lu0lN0=
+github.com/metoro-io/mcp-golang v0.16.0 h1:7NrP8Hca4IDLipPitZaTClzmN8uQcQWX8IsziXU813Y=
+github.com/metoro-io/mcp-golang v0.16.0/go.mod h1:ifLP9ZzKpN1UqFWNTpAHOqSvNkMK6b7d1FSZ5Lu0lN0=
 github.com/mitchellh/mapstructure v1.3.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=


### PR DESCRIPTION
Bump to the newest version of mcp-golang framework. They have merged a change that should unblock https://github.com/vantage-sh/vantage-mcp-server/issues/41 and should let Cursor startup with the local MCP server.