### PR TITLE
change default page size to 25 for paginated tool responses

### DIFF
--- a/src/tools/structure/constants.ts
+++ b/src/tools/structure/constants.ts
@@ -1,2 +1,2 @@
-export const DEFAULT_LIMIT = 128;
+export const DEFAULT_LIMIT = 25;
 export const SERVER_VERSION = "2.6.4";


### PR DESCRIPTION
For any paginated tool responses, we previously used a default limit of 128, resulting in large page sizes that clog up context windows. I think that 25 is a more reasonable limit. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk constant change that only reduces default page size for paginated tool API calls; main impact is fewer results returned per call, which could affect expectations in callers/tests relying on the old default.
> 
> **Overview**
> Reduces the default pagination `DEFAULT_LIMIT` used by tool requests from `128` to `25`, shrinking the number of items returned per page when a caller doesn’t specify `limit`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e1009122d757be2ae15a5b0d86d70730429aa85f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->