### PR TITLE
fix: Support cost report graph endpoint types.

### DIFF
--- a/src/cf-worker.ts
+++ b/src/cf-worker.ts
@@ -1,12 +1,6 @@
 import OAuthProvider, { type OAuthHelpers } from "@cloudflare/workers-oauth-provider";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import * as Sentry from "@sentry/cloudflare";
-import type {
-	Path,
-	RequestBodyForPathAndMethod,
-	ResponseBodyForPathAndMethod,
-	SupportedMethods,
-} from "@vantage-sh/vantage-client";
 import { McpAgent } from "agents/mcp";
 import { Hono } from "hono";
 import {
@@ -22,6 +16,12 @@ import homepage from "./homepage";
 import setupRegisteredResources from "./resources";
 import { callApi, serverMeta } from "./shared";
 import { setupRegisteredTools } from "./tools/structure/registerTool";
+import type {
+	Path,
+	RequestBodyForPathAndMethod,
+	ResponseBodyForPathAndMethod,
+	SupportedMethods,
+} from "./vantage-api";
 
 // Side effect import to register all tools
 import "./tools";

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -1,10 +1,10 @@
+import { SERVER_VERSION } from "./tools/structure/constants";
 import type {
 	Path,
 	RequestBodyForPathAndMethod,
 	ResponseBodyForPathAndMethod,
 	SupportedMethods,
-} from "@vantage-sh/vantage-client";
-import { SERVER_VERSION } from "./tools/structure/constants";
+} from "./vantage-api";
 
 export const serverMeta = {
 	name: "Vantage Cloud Costs Helper",

--- a/src/tools/get-cost-report-graph.test.ts
+++ b/src/tools/get-cost-report-graph.test.ts
@@ -39,6 +39,17 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
 	poisonOneValue(validArguments, "end_date", dateValidatorPoisoner),
 ];
 
+const outputSchemaTests: SchemaTestTableItem<OutputSchema>[] = [
+	{
+		name: "valid graph response",
+		data: {
+			url: "https://s3.amazonaws.com/bucket/cost-report-graph-uuid.png?signature=abc",
+			report_token: "rprt_123",
+			title: "AWS Costs",
+		},
+	},
+];
+
 const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
 	{
 		name: "successful call",
@@ -130,4 +141,4 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
 	},
 ];
 
-testTool(tool, argumentSchemaTests, executionTests);
+testTool(tool, argumentSchemaTests, outputSchemaTests, executionTests);

--- a/src/tools/get-cost-report-graph.ts
+++ b/src/tools/get-cost-report-graph.ts
@@ -1,5 +1,6 @@
 import { pathEncode } from "@vantage-sh/vantage-client";
 import z from "zod/v4";
+import type { CostReportGraphPath, RequestBodyForPathAndMethod } from "../vantage-api";
 import MCPUserError from "./structure/MCPUserError";
 import registerTool from "./structure/registerTool";
 import dateValidator from "./utils/dateValidator";
@@ -38,13 +39,17 @@ const args = {
 	filter: z
 		.string()
 		.optional()
-		.describe(
-			"VQL filter expression to apply to the graph (e.g. \"costs.provider = 'aws'\")"
-		),
+		.describe("VQL filter expression to apply to the graph (e.g. \"costs.provider = 'aws'\")"),
 	saved_filter_tokens: z
 		.array(z.string())
 		.optional()
 		.describe("Tokens of SavedFilters to apply to the graph"),
+};
+
+const outputSchema = {
+	url: z.string().url().describe("Public URL to the generated cost report graph image"),
+	report_token: z.string().min(1).describe("Cost report token used to generate the graph"),
+	title: z.string().min(1).describe("Cost report title associated with the generated graph"),
 };
 
 export default registerTool({
@@ -56,8 +61,9 @@ export default registerTool({
 		readOnly: true,
 	},
 	args,
+	outputSchema,
 	async execute(args, ctx) {
-		const requestParams: Record<string, unknown> = {};
+		const requestParams: RequestBodyForPathAndMethod<CostReportGraphPath, "GET"> = {};
 		if (args.start_date) requestParams.start_date = args.start_date;
 		if (args.end_date) requestParams.end_date = args.end_date;
 		if (args.date_interval) requestParams.date_interval = args.date_interval;
@@ -66,14 +72,11 @@ export default registerTool({
 		if (args.groupings) requestParams.groupings = args.groupings;
 		if (args.filter) requestParams.filter = args.filter;
 		if (args.saved_filter_tokens) requestParams.saved_filter_tokens = args.saved_filter_tokens;
-		const response = await ctx.callVantageApi(
-			`/v2/cost_reports/${pathEncode(args.cost_report_token)}/graph` as any,
-			requestParams as any,
-			"GET" as any
-		);
+		const endpoint: CostReportGraphPath = `/v2/cost_reports/${pathEncode(args.cost_report_token)}/graph`;
+		const response = await ctx.callVantageApi(endpoint, requestParams, "GET");
 		if (!response.ok) {
 			throw new MCPUserError({ errors: response.errors });
 		}
-		return response.data as any;
+		return response.data;
 	},
 });

--- a/src/tools/structure/registerTool.ts
+++ b/src/tools/structure/registerTool.ts
@@ -1,11 +1,11 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type z from "zod/v4";
 import type {
 	Path,
 	RequestBodyForPathAndMethod,
 	ResponseBodyForPathAndMethod,
 	SupportedMethods,
-} from "@vantage-sh/vantage-client";
-import type z from "zod/v4";
+} from "../../vantage-api";
 import MCPUserError from "./MCPUserError";
 
 export type ToolCallContext = {

--- a/src/tools/utils/testing.ts
+++ b/src/tools/utils/testing.ts
@@ -1,11 +1,11 @@
+import { describe, expect, it, test, vi } from "vitest";
+import z from "zod/v4";
 import type {
 	Path,
 	RequestBodyForPathAndMethod,
 	ResponseBodyForPathAndMethod,
 	SupportedMethods,
-} from "@vantage-sh/vantage-client";
-import { describe, expect, it, test, vi } from "vitest";
-import z from "zod/v4";
+} from "../../vantage-api";
 import MCPUserError from "../structure/MCPUserError";
 import {
 	setupRegisteredTools,
@@ -17,9 +17,7 @@ export type ExtractValidators<T> = T extends ToolProperties<infer V, infer _> ? 
 
 export type ExtractOutputSchema<T> = T extends ToolProperties<infer _, infer O> ? O : undefined;
 
-export type InferValidators<T extends z.ZodRawShape> = {
-	[K in keyof T]: z.input<T[K]>;
-};
+export type InferValidators<T extends z.ZodRawShape> = z.input<z.ZodObject<T>>;
 
 export type SchemaTestTableItem<Validators extends z.ZodRawShape> = {
 	name: string;

--- a/src/vantage-api.ts
+++ b/src/vantage-api.ts
@@ -1,0 +1,56 @@
+import type {
+	pathEncode,
+	Path as VantagePath,
+	RequestBodyForPathAndMethod as VantageRequestBodyForPathAndMethod,
+	ResponseBodyForPathAndMethod as VantageResponseBodyForPathAndMethod,
+	SupportedMethods as VantageSupportedMethods,
+} from "@vantage-sh/vantage-client";
+
+type EncodedPathSegment = ReturnType<typeof pathEncode>;
+
+export type CostReportGraphPath = `/v2/cost_reports/${EncodedPathSegment}/graph`;
+
+export type CostReportGraphRequest = {
+	start_date?: string;
+	end_date?: string;
+	date_interval?: string;
+	date_bin?: "cumulative" | "day" | "week" | "month" | "quarter";
+	chart_type?: "line" | "area" | "stacked_area" | "bar" | "multi_bar" | "stacked_bar" | "pie";
+	groupings?: string;
+	filter?: string;
+	saved_filter_tokens?: string[];
+};
+
+export type CostReportGraphResponse = {
+	url: string;
+	report_token: string;
+	title: string;
+};
+
+export type Path = VantagePath | CostReportGraphPath;
+
+export type SupportedMethods<P extends Path> = P extends CostReportGraphPath
+	? "GET"
+	: VantageSupportedMethods<Extract<P, VantagePath>>;
+
+export type RequestBodyForPathAndMethod<
+	P extends Path,
+	M extends SupportedMethods<P>,
+> = P extends CostReportGraphPath
+	? M extends "GET"
+		? CostReportGraphRequest
+		: never
+	: P extends VantagePath
+		? VantageRequestBodyForPathAndMethod<P, Extract<M, VantageSupportedMethods<P>>>
+		: never;
+
+export type ResponseBodyForPathAndMethod<
+	P extends Path,
+	M extends SupportedMethods<P>,
+> = P extends CostReportGraphPath
+	? M extends "GET"
+		? CostReportGraphResponse
+		: never
+	: P extends VantagePath
+		? VantageResponseBodyForPathAndMethod<P, Extract<M, VantageSupportedMethods<P>>>
+		: never;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a narrow local type extension for the missing cost report graph API endpoint
- type the `get-cost-report-graph` tool request/response and define its output schema
- make test input inference preserve optional validator fields and add output-schema coverage for the graph tool

## Testing
- `npm run type-check`
- `npm test -- src/tools/get-cost-report-graph.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-12597912-cfc5-4b23-8f2b-28028ffbb74c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-12597912-cfc5-4b23-8f2b-28028ffbb74c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

