### PR TITLE
Cost Report Graph API tool

### DIFF
--- a/src/tools/get-cost-report-graph.test.ts
+++ b/src/tools/get-cost-report-graph.test.ts
@@ -1,0 +1,133 @@
+import { pathEncode } from "@vantage-sh/vantage-client";
+import { expect } from "vitest";
+import tool from "./get-cost-report-graph";
+import {
+	dateValidatorPoisoner,
+	type ExecutionTestTableItem,
+	type ExtractOutputSchema,
+	type ExtractValidators,
+	type InferValidators,
+	poisonOneValue,
+	requestsInOrder,
+	type SchemaTestTableItem,
+	testTool,
+} from "./utils/testing";
+
+type Validators = ExtractValidators<typeof tool>;
+type OutputSchema = ExtractOutputSchema<typeof tool>;
+
+const validArguments: InferValidators<Validators> = {
+	cost_report_token: "rprt_123",
+	start_date: "2023-01-01",
+	end_date: "2023-01-31",
+	date_bin: "day",
+	chart_type: "line",
+	groupings: "provider,service",
+	filter: "costs.provider = 'aws'",
+};
+
+const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
+	{
+		name: "all valid arguments",
+		data: validArguments,
+	},
+	{
+		name: "only required arguments",
+		data: { cost_report_token: "rprt_123" },
+	},
+	poisonOneValue(validArguments, "start_date", dateValidatorPoisoner),
+	poisonOneValue(validArguments, "end_date", dateValidatorPoisoner),
+];
+
+const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
+	{
+		name: "successful call",
+		apiCallHandler: requestsInOrder([
+			{
+				endpoint: `/v2/cost_reports/${pathEncode("rprt_123")}/graph`,
+				params: {
+					start_date: "2023-01-01",
+					end_date: "2023-01-31",
+					date_bin: "day",
+					chart_type: "line",
+					groupings: "provider,service",
+					filter: "costs.provider = 'aws'",
+				},
+				method: "GET",
+				result: {
+					ok: true,
+					data: {
+						url: "https://s3.amazonaws.com/bucket/cost-report-graph-uuid.png?signature=abc",
+						report_token: "rprt_123",
+						title: "AWS Costs",
+					},
+				},
+			},
+		]),
+		handler: async ({ callExpectingSuccess }) => {
+			const res = await callExpectingSuccess(validArguments);
+			expect(res).toEqual({
+				url: "https://s3.amazonaws.com/bucket/cost-report-graph-uuid.png?signature=abc",
+				report_token: "rprt_123",
+				title: "AWS Costs",
+			});
+		},
+	},
+
+	{
+		name: "successful call with minimal arguments",
+		apiCallHandler: requestsInOrder([
+			{
+				endpoint: `/v2/cost_reports/${pathEncode("rprt_123")}/graph`,
+				params: {},
+				method: "GET",
+				result: {
+					ok: true,
+					data: {
+						url: "https://s3.amazonaws.com/bucket/graph.png?sig=xyz",
+						report_token: "rprt_123",
+						title: "My Report",
+					},
+				},
+			},
+		]),
+		handler: async ({ callExpectingSuccess }) => {
+			const res = await callExpectingSuccess({ cost_report_token: "rprt_123" });
+			expect(res).toEqual({
+				url: "https://s3.amazonaws.com/bucket/graph.png?sig=xyz",
+				report_token: "rprt_123",
+				title: "My Report",
+			});
+		},
+	},
+
+	{
+		name: "unsuccessful call",
+		apiCallHandler: requestsInOrder([
+			{
+				endpoint: `/v2/cost_reports/${pathEncode("rprt_123")}/graph`,
+				params: {
+					start_date: "2023-01-01",
+					end_date: "2023-01-31",
+					date_bin: "day",
+					chart_type: "line",
+					groupings: "provider,service",
+					filter: "costs.provider = 'aws'",
+				},
+				method: "GET",
+				result: {
+					ok: false,
+					errors: [{ message: "CostReport rprt_123 not found." }],
+				},
+			},
+		]),
+		handler: async ({ callExpectingMCPUserError }) => {
+			const err = await callExpectingMCPUserError(validArguments);
+			expect(err.exception).toEqual({
+				errors: [{ message: "CostReport rprt_123 not found." }],
+			});
+		},
+	},
+];
+
+testTool(tool, argumentSchemaTests, executionTests);

--- a/src/tools/get-cost-report-graph.ts
+++ b/src/tools/get-cost-report-graph.ts
@@ -1,0 +1,54 @@
+import { pathEncode } from "@vantage-sh/vantage-client";
+import z from "zod/v4";
+import MCPUserError from "./structure/MCPUserError";
+import registerTool from "./structure/registerTool";
+import dateValidator from "./utils/dateValidator";
+
+const description = `
+Generates a PNG graph image of a cost report and returns a publicly accessible URL to the image.
+This is useful when the user wants to see a visual chart of their costs.
+To display the image in your response, include it as a markdown image: ![Cost Report: <title>](<image_url>)
+The report token can be used to link the user to the report in the Vantage Web UI: https://console.vantage.sh/go/<CostReportToken>
+`.trim();
+
+const args = {
+	cost_report_token: z.string().min(1).describe("Cost report token to generate graph for"),
+	start_date: dateValidator("Start date for the graph, format=YYYY-MM-DD").optional(),
+	end_date: dateValidator("End date for the graph, format=YYYY-MM-DD").optional(),
+	date_bin: z
+		.enum(["cumulative", "day", "week", "month", "quarter"])
+		.optional()
+		.describe("The date bin for the graph"),
+	chart_type: z
+		.enum(["line", "area", "stacked_area", "bar", "multi_bar", "stacked_bar", "pie"])
+		.optional()
+		.describe("The chart type for the graph"),
+};
+
+export default registerTool({
+	name: "get-cost-report-graph",
+	description,
+	annotations: {
+		destructive: false,
+		openWorld: false,
+		readOnly: true,
+	},
+	args,
+	async execute(args, ctx) {
+		const requestParams = {
+			start_date: args.start_date,
+			end_date: args.end_date,
+			date_bin: args.date_bin,
+			chart_type: args.chart_type,
+		};
+		const response = await ctx.callVantageApi(
+			`/v2/cost_reports/${pathEncode(args.cost_report_token)}/graph` as any,
+			requestParams as any,
+			"GET" as any
+		);
+		if (!response.ok) {
+			throw new MCPUserError({ errors: response.errors });
+		}
+		return response.data as any;
+	},
+});

--- a/src/tools/get-cost-report-graph.ts
+++ b/src/tools/get-cost-report-graph.ts
@@ -15,6 +15,12 @@ const args = {
 	cost_report_token: z.string().min(1).describe("Cost report token to generate graph for"),
 	start_date: dateValidator("Start date for the graph, format=YYYY-MM-DD").optional(),
 	end_date: dateValidator("End date for the graph, format=YYYY-MM-DD").optional(),
+	date_interval: z
+		.string()
+		.optional()
+		.describe(
+			"Date interval for the graph (e.g. 'this_month', 'last_month', 'last_7_days', 'last_30_days', 'last_3_months', 'last_6_months', 'last_12_months'). Incompatible with start_date/end_date."
+		),
 	date_bin: z
 		.enum(["cumulative", "day", "week", "month", "quarter"])
 		.optional()
@@ -23,6 +29,22 @@ const args = {
 		.enum(["line", "area", "stacked_area", "bar", "multi_bar", "stacked_bar", "pie"])
 		.optional()
 		.describe("The chart type for the graph"),
+	groupings: z
+		.string()
+		.optional()
+		.describe(
+			"Comma-separated grouping values for aggregating costs (e.g. 'provider,service,region')"
+		),
+	filter: z
+		.string()
+		.optional()
+		.describe(
+			"VQL filter expression to apply to the graph (e.g. \"costs.provider = 'aws'\")"
+		),
+	saved_filter_tokens: z
+		.array(z.string())
+		.optional()
+		.describe("Tokens of SavedFilters to apply to the graph"),
 };
 
 export default registerTool({
@@ -35,12 +57,15 @@ export default registerTool({
 	},
 	args,
 	async execute(args, ctx) {
-		const requestParams = {
-			start_date: args.start_date,
-			end_date: args.end_date,
-			date_bin: args.date_bin,
-			chart_type: args.chart_type,
-		};
+		const requestParams: Record<string, unknown> = {};
+		if (args.start_date) requestParams.start_date = args.start_date;
+		if (args.end_date) requestParams.end_date = args.end_date;
+		if (args.date_interval) requestParams.date_interval = args.date_interval;
+		if (args.date_bin) requestParams.date_bin = args.date_bin;
+		if (args.chart_type) requestParams.chart_type = args.chart_type;
+		if (args.groupings) requestParams.groupings = args.groupings;
+		if (args.filter) requestParams.filter = args.filter;
+		if (args.saved_filter_tokens) requestParams.saved_filter_tokens = args.saved_filter_tokens;
 		const response = await ctx.callVantageApi(
 			`/v2/cost_reports/${pathEncode(args.cost_report_token)}/graph` as any,
 			requestParams as any,

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -12,6 +12,7 @@ import "./get-anomaly";
 import "./get-cost-alert";
 import "./get-cost-provider-accounts";
 import "./get-cost-report-forecast";
+import "./get-cost-report-graph";
 import "./get-cost-report";
 import "./get-folder";
 import "./get-myself";


### PR DESCRIPTION
- **feat: Add get-cost-report-graph tool.**
- **feat: Add filtering options and tests to get-cost-report-graph tool.**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new read-only tool and accompanying tests without modifying existing tool behavior, aside from registering the new tool in the index.
> 
> **Overview**
> Adds a new read-only MCP tool, `get-cost-report-graph`, which calls `GET /v2/cost_reports/{token}/graph` and returns the API’s graph metadata (including a publicly accessible PNG URL), with optional request parameters for date range/interval, binning, chart type, groupings, and filters.
> 
> Introduces a Vitest suite covering input validation (including invalid dates), success cases (full and minimal args), and error propagation via `MCPUserError`, and registers the tool in `src/tools/index.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2b00f0c924838669577d00d50de3a52001c322e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->