### PR TITLE
chore: tailor CODEOWNERS for Dependabot (engineering-platform)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,3 @@
 # Dependabot dependency manifests — @vantage-sh/engineering-platform
-# Tailored from .github/dependabot.yml + repo manifests (ecosystems: github-actions, npm).
+# Tailored from .github/dependabot.yml (ecosystems: github-actions).
 /.github/workflows/**/* @vantage-sh/engineering-platform
-/npm-shrinkwrap.json @vantage-sh/engineering-platform
-/package-lock.json @vantage-sh/engineering-platform
-/package.json @vantage-sh/engineering-platform
-/pnpm-lock.yaml @vantage-sh/engineering-platform
-/yarn.lock @vantage-sh/engineering-platform

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Dependabot dependency manifests — @vantage-sh/engineering-platform
+# Tailored from .github/dependabot.yml + repo manifests (ecosystems: github-actions, npm).
+/.github/workflows/**/* @vantage-sh/engineering-platform
+/npm-shrinkwrap.json @vantage-sh/engineering-platform
+/package-lock.json @vantage-sh/engineering-platform
+/package.json @vantage-sh/engineering-platform
+/pnpm-lock.yaml @vantage-sh/engineering-platform
+/yarn.lock @vantage-sh/engineering-platform


### PR DESCRIPTION
Assign `@vantage-sh/engineering-platform` as CODEOWNERS for Dependabot-related paths only (from `.github/dependabot.yml` plus repo manifest inference).

- **core**: updates `config/teams/engineering_platform.yml` and regenerated `.github/CODEOWNERS` entries for bundler, npm, docker, and docker-compose; GitHub Actions remain under existing `.github/**/*` ownership.
- **Other repos**: `.github/CODEOWNERS` lists only manifests for the ecosystems this repo uses.

Regenerate across the org later with: `node generate-tailored-dependabot-codeowners.mjs` at the ghorg root (repos other than `core`).

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a CODEOWNERS rule only, affecting review assignment for `.github/workflows` without changing application or CI behavior.
> 
> **Overview**
> Adds a new `.github/CODEOWNERS` file that assigns `@vantage-sh/engineering-platform` as the owner for `.github/workflows/**/*`, tailoring ownership for Dependabot-related GitHub Actions dependency manifests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2c75d42ffad61e41193e76039a6a7b24a55476d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Related to PLA-1407