### PR TITLE
docs: Add Cursor Cloud specific dev environment instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,3 +21,23 @@
 
 ## Project Structure
 This is a Cloudflare Workers project using Hono framework for a Vantage MCP server with OAuth authentication. Main dependencies: Hono, MCP SDK, OAuth4WebAPI, Axios, Zod for validation.
+
+## Cursor Cloud specific instructions
+
+### Services
+- **Wrangler dev server** (`npm run dev`): HTTP mode on port 8787. Emulates Cloudflare Workers locally with KV and Durable Objects. OAuth is stubbed with dummy values in `wrangler-DEV.jsonc`.
+- **Local stdio mode** (`npm run local`): Requires `VANTAGE_TOKEN` env var. Useful for testing MCP protocol interactions directly via stdin/stdout.
+
+### Running the dev server
+- Run `npm run cf-typegen` before `npm run type-check` if `worker-configuration.d.ts` is missing or stale (e.g. after changing wrangler config). The generated types are git-tracked but may drift.
+- `npm run dev` starts Wrangler on port 8787. OAuth/Auth0 vars are set to `"local-dummy"` in `wrangler-DEV.jsonc`; set `VANTAGE_MCP_TOKEN` in that file to bypass OAuth for local testing.
+- The `/sse` endpoint requires a valid token; without `VANTAGE_MCP_TOKEN` configured, requests return 401.
+
+### Testing
+- `npm test -- --run` runs all 399 Vitest tests (unit tests with mocks, no network needed).
+- Pre-commit hook runs `npm run check:lint:all -- --write` (Biome check with auto-fix).
+
+### Gotchas
+- The project uses `npm` (lockfile is `package-lock.json`); do not use pnpm/yarn.
+- Husky git hooks are installed via the `prepare` script during `npm install`.
+- `biome.json` sets `indentWidth: 2` (not 4 as stated in the Code Style section above); follow the actual Biome config.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` with practical guidance for future Cloud Agents working in this repository.

## Changes

- Documents how to run the Wrangler dev server and local stdio mode
- Notes that `npm run cf-typegen` must precede `npm run type-check` when `worker-configuration.d.ts` is stale
- Clarifies testing commands (399 Vitest unit tests, pre-commit hook behavior)
- Documents gotchas: npm-only lockfile, Husky setup via `prepare`, actual Biome indent width (2, not 4)

## Evidence of working dev environment

[demo_mcp_server_running.mp4](https://cursor.com/agents/bc-6b318c1f-c03e-4d1c-bae5-219b71912d88/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_mcp_server_running.mp4)

MCP server homepage served on localhost:8787:

[Vantage MCP Server homepage](https://cursor.com/agents/bc-6b318c1f-c03e-4d1c-bae5-219b71912d88/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmcp_server_homepage.webp)

MCP stdio mode returning proper JSON-RPC initialization response:

[MCP stdio initialization test](https://cursor.com/agents/bc-6b318c1f-c03e-4d1c-bae5-219b71912d88/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmcp_stdio_initialization.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6b318c1f-c03e-4d1c-bae5-219b71912d88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b318c1f-c03e-4d1c-bae5-219b71912d88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

