### PR TITLE
Add auto-merge to housekeeping

### DIFF
--- a/src/tools/bin/generate-version-pr.ts
+++ b/src/tools/bin/generate-version-pr.ts
@@ -221,6 +221,21 @@ async function doPr(description: string, newVersion: string) {
 		false
 	);
 	console.log("PR created successfully");
+
+	runCommandAndPipeToUser(
+		"gh",
+		[
+			"pr",
+			"merge",
+			"--auto",
+			"--squash",
+			"--repo",
+			"vantage-sh/vantage-mcp-server",
+			"automated-bump",
+		],
+		false
+	);
+	console.log("Auto-merge enabled");
 }
 
 (async () => {


### PR DESCRIPTION
I would like us to set up auto approval to the house keeping PRs, such as https://github.com/vantage-sh/vantage-mcp-server/pull/111 so that we don't have to remember to merge them. First step is to set the PR to be on auto merge. Then we'll need to set up functionality to automatically add an approval

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to release automation that only adds an extra `gh` CLI call; primary risk is unintended auto-merging if branch/PR targeting is misconfigured.
> 
> **Overview**
> After creating the `automated-bump` version PR, `generate-version-pr.ts` now runs `gh pr merge --auto --squash` to enable auto-merge for that PR, reducing manual housekeeping.
> 
> The change only affects the post-creation step of the existing release automation; dry-run behavior remains unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a84b88a11db9f407a34cb49dcaa7c884ef2c6851. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->