### PR TITLE
List cost reports inside a folder

### DIFF
--- a/src/tools/list-cost-reports.test.ts
+++ b/src/tools/list-cost-reports.test.ts
@@ -16,6 +16,7 @@ type OutputSchema = ExtractOutputSchema<typeof tool>;
 
 const validArguments: InferValidators<Validators> = {
 	page: 1,
+	folder_token: "fldr_123",
 };
 
 const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
@@ -23,6 +24,7 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
 		name: "default page",
 		data: {
 			page: undefined,
+			folder_token: undefined,
 		},
 	},
 	{

--- a/src/tools/list-cost-reports.test.ts
+++ b/src/tools/list-cost-reports.test.ts
@@ -78,6 +78,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
 				params: {
 					page: 1,
 					limit: DEFAULT_LIMIT,
+					folder_token: "fldr_123",
 				},
 				method: "GET",
 				result: {
@@ -105,6 +106,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
 				params: {
 					page: 1,
 					limit: DEFAULT_LIMIT,
+					folder_token: "fldr_123",
 				},
 				method: "GET",
 				result: {

--- a/src/tools/list-cost-reports.ts
+++ b/src/tools/list-cost-reports.ts
@@ -15,6 +15,12 @@ Vantage offers data related to a cost report: Forecasts. The same report token c
 
 const args = {
 	page: z.number().optional().default(1).describe("The page number to return, defaults to 1"),
+	folder_token: z
+		.string()
+		.optional()
+		.describe(
+			"The token of a folder to filter cost reports by. Only reports within that folder will be returned."
+		),
 };
 
 export default registerTool({


### PR DESCRIPTION
https://vantagesh.slack.com/archives/C0ANLLL6PKL/p1776355776536189

<img width="1451" height="543" alt="image" src="https://github.com/user-attachments/assets/78088a40-53e9-49ef-b3ed-91ff0eab7e76" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive change that only introduces an optional request parameter and corresponding test updates; minimal impact unless the upstream API behaves unexpectedly with the new filter.
> 
> **Overview**
> `list-cost-reports` now accepts an optional `folder_token` argument to filter results to cost reports within a specific folder, passing it through to the `/v2/cost_reports` request.
> 
> Tests for `list-cost-reports` were updated to cover the new argument in schema validation and to assert the API call includes `folder_token` for both success and error cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c3cb9180ec4367d5cd1f166c8711fb3253b7775. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->