### PR TITLE
Support min_savings in recommendations tool

### DIFF
--- a/src/tools/list-recommendations.test.ts
+++ b/src/tools/list-recommendations.test.ts
@@ -21,6 +21,7 @@ const validArguments: InferValidators<Validators> = {
   workspace_token: "wt_123",
   provider_account_id: "123456789",
   type: "aws",
+  min_savings: 100,
   tag_key: undefined,
   tag_value: undefined,
   regions: undefined,
@@ -38,6 +39,7 @@ const minimalArgs: InferValidators<Validators> = {
   workspace_token: undefined,
   provider_account_id: undefined,
   type: undefined,
+  min_savings: undefined,
   tag_key: undefined,
   tag_value: undefined,
   regions: undefined,
@@ -135,6 +137,13 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
       ...validArguments,
       start_date: "2024-01-01",
       end_date: "2024-12-31",
+    },
+  },
+  {
+    name: "min_savings is valid",
+    data: {
+      ...validArguments,
+      min_savings: 250.5,
     },
   },
   {

--- a/src/tools/list-recommendations.ts
+++ b/src/tools/list-recommendations.ts
@@ -155,6 +155,7 @@ Recommendations can be filtered by:
 - Region via regions (requires workspace_token)
 - Tag key/value pair via tag_key + tag_value (both required together; requires workspace_token) — use this when users ask about recommendations for a specific virtual tag, e.g. "recommendations for department=engineering"
 - Date range via start_date + end_date in YYYY-MM-DD format (both required together; requires workspace_token)
+- Minimum monthly potential savings via min_savings
 - Recommendation type via type (case-insensitive fuzzy matching; e.g. "AWS recommendations" -> type=aws; "EC2 rightsizing" -> type=aws:ec2:rightsizing)
 
 The token of each recommendation can be used with other recommendation tools to get detailed information and see specific resources affected.
@@ -182,6 +183,13 @@ const args = {
     .enum(["open", "resolved", "dismissed"])
     .optional()
     .describe("Filter recommendations by status: open (default), resolved, or dismissed"),
+  min_savings: z
+    .number()
+    .nonnegative()
+    .optional()
+    .describe(
+      "Filter to recommendations with monthly potential savings greater than or equal to this amount, in the workspace currency."
+    ),
   tag_key: z
     .string()
     .optional()


### PR DESCRIPTION
## Summary
- Add `min_savings` as an optional non-negative filter for `list-recommendations`.
- Document the minimum monthly savings filter and cover it in the tool schema tests.

## Test plan
- `npm test -- src/tools/list-recommendations.test.ts`
- `npm run type-check`
- `biome check --write` via commit hook


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an optional, non-negative numeric filter to the `list-recommendations` tool schema and updates tests/documentation accordingly, without changing core execution flow.
> 
> **Overview**
> Adds support for filtering `list-recommendations` results by `min_savings` (optional, non-negative number), and documents this new filter in the tool description.
> 
> Updates `list-recommendations` schema tests to include `min_savings` in both minimal/full argument sets and validates that decimal values are accepted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0171f38d43af47711e0e67110269de2a28a47a0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->