### PR TITLE
feat: Add get financial commitment report tool.

### DIFF
--- a/src/tools/get-financial-commitment-report.test.ts
+++ b/src/tools/get-financial-commitment-report.test.ts
@@ -28,6 +28,13 @@ testTool(
         financial_commitment_report_token: "fncl_cmnt_rprt_86a93126175f91ed",
       },
     },
+    {
+      name: "rejects empty financial_commitment_report_token",
+      data: {
+        financial_commitment_report_token: "",
+      },
+      expectedIssues: ["Too small: expected string to have >=1 characters"],
+    },
   ],
   [
     {
@@ -46,6 +53,26 @@ testTool(
       handler: async ({ callExpectingSuccess }) => {
         const res = await callExpectingSuccess({
           financial_commitment_report_token: "fncl_cmnt_rprt_86a93126175f91ed",
+        });
+        expect(res).toEqual(success);
+      },
+    },
+    {
+      name: "encodes financial_commitment_report_token in endpoint",
+      apiCallHandler: requestsInOrder([
+        {
+          endpoint: `/v2/financial_commitment_reports/${pathEncode("fncl_cmnt_rprt_86a93126175f91ed/with space")}`,
+          params: {},
+          method: "GET",
+          result: {
+            ok: true,
+            data: success,
+          },
+        },
+      ]),
+      handler: async ({ callExpectingSuccess }) => {
+        const res = await callExpectingSuccess({
+          financial_commitment_report_token: "fncl_cmnt_rprt_86a93126175f91ed/with space",
         });
         expect(res).toEqual(success);
       },

--- a/src/tools/get-financial-commitment-report.test.ts
+++ b/src/tools/get-financial-commitment-report.test.ts
@@ -1,0 +1,76 @@
+import { type GetFinancialCommitmentReportResponse, pathEncode } from "@vantage-sh/vantage-client";
+import { expect } from "vitest";
+import tool from "./get-financial-commitment-report";
+import { requestsInOrder, testTool } from "./utils/testing";
+
+const success: GetFinancialCommitmentReportResponse = {
+  token: "fncl_cmnt_rprt_86a93126175f91ed",
+  title: "All Financial Commitments",
+  default: false,
+  created_at: "2025-01-27T21:42:04Z",
+  workspace_token: "wrkspc_0e9408c2a0682914",
+  user_token: null,
+  start_date: "2024-10-01",
+  end_date: "2025-01-25",
+  date_interval: "last_3_months",
+  date_bucket: "month",
+  groupings: "cost_type",
+  on_demand_costs_scope: "discountable",
+  filter: "(financial_commitments.provider = 'aws')",
+};
+
+testTool(
+  tool,
+  [
+    {
+      name: "takes financial_commitment_report_token",
+      data: {
+        financial_commitment_report_token: "fncl_cmnt_rprt_86a93126175f91ed",
+      },
+    },
+  ],
+  [
+    {
+      name: "successful call",
+      apiCallHandler: requestsInOrder([
+        {
+          endpoint: `/v2/financial_commitment_reports/${pathEncode("fncl_cmnt_rprt_86a93126175f91ed")}`,
+          params: {},
+          method: "GET",
+          result: {
+            ok: true,
+            data: success,
+          },
+        },
+      ]),
+      handler: async ({ callExpectingSuccess }) => {
+        const res = await callExpectingSuccess({
+          financial_commitment_report_token: "fncl_cmnt_rprt_86a93126175f91ed",
+        });
+        expect(res).toEqual(success);
+      },
+    },
+    {
+      name: "unsuccessful call",
+      apiCallHandler: requestsInOrder([
+        {
+          endpoint: `/v2/financial_commitment_reports/${pathEncode("fncl_cmnt_rprt_nonexistent")}`,
+          params: {},
+          method: "GET",
+          result: {
+            ok: false,
+            errors: [{ message: "Financial commitment report not found" }],
+          },
+        },
+      ]),
+      handler: async ({ callExpectingMCPUserError }) => {
+        const err = await callExpectingMCPUserError({
+          financial_commitment_report_token: "fncl_cmnt_rprt_nonexistent",
+        });
+        expect(err.exception).toEqual({
+          errors: [{ message: "Financial commitment report not found" }],
+        });
+      },
+    },
+  ]
+);

--- a/src/tools/get-financial-commitment-report.ts
+++ b/src/tools/get-financial-commitment-report.ts
@@ -5,10 +5,14 @@ import registerTool from "./structure/registerTool";
 
 const description = `
 Gets a specific financial commitment report by its token.
+
+Use this tool when you already have a financial commitment report token, such as one returned by
+Vantage or referenced in the Vantage console. The response includes the report's title, workspace,
+date range, grouping, cost scope, and filter configuration.
 `.trim();
 
 const args = {
-  financial_commitment_report_token: z.string().describe("The financial commitment report token to retrieve"),
+  financial_commitment_report_token: z.string().min(1).describe("The financial commitment report token to retrieve"),
 };
 
 export default registerTool({

--- a/src/tools/get-financial-commitment-report.ts
+++ b/src/tools/get-financial-commitment-report.ts
@@ -1,0 +1,35 @@
+import { pathEncode } from "@vantage-sh/vantage-client";
+import z from "zod/v4";
+import MCPUserError from "./structure/MCPUserError";
+import registerTool from "./structure/registerTool";
+
+const description = `
+Gets a specific financial commitment report by its token.
+`.trim();
+
+const args = {
+  financial_commitment_report_token: z.string().describe("The financial commitment report token to retrieve"),
+};
+
+export default registerTool({
+  name: "get-financial-commitment-report",
+  title: "Get Financial Commitment Report",
+  description,
+  annotations: {
+    destructive: false,
+    openWorld: false,
+    readOnly: true,
+  },
+  args,
+  async execute(args, ctx) {
+    const response = await ctx.callVantageApi(
+      `/v2/financial_commitment_reports/${pathEncode(args.financial_commitment_report_token)}`,
+      {},
+      "GET"
+    );
+    if (!response.ok) {
+      throw new MCPUserError({ errors: response.errors });
+    }
+    return response.data;
+  },
+});

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -13,6 +13,7 @@ import "./get-cost-alert";
 import "./get-cost-provider-accounts";
 import "./get-cost-report-forecast";
 import "./get-cost-report";
+import "./get-financial-commitment-report";
 import "./get-folder";
 import "./get-myself";
 import "./get-provider-resource";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add the `get-financial-commitment-report` MCP tool for retrieving financial commitment reports by token.
- Register the generated tool import in `src/tools/index.ts`.
- Add focused Vitest coverage for schema acceptance, success, error handling, and registration annotations.

### Testing
- `npm test -- --run src/tools/get-financial-commitment-report.test.ts`
- `npm run type-check`
- `npm test -- --run`
- `npm run check:lint:all`

Resolves ENG-1836
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6cc37054-b326-40b5-8a33-23af1888793f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6cc37054-b326-40b5-8a33-23af1888793f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

