### PR TITLE
feat: Add business metrics read-only tools.

### DIFF
--- a/src/tools/business-metrics/get-business-metric-forecasted-values.test.ts
+++ b/src/tools/business-metrics/get-business-metric-forecasted-values.test.ts
@@ -1,0 +1,140 @@
+import type { GetBusinessMetricForecastedValuesResponse } from "@vantage-sh/vantage-client";
+import { pathEncode } from "@vantage-sh/vantage-client";
+import { expect } from "vitest";
+import {
+  dateValidatorPoisoner,
+  type ExecutionTestTableItem,
+  type ExtractOutputSchema,
+  type ExtractValidators,
+  type InferValidators,
+  poisonOneValue,
+  requestsInOrder,
+  type SchemaTestTableItem,
+  testTool,
+} from "../utils/testing";
+import tool from "./get-business-metric-forecasted-values";
+import { BUSINESS_METRICS_LIMIT } from "./schemas";
+
+type Validators = ExtractValidators<typeof tool>;
+type OutputSchema = ExtractOutputSchema<typeof tool>;
+
+const validArguments: InferValidators<Validators> = {
+  business_metric_token: "bsnss_mtrc_3080a050c04104ff",
+  page: 1,
+  start_date: "2025-01-01",
+};
+
+const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
+  {
+    name: "default page and start date",
+    data: {
+      business_metric_token: "bsnss_mtrc_3080a050c04104ff",
+      page: undefined,
+      start_date: undefined,
+    },
+  },
+  {
+    name: "valid arguments",
+    data: validArguments,
+  },
+  poisonOneValue<Validators, string>(validArguments, "start_date", dateValidatorPoisoner),
+];
+
+const successData: GetBusinessMetricForecastedValuesResponse = {
+  values: [
+    { date: "2025-01-03T00:00:00Z", amount: "300.0", label: "Prod" },
+    { date: "2025-01-02T00:00:00Z", amount: "200.0" },
+  ],
+};
+
+const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
+  {
+    name: "successful call",
+    apiCallHandler: requestsInOrder([
+      {
+        endpoint: `/v2/business_metrics/${pathEncode("bsnss_mtrc_3080a050c04104ff")}/forecasted_values`,
+        params: {
+          page: 1,
+          start_date: "2025-01-01",
+          limit: BUSINESS_METRICS_LIMIT,
+        },
+        method: "GET",
+        result: {
+          ok: true,
+          data: successData,
+        },
+      },
+    ]),
+    handler: async ({ callExpectingSuccess }) => {
+      const res = await callExpectingSuccess(validArguments);
+      expect(res).toEqual({
+        values: successData.values,
+        pagination: {
+          hasNextPage: false,
+          nextPage: 0,
+        },
+      });
+    },
+  },
+  {
+    name: "encodes token in path",
+    apiCallHandler: requestsInOrder([
+      {
+        endpoint: `/v2/business_metrics/${pathEncode("bsnss_mtrc_with/slash")}/forecasted_values`,
+        params: {
+          page: 1,
+          start_date: undefined,
+          limit: BUSINESS_METRICS_LIMIT,
+        },
+        method: "GET",
+        result: {
+          ok: true,
+          data: successData,
+        },
+      },
+    ]),
+    handler: async ({ callExpectingSuccess }) => {
+      const res = await callExpectingSuccess({
+        business_metric_token: "bsnss_mtrc_with/slash",
+        page: 1,
+        start_date: undefined,
+      });
+      expect(res).toEqual({
+        values: successData.values,
+        pagination: {
+          hasNextPage: false,
+          nextPage: 0,
+        },
+      });
+    },
+  },
+  {
+    name: "unsuccessful call",
+    apiCallHandler: requestsInOrder([
+      {
+        endpoint: `/v2/business_metrics/${pathEncode("bsnss_mtrc_nonexistent")}/forecasted_values`,
+        params: {
+          page: 1,
+          start_date: "2025-01-01",
+          limit: BUSINESS_METRICS_LIMIT,
+        },
+        method: "GET",
+        result: {
+          ok: false,
+          errors: [{ message: "Business Metric not found" }],
+        },
+      },
+    ]),
+    handler: async ({ callExpectingMCPUserError }) => {
+      const err = await callExpectingMCPUserError({
+        ...validArguments,
+        business_metric_token: "bsnss_mtrc_nonexistent",
+      });
+      expect(err.exception).toEqual({
+        errors: [{ message: "Business Metric not found" }],
+      });
+    },
+  },
+];
+
+testTool(tool, argumentSchemaTests, executionTests);

--- a/src/tools/business-metrics/get-business-metric-forecasted-values.ts
+++ b/src/tools/business-metrics/get-business-metric-forecasted-values.ts
@@ -1,0 +1,41 @@
+import { pathEncode } from "@vantage-sh/vantage-client";
+import MCPUserError from "../structure/MCPUserError";
+import registerTool from "../structure/registerTool";
+import paginationData from "../utils/paginationData";
+import { BUSINESS_METRICS_LIMIT, businessMetricValueArgs } from "./schemas";
+
+const description = `
+Get forecasted values for a BusinessMetric.
+Values are returned in descending date order by the Vantage API and can include optional labels.
+Use start_date to limit results to values on or after a YYYY-MM-DD date.
+This endpoint is paginated. If the user asks for all values, complete data, or values for a date range such as a month, keep calling this tool with pagination.nextPage until pagination.hasNextPage is false before answering.
+The API only supports a start_date lower bound. For bounded ranges, such as a specific month, fetch all pages from the requested start date and then filter the returned values to the requested end date locally.
+`.trim();
+
+export default registerTool({
+  name: "get-business-metric-forecasted-values",
+  title: "Get Business Metric Forecasted Values",
+  description,
+  annotations: {
+    destructive: false,
+    openWorld: false,
+    readOnly: true,
+  },
+  args: businessMetricValueArgs,
+  async execute(args, ctx) {
+    const { business_metric_token, ...params } = args;
+    const requestParams = { ...params, limit: BUSINESS_METRICS_LIMIT };
+    const response = await ctx.callVantageApi(
+      `/v2/business_metrics/${pathEncode(business_metric_token)}/forecasted_values`,
+      requestParams,
+      "GET"
+    );
+    if (!response.ok) {
+      throw new MCPUserError({ errors: response.errors });
+    }
+    return {
+      values: response.data.values,
+      pagination: paginationData(response.data as { links?: { next?: string | null } | null }),
+    };
+  },
+});

--- a/src/tools/business-metrics/get-business-metric-values.test.ts
+++ b/src/tools/business-metrics/get-business-metric-values.test.ts
@@ -1,0 +1,140 @@
+import type { GetBusinessMetricValuesResponse } from "@vantage-sh/vantage-client";
+import { pathEncode } from "@vantage-sh/vantage-client";
+import { expect } from "vitest";
+import {
+  dateValidatorPoisoner,
+  type ExecutionTestTableItem,
+  type ExtractOutputSchema,
+  type ExtractValidators,
+  type InferValidators,
+  poisonOneValue,
+  requestsInOrder,
+  type SchemaTestTableItem,
+  testTool,
+} from "../utils/testing";
+import tool from "./get-business-metric-values";
+import { BUSINESS_METRICS_LIMIT } from "./schemas";
+
+type Validators = ExtractValidators<typeof tool>;
+type OutputSchema = ExtractOutputSchema<typeof tool>;
+
+const validArguments: InferValidators<Validators> = {
+  business_metric_token: "bsnss_mtrc_3080a050c04104ff",
+  page: 1,
+  start_date: "2024-01-01",
+};
+
+const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
+  {
+    name: "default page and start date",
+    data: {
+      business_metric_token: "bsnss_mtrc_3080a050c04104ff",
+      page: undefined,
+      start_date: undefined,
+    },
+  },
+  {
+    name: "valid arguments",
+    data: validArguments,
+  },
+  poisonOneValue<Validators, string>(validArguments, "start_date", dateValidatorPoisoner),
+];
+
+const successData: GetBusinessMetricValuesResponse = {
+  values: [
+    { date: "2024-01-03T00:00:00Z", amount: "300.0", label: "Prod" },
+    { date: "2024-01-02T00:00:00Z", amount: "200.0" },
+  ],
+};
+
+const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
+  {
+    name: "successful call",
+    apiCallHandler: requestsInOrder([
+      {
+        endpoint: `/v2/business_metrics/${pathEncode("bsnss_mtrc_3080a050c04104ff")}/values`,
+        params: {
+          page: 1,
+          start_date: "2024-01-01",
+          limit: BUSINESS_METRICS_LIMIT,
+        },
+        method: "GET",
+        result: {
+          ok: true,
+          data: successData,
+        },
+      },
+    ]),
+    handler: async ({ callExpectingSuccess }) => {
+      const res = await callExpectingSuccess(validArguments);
+      expect(res).toEqual({
+        values: successData.values,
+        pagination: {
+          hasNextPage: false,
+          nextPage: 0,
+        },
+      });
+    },
+  },
+  {
+    name: "encodes token in path",
+    apiCallHandler: requestsInOrder([
+      {
+        endpoint: `/v2/business_metrics/${pathEncode("bsnss_mtrc_with/slash")}/values`,
+        params: {
+          page: 1,
+          start_date: undefined,
+          limit: BUSINESS_METRICS_LIMIT,
+        },
+        method: "GET",
+        result: {
+          ok: true,
+          data: successData,
+        },
+      },
+    ]),
+    handler: async ({ callExpectingSuccess }) => {
+      const res = await callExpectingSuccess({
+        business_metric_token: "bsnss_mtrc_with/slash",
+        page: 1,
+        start_date: undefined,
+      });
+      expect(res).toEqual({
+        values: successData.values,
+        pagination: {
+          hasNextPage: false,
+          nextPage: 0,
+        },
+      });
+    },
+  },
+  {
+    name: "unsuccessful call",
+    apiCallHandler: requestsInOrder([
+      {
+        endpoint: `/v2/business_metrics/${pathEncode("bsnss_mtrc_nonexistent")}/values`,
+        params: {
+          page: 1,
+          start_date: "2024-01-01",
+          limit: BUSINESS_METRICS_LIMIT,
+        },
+        method: "GET",
+        result: {
+          ok: false,
+          errors: [{ message: "Business Metric not found" }],
+        },
+      },
+    ]),
+    handler: async ({ callExpectingMCPUserError }) => {
+      const err = await callExpectingMCPUserError({
+        ...validArguments,
+        business_metric_token: "bsnss_mtrc_nonexistent",
+      });
+      expect(err.exception).toEqual({
+        errors: [{ message: "Business Metric not found" }],
+      });
+    },
+  },
+];
+
+testTool(tool, argumentSchemaTests, executionTests);

--- a/src/tools/business-metrics/get-business-metric-values.ts
+++ b/src/tools/business-metrics/get-business-metric-values.ts
@@ -1,0 +1,41 @@
+import { pathEncode } from "@vantage-sh/vantage-client";
+import MCPUserError from "../structure/MCPUserError";
+import registerTool from "../structure/registerTool";
+import paginationData from "../utils/paginationData";
+import { BUSINESS_METRICS_LIMIT, businessMetricValueArgs } from "./schemas";
+
+const description = `
+Get historical values for a BusinessMetric.
+Values are returned in descending date order by the Vantage API and can include optional labels.
+Use start_date to limit results to values on or after a YYYY-MM-DD date.
+This endpoint is paginated. If the user asks for all values, complete data, or values for a date range such as a month, keep calling this tool with pagination.nextPage until pagination.hasNextPage is false before answering.
+The API only supports a start_date lower bound. For bounded ranges, such as a specific month, fetch all pages from the requested start date and then filter the returned values to the requested end date locally.
+`.trim();
+
+export default registerTool({
+  name: "get-business-metric-values",
+  title: "Get Business Metric Values",
+  description,
+  annotations: {
+    destructive: false,
+    openWorld: false,
+    readOnly: true,
+  },
+  args: businessMetricValueArgs,
+  async execute(args, ctx) {
+    const { business_metric_token, ...params } = args;
+    const requestParams = { ...params, limit: BUSINESS_METRICS_LIMIT };
+    const response = await ctx.callVantageApi(
+      `/v2/business_metrics/${pathEncode(business_metric_token)}/values`,
+      requestParams,
+      "GET"
+    );
+    if (!response.ok) {
+      throw new MCPUserError({ errors: response.errors });
+    }
+    return {
+      values: response.data.values,
+      pagination: paginationData(response.data as { links?: { next?: string | null } | null }),
+    };
+  },
+});

--- a/src/tools/business-metrics/get-business-metric.test.ts
+++ b/src/tools/business-metrics/get-business-metric.test.ts
@@ -1,0 +1,89 @@
+import { type GetBusinessMetricResponse, pathEncode } from "@vantage-sh/vantage-client";
+import { expect } from "vitest";
+import { requestsInOrder, testTool } from "../utils/testing";
+import tool from "./get-business-metric";
+
+const success: GetBusinessMetricResponse = {
+  token: "bsnss_mtrc_6d8f14830f9870ac",
+  title: "Quo Lux",
+  created_by_token: "usr_622d8870faf147bb",
+  cost_report_tokens_with_metadata: [],
+  import_type: "csv",
+  integration_token: "",
+};
+
+testTool(
+  tool,
+  [
+    {
+      name: "takes business_metric_token",
+      data: {
+        business_metric_token: "bsnss_mtrc_6d8f14830f9870ac",
+      },
+    },
+  ],
+  [
+    {
+      name: "successful call",
+      apiCallHandler: requestsInOrder([
+        {
+          endpoint: `/v2/business_metrics/${pathEncode("bsnss_mtrc_6d8f14830f9870ac")}`,
+          params: {},
+          method: "GET",
+          result: {
+            ok: true,
+            data: success,
+          },
+        },
+      ]),
+      handler: async ({ callExpectingSuccess }) => {
+        const res = await callExpectingSuccess({
+          business_metric_token: "bsnss_mtrc_6d8f14830f9870ac",
+        });
+        expect(res).toEqual(success);
+      },
+    },
+    {
+      name: "encodes token in path",
+      apiCallHandler: requestsInOrder([
+        {
+          endpoint: `/v2/business_metrics/${pathEncode("bsnss_mtrc_with/slash")}`,
+          params: {},
+          method: "GET",
+          result: {
+            ok: true,
+            data: success,
+          },
+        },
+      ]),
+      handler: async ({ callExpectingSuccess }) => {
+        const res = await callExpectingSuccess({
+          business_metric_token: "bsnss_mtrc_with/slash",
+        });
+        expect(res).toEqual(success);
+      },
+    },
+    {
+      name: "unsuccessful call",
+      apiCallHandler: requestsInOrder([
+        {
+          endpoint: `/v2/business_metrics/${pathEncode("bsnss_mtrc_nonexistent")}`,
+          params: {},
+          method: "GET",
+          result: {
+            ok: false,
+            errors: [{ message: "Business Metric not found" }],
+          },
+        },
+      ]),
+      handler: async ({ callExpectingMCPUserError }) => {
+        const err = await callExpectingMCPUserError({
+          business_metric_token: "bsnss_mtrc_nonexistent",
+        });
+        expect(err.exception).toEqual({
+          errors: [{ message: "Business Metric not found" }],
+        });
+      },
+    },
+  ]
+);

--- a/src/tools/business-metrics/get-business-metric.ts
+++ b/src/tools/business-metrics/get-business-metric.ts
@@ -1,0 +1,36 @@
+import { pathEncode } from "@vantage-sh/vantage-client";
+import z from "zod/v4";
+import MCPUserError from "../structure/MCPUserError";
+import registerTool from "../structure/registerTool";
+
+const description = `
+Get a specific BusinessMetric by token.
+BusinessMetrics can be attached to Cost Reports for per-unit cost analysis, and their values can be retrieved with get-business-metric-values or get-business-metric-forecasted-values.
+`.trim();
+
+const args = {
+  business_metric_token: z.string().describe("The BusinessMetric token to retrieve."),
+};
+
+export default registerTool({
+  name: "get-business-metric",
+  title: "Get Business Metric",
+  description,
+  annotations: {
+    destructive: false,
+    openWorld: false,
+    readOnly: true,
+  },
+  args,
+  async execute(args, ctx) {
+    const response = await ctx.callVantageApi(
+      `/v2/business_metrics/${pathEncode(args.business_metric_token)}`,
+      {},
+      "GET"
+    );
+    if (!response.ok) {
+      throw new MCPUserError({ errors: response.errors });
+    }
+    return response.data;
+  },
+});

--- a/src/tools/business-metrics/index.ts
+++ b/src/tools/business-metrics/index.ts
@@ -1,0 +1,4 @@
+import "./get-business-metric";
+import "./get-business-metric-forecasted-values";
+import "./get-business-metric-values";
+import "./list-business-metrics";

--- a/src/tools/business-metrics/list-business-metrics.test.ts
+++ b/src/tools/business-metrics/list-business-metrics.test.ts
@@ -1,0 +1,117 @@
+import type { GetBusinessMetricsResponse } from "@vantage-sh/vantage-client";
+import { expect } from "vitest";
+import {
+  type ExecutionTestTableItem,
+  type ExtractOutputSchema,
+  type ExtractValidators,
+  type InferValidators,
+  requestsInOrder,
+  type SchemaTestTableItem,
+  testTool,
+} from "../utils/testing";
+import tool from "./list-business-metrics";
+import { BUSINESS_METRICS_LIMIT } from "./schemas";
+
+type Validators = ExtractValidators<typeof tool>;
+type OutputSchema = ExtractOutputSchema<typeof tool>;
+
+const validArguments: InferValidators<Validators> = {
+  page: 1,
+};
+
+const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
+  {
+    name: "default page",
+    data: {
+      page: undefined,
+    },
+  },
+  {
+    name: "valid page number",
+    data: validArguments,
+  },
+];
+
+const successData: GetBusinessMetricsResponse = {
+  business_metrics: [
+    {
+      token: "bsnss_mtrc_124dc3483510ac35",
+      title: "Business Metric",
+      created_by_token: "usr_80447a58ff9821dd",
+      cost_report_tokens_with_metadata: [],
+      import_type: "csv",
+      integration_token: "",
+    },
+    {
+      token: "bsnss_mtrc_2534c89d90b714f7",
+      title: "AWS Metric",
+      created_by_token: "usr_752202a1bb7c9a70",
+      cost_report_tokens_with_metadata: [],
+      import_type: "cloudwatch",
+      integration_token: "accss_crdntl_742fd1207f8b6816",
+      cloudwatch_fields: {
+        stat: "Maximum",
+        region: "us-east-1",
+        namespace: "AWS/EC2",
+        metric_name: "CPUUtilization",
+        dimensions: [{ name: "InstanceId", value: "i-06105d0faad66r97" }],
+        label_dimension: null,
+      },
+    },
+  ],
+};
+
+const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
+  {
+    name: "successful call",
+    apiCallHandler: requestsInOrder([
+      {
+        endpoint: "/v2/business_metrics",
+        params: {
+          page: 1,
+          limit: BUSINESS_METRICS_LIMIT,
+        },
+        method: "GET",
+        result: {
+          ok: true,
+          data: successData,
+        },
+      },
+    ]),
+    handler: async ({ callExpectingSuccess }) => {
+      const res = await callExpectingSuccess(validArguments);
+      expect(res).toEqual({
+        business_metrics: successData.business_metrics,
+        pagination: {
+          hasNextPage: false,
+          nextPage: 0,
+        },
+      });
+    },
+  },
+  {
+    name: "unsuccessful call",
+    apiCallHandler: requestsInOrder([
+      {
+        endpoint: "/v2/business_metrics",
+        params: {
+          page: 1,
+          limit: BUSINESS_METRICS_LIMIT,
+        },
+        method: "GET",
+        result: {
+          ok: false,
+          errors: [{ message: "Access denied" }],
+        },
+      },
+    ]),
+    handler: async ({ callExpectingMCPUserError }) => {
+      const err = await callExpectingMCPUserError(validArguments);
+      expect(err.exception).toEqual({
+        errors: [{ message: "Access denied" }],
+      });
+    },
+  },
+];
+
+testTool(tool, argumentSchemaTests, executionTests);

--- a/src/tools/business-metrics/list-business-metrics.ts
+++ b/src/tools/business-metrics/list-business-metrics.ts
@@ -1,0 +1,39 @@
+import z from "zod/v4";
+import MCPUserError from "../structure/MCPUserError";
+import registerTool from "../structure/registerTool";
+import paginationData from "../utils/paginationData";
+import { BUSINESS_METRICS_LIMIT } from "./schemas";
+
+const description = `
+List all BusinessMetrics available to the current Vantage API token.
+Use page 1 when calling this tool for the first time. If the user asks for all BusinessMetrics or needs to search across the full set, keep calling this tool with pagination.nextPage until pagination.hasNextPage is false.
+BusinessMetrics represent business KPIs, such as requests, users, or revenue, that can be attached to Cost Reports for per-unit cost analysis.
+The token of a BusinessMetric can be used with get-business-metric, get-business-metric-values, and get-business-metric-forecasted-values.
+`.trim();
+
+const args = {
+  page: z.number().optional().default(1).describe("The page number to return, defaults to 1."),
+};
+
+export default registerTool({
+  name: "list-business-metrics",
+  title: "List Business Metrics",
+  description,
+  annotations: {
+    destructive: false,
+    openWorld: false,
+    readOnly: true,
+  },
+  args,
+  async execute(args, ctx) {
+    const requestParams = { ...args, limit: BUSINESS_METRICS_LIMIT };
+    const response = await ctx.callVantageApi("/v2/business_metrics", requestParams, "GET");
+    if (!response.ok) {
+      throw new MCPUserError({ errors: response.errors });
+    }
+    return {
+      business_metrics: response.data.business_metrics,
+      pagination: paginationData(response.data as { links?: { next?: string | null } | null }),
+    };
+  },
+});

--- a/src/tools/business-metrics/schemas.ts
+++ b/src/tools/business-metrics/schemas.ts
@@ -1,0 +1,12 @@
+import z from "zod/v4";
+import dateValidator from "../utils/dateValidator";
+
+export const BUSINESS_METRICS_LIMIT = 1000;
+
+export const businessMetricValueArgs = {
+  business_metric_token: z.string().describe("The BusinessMetric token to retrieve values for."),
+  page: z.number().optional().default(1).describe("The page number to return, defaults to 1."),
+  start_date: dateValidator(
+    "Query BusinessMetric values by the first date to filter from. Must be YYYY-MM-DD format."
+  ).optional(),
+};

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,6 +1,7 @@
 // This file is auto-generated. Do not edit directly. Run npm run generate-tools-index to update.
 
 import "./budgets";
+import "./business-metrics";
 import "./create-cost-alert";
 import "./create-cost-report";
 import "./create-dashboard";


### PR DESCRIPTION
### Problem
The MCP server did not expose the BusinessMetrics read APIs, so clients could not list metrics or inspect historical and forecasted unit values through MCP.

### Solution
- Added a new `business-metrics` tool group and registered it in the generated tools index.
- Implemented four read-only tools for the documented Vantage endpoints:
  - `list-business-metrics`
  - `get-business-metric`
  - `get-business-metric-values`
  - `get-business-metric-forecasted-values`
- Reused the existing tool patterns for paging, token path encoding, error handling, and `start_date` validation.
- Kept CSV import, create, update, and delete operations out of scope for this change.

### Validation
- Added focused unit tests for all four tools, covering success and error paths, paging defaults, token encoding, and `start_date` validation.
- Ran the targeted BusinessMetrics test suite.
- Ran TypeScript type-checking.
- Ran the full Biome check.

### Rollout
- Low-risk additive change behind the existing MCP surface.
- No schema migrations or API contract changes in the server itself.
- No special rollout steps beyond deploying the updated MCP server.
