### PR TITLE
Update `agents` & `zod`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@modelcontextprotocol/sdk": "1.27.1",
         "@sentry/cloudflare": "10.30.0",
         "@vantage-sh/vantage-client": "2.2.1",
-        "agents": "^0.10.0",
+        "agents": "^0.11.0",
         "axios": "1.13.5",
         "hono": "4.12.12",
         "jose": "^6.0.11",
@@ -4353,15 +4353,15 @@
       }
     },
     "node_modules/agents": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/agents/-/agents-0.10.0.tgz",
-      "integrity": "sha512-N1eHE0u1ECn5yJuAr98Z9prBUTrJCK7ya9expqaGbpYat7n+lraeI9JUS0Y+ANI2msqUaDZD5gdNEpg7GoQJlA==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/agents/-/agents-0.11.0.tgz",
+      "integrity": "sha512-FBjTA0G5ejwYMcizqTkX2ONJFXV1vqMM5P0yqOu6r0dWzTmaW84LKQACMava2HkPO4+nVhesW94+kf1E/a+MDw==",
       "license": "MIT",
       "dependencies": {
         "@babel/plugin-proposal-decorators": "^7.29.0",
         "@cfworker/json-schema": "^4.1.1",
         "@modelcontextprotocol/sdk": "1.29.0",
-        "@rolldown/plugin-babel": "^0.2.2",
+        "@rolldown/plugin-babel": "^0.2.3",
         "cron-schedule": "^6.0.0",
         "json-schema": "^0.4.0",
         "json-schema-to-typescript": "^15.0.4",
@@ -4376,10 +4376,10 @@
         "agents": "dist/cli/index.js"
       },
       "peerDependencies": {
-        "@ai-sdk/openai": "^3.0.0",
         "@ai-sdk/react": "^3.0.0",
-        "@cloudflare/ai-chat": "^0.4.0",
+        "@cloudflare/ai-chat": "^0.4.2",
         "@cloudflare/codemode": "^0.3.4",
+        "@tanstack/ai": "^0.10.2",
         "@x402/core": "^2.0.0",
         "@x402/evm": "^2.0.0",
         "ai": "^6.0.0",
@@ -4389,9 +4389,6 @@
         "zod": "^4.0.0"
       },
       "peerDependenciesMeta": {
-        "@ai-sdk/openai": {
-          "optional": true
-        },
         "@ai-sdk/react": {
           "optional": true
         },
@@ -4399,6 +4396,9 @@
           "optional": true
         },
         "@cloudflare/codemode": {
+          "optional": true
+        },
+        "@tanstack/ai": {
           "optional": true
         },
         "@x402/core": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@modelcontextprotocol/sdk": "1.27.1",
         "@sentry/cloudflare": "10.30.0",
         "@vantage-sh/vantage-client": "2.2.1",
-        "agents": "^0.6.0",
+        "agents": "^0.7.0",
         "axios": "1.13.5",
         "hono": "4.12.12",
         "jose": "^6.0.11",
@@ -3630,9 +3630,9 @@
       }
     },
     "node_modules/agents": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/agents/-/agents-0.6.0.tgz",
-      "integrity": "sha512-BUqYwtTyNp0ksAJo0b4uSn4lmIDYkLAeXDnu3VaCHyLUPI5C/1PECOVrD0xHzHkGkbE/yL79Eaasuuk9U7kGwQ==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/agents/-/agents-0.7.0.tgz",
+      "integrity": "sha512-uK1i/NeAMSgDU2VCqy4LGY4PKGzORpXjZzEHMewkFq9urS48lyguHpmNU+ckN2+nz+OGrVQ7WRRuu/rQC8dvOA==",
       "license": "MIT",
       "dependencies": {
         "@cfworker/json-schema": "^4.1.1",
@@ -3642,8 +3642,8 @@
         "json-schema-to-typescript": "^15.0.4",
         "mimetext": "^3.0.28",
         "nanoid": "^5.1.6",
-        "partyserver": "^0.3.0",
-        "partysocket": "1.1.15",
+        "partyserver": "^0.3.2",
+        "partysocket": "1.1.16",
         "yargs": "^18.0.0"
       },
       "bin": {
@@ -3652,8 +3652,8 @@
       "peerDependencies": {
         "@ai-sdk/openai": "^3.0.0",
         "@ai-sdk/react": "^3.0.0",
-        "@cloudflare/ai-chat": "^0.1.4",
-        "@cloudflare/codemode": "^0.1.1",
+        "@cloudflare/ai-chat": "^0.1.6",
+        "@cloudflare/codemode": "^0.1.2",
         "@x402/core": "^2.0.0",
         "@x402/evm": "^2.0.0",
         "ai": "^6.0.0",
@@ -6074,9 +6074,9 @@
       }
     },
     "node_modules/partysocket": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/partysocket/-/partysocket-1.1.15.tgz",
-      "integrity": "sha512-d8dvcNMqtWQU1k3OguLN+Vk3GV6uFD0PEhu9EZkCDZuE/xAsdeFlv8fCcsFefQWzoZyVNvTpAKTvutXc6exrEg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/partysocket/-/partysocket-1.1.16.tgz",
+      "integrity": "sha512-d7xFv+ZC7x0p/DAHWJ5FhxQhimIx+ucyZY+kxL0cKddLBmK9c4p2tEA/L+dOOrWm6EYrRwrBjKQV0uSzOY9x1w==",
       "license": "MIT",
       "dependencies": {
         "event-target-polyfill": "^0.0.4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@modelcontextprotocol/sdk": "1.27.1",
         "@sentry/cloudflare": "10.30.0",
         "@vantage-sh/vantage-client": "2.2.1",
-        "agents": "^0.8.0",
+        "agents": "^0.9.0",
         "axios": "1.13.5",
         "hono": "4.12.12",
         "jose": "^6.0.11",
@@ -103,13 +103,12 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
-      "dev": true,
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -117,40 +116,344 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "peer": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/generator/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@babel/helper-annotate-as-pure": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.29.7.tgz",
+      "integrity": "sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "peer": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-create-class-features-plugin": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.29.7.tgz",
+      "integrity": "sha512-IY3ZD9Tmooqr3TUhc3DUWxiuo8xx1DWLhd5M7hQ+ZWJamqM2BbalrBJb2MisSLoYorOj75U03qULCxQTY9r3hg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.29.7",
+        "@babel/helper-member-expression-to-functions": "^7.29.7",
+        "@babel/helper-optimise-call-expression": "^7.29.7",
+        "@babel/helper-replace-supers": "^7.29.7",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-create-class-features-plugin/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-member-expression-to-functions": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.29.7.tgz",
+      "integrity": "sha512-j+7JYmk1JYDtACIGj0QJqqWZjoUpMoEikQGADMaHgCMCSDqd2+P32rfcibUNrGOMWrlzK1WJBdxrB3JJQZwWtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-optimise-call-expression": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.29.7.tgz",
+      "integrity": "sha512-+kmGVjcT9RGYzoDwdwEqEvGgKe3BYq+O1iGzjFubaNgZHwYHP6lsF2Yghf4kEuv9BV7tYDZ913aBW9am6YKong==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-replace-supers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.29.7.tgz",
+      "integrity": "sha512-atfGXWSeCiF4DnKZIfmJfQRkSw9b9gNNXR1kqKjbhG4pGYCOnkp8OcTB8E3NXjBu8NpheSnOeNKz8KT7UNFTmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-member-expression-to-functions": "^7.29.7",
+        "@babel/helper-optimise-call-expression": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.29.7.tgz",
+      "integrity": "sha512-brcMGQaVzIeUb+6/bs1Av0f8YuNNjKY2JyvfRCsFuFsdKccEQ5Ges2y74D74NZ1Rz8lKJ9ksJkfqwQFJ/iNEyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-      "dev": true,
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-      "dev": true,
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/parser": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
-      "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
-      "dev": true,
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.5"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-proposal-decorators": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.29.7.tgz",
+      "integrity": "sha512-EtU0Hi3GvrTqD56xKmZvV/uCXK2ZbwVNPNLAquVItcAZpUhkXwWlo3Fmj0c2LxgSf2I8IDULeAepwNP1OefLXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/plugin-syntax-decorators": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-decorators": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.29.7.tgz",
+      "integrity": "sha512-9MTTLbF39X6sqM92JPEsoI7++26hjZvzkxKZy64aMhWLH2mPkJ/Q3AV4QLmls3R14FpSpkOwQQfUh962JGQxxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -174,15 +477,46 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/types": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
-      "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
-      "dev": true,
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -807,13 +1141,35 @@
         "node": ">=12"
       }
     },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
-      "dev": true,
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1804,11 +2160,52 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -1818,7 +2215,6 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
@@ -2037,6 +2433,25 @@
         "node": ">=16.20.0"
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
@@ -2044,6 +2459,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.132.0.tgz",
+      "integrity": "sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
       }
     },
     "node_modules/@poppinss/colors": {
@@ -2951,6 +3376,288 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.2.tgz",
+      "integrity": "sha512-ZS4D1JPGn/MYQN/SYDWftIE/nVsM8j/AFOYEzAoOE2O3NktQOZru+/vYXGbR/qtdLdIfGCP0lcoJiYVzsEz+iQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.2.tgz",
+      "integrity": "sha512-vdFA9+C/rekyGce7WqHs/xoT0ioZEWaOFyZLIV1mEeNFaFDUQrPIo8Vs2GvJ6eetb3rzDUtUBgzto3ExpXJB3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.2.tgz",
+      "integrity": "sha512-BewSOwTHazv77DTYiAZXSqqKZ4KP/KonFisDMVU7PImxoWfB2aepnPhd2E4SWz3zDzYgDNbs6jBmTdgNnF02GA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.2.tgz",
+      "integrity": "sha512-m41o7M0YWtUdqk61Tb+jnKb2rN++iRdIASlExkUoKfIAH30DOHCB8fVLzSUpbWHHU8esmEioY62PxzexE8MBuA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.2.tgz",
+      "integrity": "sha512-jcojB9H7W/jS29pMKWAK1N+fU99vXodHDTatS3b3y/XSOCiHo0kkA74pL3jJmkoQtYpOCxDvaKs1fo2Ij/1X5w==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.2.tgz",
+      "integrity": "sha512-1jn6qDU5iiOgFgygDzKUuKP0maTi0/f1+sBLgvij/76C77Nm3ts6ufz9Bjg5q5dduxiUIxtq86JIoBvo1xQ4Ig==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.2.tgz",
+      "integrity": "sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.2.tgz",
+      "integrity": "sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.2.tgz",
+      "integrity": "sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.2.tgz",
+      "integrity": "sha512-0+bOkiQ779+r1WpoHOWHqncvyySci0vKph+myNDYb+im6meJAzHQXay6oEgnkHuUGouM1LKTZwqKpBow6Kj7CQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.2.tgz",
+      "integrity": "sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.2.tgz",
+      "integrity": "sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.2.tgz",
+      "integrity": "sha512-mb1VobWn6NheziTk5/WEaR6AKVbrwT5sOi6C7zk3gy/pD1qtJfU1j4PgTo2NJnOtbL9Dl3Aeei8w9jJ7qC2jZQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.2.tgz",
+      "integrity": "sha512-SqKonF56vA/L2yHwHYcEp2P34URpOZ7d1fS635cTkpDnUtEGdUbhI6NzsPdqeSWvAAeGDrxjWjNmibDIdFf9/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.2.tgz",
+      "integrity": "sha512-v7qRI7gXLRINcOGXt+7YmAZ6iFuyZVMIoXAxhd8oP+DR9dLfL9GfNIx7PLMxmhZdvq8waUJBQiWN9EKNy+TRBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.60.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
@@ -2958,7 +3665,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2972,7 +3678,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2986,7 +3691,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3000,7 +3704,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3014,7 +3717,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3028,7 +3730,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3042,7 +3743,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3056,7 +3756,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3070,7 +3769,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3084,7 +3782,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3098,7 +3795,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3112,7 +3808,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3126,7 +3821,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3140,7 +3834,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3154,7 +3847,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3168,7 +3860,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3182,7 +3873,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3196,7 +3886,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3210,7 +3899,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3224,7 +3912,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3238,7 +3925,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3252,7 +3938,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3266,7 +3951,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3280,7 +3964,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3294,7 +3977,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3414,6 +4096,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -3436,7 +4129,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
@@ -3455,7 +4148,7 @@
       "version": "24.3.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
       "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.10.0"
@@ -3660,21 +4353,23 @@
       }
     },
     "node_modules/agents": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/agents/-/agents-0.8.0.tgz",
-      "integrity": "sha512-7yFkER0npHTowGU9gr2buqb/StpNvURqU5urG63zYQ7twZIyUs/UeZbp88f/AHJKZnLQUlM8MT0TN38Nt3m3Ag==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/agents/-/agents-0.9.0.tgz",
+      "integrity": "sha512-Ucw2gh3VMV+3oXE37I9zk/oVdy9lmAWj5ASuFY91Cf9tvlovkzYZ2k297RxnEPeKkpiAYhaCr5IA53jCCVgD2g==",
       "license": "MIT",
       "dependencies": {
+        "@babel/plugin-proposal-decorators": "^7.29.0",
         "@cfworker/json-schema": "^4.1.1",
-        "@modelcontextprotocol/sdk": "1.26.0",
+        "@modelcontextprotocol/sdk": "1.29.0",
+        "@rolldown/plugin-babel": "^0.2.2",
         "cron-schedule": "^6.0.0",
         "json-schema": "^0.4.0",
         "json-schema-to-typescript": "^15.0.4",
         "mimetext": "^3.0.28",
         "nanoid": "^5.1.7",
-        "partyserver": "^0.3.3",
+        "partyserver": "^0.4.1",
         "partysocket": "1.1.16",
-        "picomatch": "^4.0.3",
+        "picomatch": "^4.0.4",
         "yargs": "^18.0.0"
       },
       "bin": {
@@ -3683,13 +4378,14 @@
       "peerDependencies": {
         "@ai-sdk/openai": "^3.0.0",
         "@ai-sdk/react": "^3.0.0",
-        "@cloudflare/ai-chat": "^0.2.0",
-        "@cloudflare/codemode": "^0.3.0",
+        "@cloudflare/ai-chat": "^0.3.2",
+        "@cloudflare/codemode": "^0.3.3",
         "@x402/core": "^2.0.0",
         "@x402/evm": "^2.0.0",
         "ai": "^6.0.0",
         "react": "^19.0.0",
         "viem": ">=2.0.0",
+        "vite": ">=6.0.0",
         "zod": "^4.0.0"
       },
       "peerDependenciesMeta": {
@@ -3712,6 +4408,39 @@
           "optional": true
         },
         "viem": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/agents/node_modules/@rolldown/plugin-babel": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/plugin-babel/-/plugin-babel-0.2.3.tgz",
+      "integrity": "sha512-+zEk16yGlz1F9STiRr6uG9hmIXb6nprjLczV/htGptYuLoCuxb+itZ03RKCEeOhBpDDd1NU7qF6x1VLMUp62bw==",
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=22.12.0 || ^24.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.29.0 || ^8.0.0-rc.1",
+        "@babel/plugin-transform-runtime": "^7.29.0 || ^8.0.0-rc.1",
+        "@babel/runtime": "^7.27.0 || ^8.0.0-rc.1",
+        "rolldown": "^1.0.0-rc.5",
+        "vite": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/plugin-transform-runtime": {
+          "optional": true
+        },
+        "@babel/runtime": {
+          "optional": true
+        },
+        "vite": {
           "optional": true
         }
       }
@@ -4033,6 +4762,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.32",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.32.tgz",
+      "integrity": "sha512-wbPvpyjJPC0zdfdKXxqEL3Ea+bOMD/87X4lftiJkkaBiuG6ALQy1SLmEd7BSmVCuwCQsBrCamgBoLyfFDD1EPg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/blake3-wasm": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
@@ -4073,6 +4815,40 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
     "node_modules/bundle-name": {
@@ -4138,6 +4914,27 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001793",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
+      "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0",
+      "peer": true
     },
     "node_modules/chai": {
       "version": "6.2.1",
@@ -4382,6 +5179,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/cookie": {
       "version": "0.7.2",
@@ -4637,6 +5441,13 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.361",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.361.tgz",
+      "integrity": "sha512-Q6Hts7N9FnJc5LeGRINFvLhCI9xZmNtTDe5ZbcVezQz7cU4a8Aua3GH1b8J2XY8Al9PF+OCwYqhgsOOheMdvkA==",
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -5063,7 +5874,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -5081,6 +5891,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/get-caller-file": {
@@ -5155,7 +5975,7 @@
       "version": "4.13.0",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.0.tgz",
       "integrity": "sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -5604,7 +6424,7 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -5629,7 +6449,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -5642,6 +6461,18 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/json-parse-even-better-errors": {
@@ -5693,6 +6524,19 @@
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/kleur": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
@@ -5715,6 +6559,16 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
     },
     "node_modules/lucide-react": {
       "version": "0.523.0",
@@ -5970,6 +6824,16 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/node-releases": {
+      "version": "2.0.46",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.46.tgz",
+      "integrity": "sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/oauth4webapi": {
       "version": "3.8.5",
       "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.5.tgz",
@@ -6093,9 +6957,9 @@
       }
     },
     "node_modules/partyserver": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/partyserver/-/partyserver-0.3.3.tgz",
-      "integrity": "sha512-jSGWNZ5lJj9czq+97y9N02HyZZtQH8wmgJRkTQahfGnzgL5+R12dMX3E+p7BscB2cVj6LZLv1uHpKL057rjJmw==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/partyserver/-/partyserver-0.4.1.tgz",
+      "integrity": "sha512-StSs0oY8RmTxjGNil7VbCG4gnTN+4rYX20fiUIItAxTPpr/5rPDZT6PIvMROkk9M1Gn7GzE1wuQXwhxceaGhXA==",
       "license": "ISC",
       "dependencies": {
         "nanoid": "^5.1.6"
@@ -6158,7 +7022,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -6187,7 +7050,7 @@
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
       "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "opencollective",
@@ -6216,7 +7079,7 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -6461,17 +7324,51 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.2.tgz",
+      "integrity": "sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@oxc-project/types": "=0.132.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.2",
+        "@rolldown/binding-darwin-arm64": "1.0.2",
+        "@rolldown/binding-darwin-x64": "1.0.2",
+        "@rolldown/binding-freebsd-x64": "1.0.2",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.2",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.2",
+        "@rolldown/binding-linux-arm64-musl": "1.0.2",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.2",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.2",
+        "@rolldown/binding-linux-x64-gnu": "1.0.2",
+        "@rolldown/binding-linux-x64-musl": "1.0.2",
+        "@rolldown/binding-openharmony-arm64": "1.0.2",
+        "@rolldown/binding-wasm32-wasi": "1.0.2",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.2",
+        "@rolldown/binding-win32-x64-msvc": "1.0.2"
       }
     },
     "node_modules/rollup": {
       "version": "4.60.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
       "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.8"
@@ -6877,7 +7774,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -7082,14 +7979,14 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
+      "devOptional": true,
       "license": "0BSD"
     },
     "node_modules/tsx": {
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.27.0",
@@ -7112,7 +8009,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7129,7 +8025,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7146,7 +8041,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7163,7 +8057,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7180,7 +8073,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7197,7 +8089,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7214,7 +8105,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7231,7 +8121,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7248,7 +8137,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7265,7 +8153,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7282,7 +8169,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7299,7 +8185,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7316,7 +8201,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7333,7 +8217,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7350,7 +8233,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7367,7 +8249,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7384,7 +8265,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7401,7 +8281,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7418,7 +8297,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7435,7 +8313,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7452,7 +8329,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7469,7 +8345,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7486,7 +8361,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7503,7 +8377,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7520,7 +8393,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7537,7 +8409,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7551,7 +8422,7 @@
       "version": "0.27.1",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.1.tgz",
       "integrity": "sha512-yY35KZckJJuVVPXpvjgxiCuVEJT67F6zDeVTv4rizyPrfGBUpZQsvmxnN+C371c2esD/hNMjj4tpBhuueLN7aA==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -7631,7 +8502,7 @@
       "version": "7.10.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
       "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unenv": {
@@ -7651,6 +8522,37 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
       }
     },
     "node_modules/uri-js": {
@@ -7728,7 +8630,7 @@
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.27.0",
@@ -7806,7 +8708,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7823,7 +8724,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7840,7 +8740,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7857,7 +8756,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7874,7 +8772,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7891,7 +8788,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7908,7 +8804,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7925,7 +8820,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7942,7 +8836,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7959,7 +8852,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7976,7 +8868,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7993,7 +8884,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8010,7 +8900,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8027,7 +8916,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8044,7 +8932,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8061,7 +8948,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8078,7 +8964,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8095,7 +8980,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8112,7 +8996,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8129,7 +9012,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8146,7 +9028,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8163,7 +9044,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8180,7 +9060,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8197,7 +9076,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8214,7 +9092,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8231,7 +9108,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8245,7 +9121,7 @@
       "version": "0.27.7",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
       "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -9022,6 +9898,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@modelcontextprotocol/sdk": "1.27.1",
         "@sentry/cloudflare": "10.30.0",
         "@vantage-sh/vantage-client": "2.2.1",
-        "agents": "^0.12.0",
+        "agents": "^0.13.2",
         "axios": "1.13.5",
         "hono": "4.12.12",
         "jose": "^6.0.11",
@@ -4318,9 +4318,9 @@
       }
     },
     "node_modules/agents": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/agents/-/agents-0.12.0.tgz",
-      "integrity": "sha512-OIKDIEU2/rhRdBytB2mWbQ91pD5GSAYGTZpCWJt7n7r74oPr0r1t5a0VHBGT3TE+uSbyJYD+py76ncDpv/1OIA==",
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/agents/-/agents-0.13.2.tgz",
+      "integrity": "sha512-s4v/e+BHrDKowsfjoCbQVA9FGPZgWz+1QCX41rR7UA2CHh90ZkARej3qrHhT+YxzYUfuWwbR9yQGFzP7/8rLsQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/plugin-proposal-decorators": "^7.29.0",
@@ -4329,21 +4329,22 @@
         "@rolldown/plugin-babel": "^0.2.3",
         "cron-schedule": "^6.0.0",
         "mimetext": "^3.0.28",
-        "nanoid": "^5.1.9",
-        "partyserver": "^0.5.5",
-        "partysocket": "1.1.18",
+        "nanoid": "^5.1.11",
+        "partyserver": "^0.5.6",
+        "partysocket": "1.1.19",
         "yargs": "^18.0.0"
       },
       "bin": {
         "agents": "dist/cli/index.js"
       },
       "peerDependencies": {
-        "@cloudflare/ai-chat": ">=0.5.2 <1.0.0",
+        "@cloudflare/ai-chat": ">=0.6.1 <1.0.0",
         "@cloudflare/codemode": ">=0.3.4 <1.0.0",
         "@tanstack/ai": ">=0.10.2 <1.0.0",
         "@x402/core": "^2.0.0",
         "@x402/evm": "^2.0.0",
         "ai": "^6.0.0",
+        "chat": "^4.29.0",
         "react": "^19.0.0",
         "vite": ">=6.0.0 <9.0.0",
         "zod": "^4.0.0"
@@ -4362,6 +4363,9 @@
           "optional": true
         },
         "@x402/evm": {
+          "optional": true
+        },
+        "chat": {
           "optional": true
         },
         "vite": {
@@ -6878,9 +6882,9 @@
       }
     },
     "node_modules/partysocket": {
-      "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/partysocket/-/partysocket-1.1.18.tgz",
-      "integrity": "sha512-SyuvH9VavWOSa14v6dYdp3yfSUDII4BQB1+TkGOFBkjfZKjnDBiba4fhdhwBlqGBkqw4ea3gTA1DYhSffX24Wg==",
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/partysocket/-/partysocket-1.1.19.tgz",
+      "integrity": "sha512-hPwsXSdUc8PKNCinET6TD3JQOxzQ2JaP0bUZQXBVl6UM8UuLn1odgf1LcJXHy4UHSQwWL/RU3AnyhEsGM+W+sg==",
       "license": "MIT",
       "dependencies": {
         "event-target-polyfill": "^0.0.4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "vantage-mcp-server",
       "dependencies": {
         "@cloudflare/workers-oauth-provider": "^0.0.11",
-        "@modelcontextprotocol/sdk": "1.27.1",
+        "@modelcontextprotocol/sdk": "1.29.0",
         "@sentry/cloudflare": "10.30.0",
         "@vantage-sh/vantage-client": "2.2.1",
         "agents": "^0.13.2",
@@ -2340,9 +2340,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.27.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
-      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@modelcontextprotocol/sdk": "1.27.1",
         "@sentry/cloudflare": "10.30.0",
         "@vantage-sh/vantage-client": "2.2.1",
-        "agents": "0.3.10",
+        "agents": "^0.4.0",
         "axios": "1.13.5",
         "hono": "4.12.12",
         "jose": "^6.0.11",
@@ -37,15 +37,15 @@
       }
     },
     "node_modules/@ai-sdk/gateway": {
-      "version": "3.0.88",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.88.tgz",
-      "integrity": "sha512-AFoj7xdWAtCQcy0jJ235ENSakYM8D28qBX+rB+/rX4r8qe/LXgl0e5UivOqxAlIM5E9jnQdYxIPuj3XFtGk/yg==",
+      "version": "3.0.120",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.120.tgz",
+      "integrity": "sha512-MYKAeD2q7/sa1ZdqtL2tw0Me0B8Tok6Q/fhkJDhJl39dG8u+VBlWO9yk9lcdm784bM418o1EKObo4aOxs6+18Q==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@ai-sdk/provider": "3.0.8",
-        "@ai-sdk/provider-utils": "4.0.22",
-        "@vercel/oidc": "3.1.0"
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.27",
+        "@vercel/oidc": "3.2.0"
       },
       "engines": {
         "node": ">=18"
@@ -55,9 +55,9 @@
       }
     },
     "node_modules/@ai-sdk/provider": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
-      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz",
+      "integrity": "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -68,15 +68,15 @@
       }
     },
     "node_modules/@ai-sdk/provider-utils": {
-      "version": "4.0.22",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.22.tgz",
-      "integrity": "sha512-B2OTFcRw/Pdka9ZTjpXv6T6qZ6RruRuLokyb8HwW+aoW9ndJ3YasA3/mVswyJw7VMBF8ofXgqvcrCt9KYvFifg==",
+      "version": "4.0.27",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.27.tgz",
+      "integrity": "sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider": "3.0.10",
         "@standard-schema/spec": "^1.1.0",
-        "eventsource-parser": "^3.0.6"
+        "eventsource-parser": "^3.0.8"
       },
       "engines": {
         "node": ">=18"
@@ -368,29 +368,29 @@
       "license": "MIT"
     },
     "node_modules/@cloudflare/ai-chat": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@cloudflare/ai-chat/-/ai-chat-0.0.6.tgz",
-      "integrity": "sha512-XDJP7ywORzQd17f09hMY1n3+bQsLw+BmXh7HzuWGb7gBBbD23OlQXccuQQqFNBYHi+IfIpe9YdGbHaUGsfCUwA==",
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@cloudflare/ai-chat/-/ai-chat-0.0.7.tgz",
+      "integrity": "sha512-yjRoM8AIFJccgSWvR7LZdf435E63oYXquyh2VpFpXsgYO3okYL1ONTIHG6QBDAnJrMf213/z6Vy47V7Py9slYw==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
-        "agents": "0.3.10",
+        "agents": "^0.4.0",
         "ai": "^6.0.0",
         "react": "^19.0.0",
         "zod": "^3.25.0 || ^4.0.0"
       }
     },
     "node_modules/@cloudflare/codemode": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@cloudflare/codemode/-/codemode-0.0.6.tgz",
-      "integrity": "sha512-P8ba7fgyeOOEODgU+lyUj82P89VfslKExsdF6nPGRebIbgiCbbpoLHBmBtdRRsIasVHUhceSazJxIS6dg70yRA==",
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@cloudflare/codemode/-/codemode-0.0.7.tgz",
+      "integrity": "sha512-hzT8WWMel7CaCtEuFG1jtw1jRb6tBpIqQje5DG/dtAWobFnh+UGplGqSyLFEqD8BLknHYrMT/qxdguR94d03dg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "zod-to-ts": "^2.0.0"
       },
       "peerDependencies": {
-        "agents": "^0.3.7",
+        "agents": "^0.4.0",
         "ai": "^6.0.0",
         "zod": "^3.25.0 || ^4.0.0"
       }
@@ -3466,9 +3466,9 @@
       "license": "MIT"
     },
     "node_modules/@vercel/oidc": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.1.0.tgz",
-      "integrity": "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
       "license": "Apache-2.0",
       "peer": true,
       "engines": {
@@ -3658,21 +3658,21 @@
       }
     },
     "node_modules/agents": {
-      "version": "0.3.10",
-      "resolved": "https://registry.npmjs.org/agents/-/agents-0.3.10.tgz",
-      "integrity": "sha512-hKj3nbej14GA2SgE6/stQheJF35LCS7DxMuHG0QDl1/npnnECYyG0Yf5DXl6AvJAZOFNDwT3iEzKi8yLZngPDA==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/agents/-/agents-0.4.0.tgz",
+      "integrity": "sha512-YZPNCpO9KxHsyE1HyGFHPKs2MrRiOaQ6GJ9R8uPGqjmsfGZ0WWB7mayiQDgSx7tezwckrX4ShtGGftffDCMx0Q==",
       "license": "MIT",
       "dependencies": {
         "@cfworker/json-schema": "^4.1.1",
-        "@modelcontextprotocol/sdk": "1.25.2",
+        "@modelcontextprotocol/sdk": "1.26.0",
         "cron-schedule": "^6.0.0",
         "escape-html": "^1.0.3",
         "json-schema": "^0.4.0",
         "json-schema-to-typescript": "^15.0.4",
         "mimetext": "^3.0.28",
         "nanoid": "^5.1.6",
-        "partyserver": "^0.1.2",
-        "partysocket": "1.1.11",
+        "partyserver": "^0.1.4",
+        "partysocket": "1.1.13",
         "yargs": "^18.0.0"
       },
       "bin": {
@@ -3681,12 +3681,13 @@
       "peerDependencies": {
         "@ai-sdk/openai": "^3.0.0",
         "@ai-sdk/react": "^3.0.0",
-        "@cloudflare/ai-chat": "^0.0.6",
-        "@cloudflare/codemode": "^0.0.6",
+        "@cloudflare/ai-chat": "^0.0.7",
+        "@cloudflare/codemode": "^0.0.7",
+        "@x402/core": "^2.0.0",
+        "@x402/evm": "^2.0.0",
         "ai": "^6.0.0",
         "react": "^19.0.0",
         "viem": ">=2.0.0",
-        "x402": "^0.7.1",
         "zod": "^3.25.0 || ^4.0.0"
       },
       "peerDependenciesMeta": {
@@ -3696,10 +3697,13 @@
         "@ai-sdk/react": {
           "optional": true
         },
-        "viem": {
+        "@x402/core": {
           "optional": true
         },
-        "x402": {
+        "@x402/evm": {
+          "optional": true
+        },
+        "viem": {
           "optional": true
         }
       }
@@ -3824,16 +3828,16 @@
       }
     },
     "node_modules/ai": {
-      "version": "6.0.146",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.146.tgz",
-      "integrity": "sha512-70DE8k1rR0N3mXxyyfjYAx/FxRln/kQ5ym18lt1ys1eUklcPuoIXGbUBwdfCbmkt6YF3jCDZ5+OgkWieP/NGDw==",
+      "version": "6.0.191",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.191.tgz",
+      "integrity": "sha512-zAxvjKebQE7YkSyyNIl0OM7i6/zygnKeF+yNUjD4nWOelYrG+LpDd6RnH6mjySI4zUpZ7o4wbnmAy8jc6u98vQ==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@ai-sdk/gateway": "3.0.88",
-        "@ai-sdk/provider": "3.0.8",
-        "@ai-sdk/provider-utils": "4.0.22",
-        "@opentelemetry/api": "1.9.0"
+        "@ai-sdk/gateway": "3.0.120",
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.27",
+        "@opentelemetry/api": "^1.9.0"
       },
       "engines": {
         "node": ">=18"
@@ -4830,9 +4834,9 @@
       }
     },
     "node_modules/eventsource-parser": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
-      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -6093,9 +6097,9 @@
       }
     },
     "node_modules/partysocket": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/partysocket/-/partysocket-1.1.11.tgz",
-      "integrity": "sha512-P0EtOQiAwvLriqLgdThcSaREfz3bP77LkLSdmXq680BosPKvGSoGTh/d0g3S+UNmaqcw89Ad7JXHHKyRx3xU9Q==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/partysocket/-/partysocket-1.1.13.tgz",
+      "integrity": "sha512-RNXGzc6j0NISGE84+VTHHtbPwmnzZuOYJm9XZ+en+aZlIA2vC4AfwPlYxAHmGGGko3pQF7xRNhoe7bu1Brej4Q==",
       "license": "MIT",
       "dependencies": {
         "event-target-polyfill": "^0.0.4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@modelcontextprotocol/sdk": "1.27.1",
         "@sentry/cloudflare": "10.30.0",
         "@vantage-sh/vantage-client": "2.2.1",
-        "agents": "^0.11.0",
+        "agents": "^0.12.0",
         "axios": "1.13.5",
         "hono": "4.12.12",
         "jose": "^6.0.11",
@@ -83,23 +83,6 @@
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
-    "node_modules/@apidevtools/json-schema-ref-parser": {
-      "version": "11.9.3",
-      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.9.3.tgz",
-      "integrity": "sha512-60vepv88RwcJtSHrD6MjIL6Ta3SOYbgfnkHb+ppAVK+o9mXprRtulx7VlRl3lN3bbvysAfCS7WMVfhUYemB0IQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@jsdevtools/ono": "^7.1.3",
-        "@types/json-schema": "^7.0.15",
-        "js-yaml": "^4.1.0"
-      },
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/philsturgeon"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -819,9 +802,9 @@
       "license": "MIT"
     },
     "node_modules/@cloudflare/workers-types": {
-      "version": "4.20260405.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260405.1.tgz",
-      "integrity": "sha512-PokTmySa+D6MY01R1UfYH48korsN462NK/fl3aw47Hg7XuLuSo/RTpjT0vtWaJhJoFY5tHGOBBIbDcIc8wltLg==",
+      "version": "4.20260526.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260526.1.tgz",
+      "integrity": "sha512-pQZBjD7p6C5R1ZPkSywA2yiZnL/LVfqdPKLQLdbEItro4ekmMuGXQv72vHkHIT3GeZmEgZktMA0JoWn2fBKmXw==",
       "license": "MIT OR Apache-2.0",
       "peer": true
     },
@@ -2227,12 +2210,6 @@
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
-    },
-    "node_modules/@jsdevtools/ono": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
-      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
-      "license": "MIT"
     },
     "node_modules/@modelcontextprotocol/inspector": {
       "version": "0.16.7",
@@ -4132,18 +4109,6 @@
       "devOptional": true,
       "license": "MIT"
     },
-    "node_modules/@types/json-schema": {
-      "version": "7.0.15",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
-      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "license": "MIT"
-    },
-    "node_modules/@types/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-FOvQ0YPD5NOfPgMzJihoT+Za5pdkDJWcbpuj1DjaKZIr/gxodQjY/uWEFlTNqW2ugXHUiL8lRQgw63dzKHZdeQ==",
-      "license": "MIT"
-    },
     "node_modules/@types/node": {
       "version": "24.3.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
@@ -4353,9 +4318,9 @@
       }
     },
     "node_modules/agents": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/agents/-/agents-0.11.0.tgz",
-      "integrity": "sha512-FBjTA0G5ejwYMcizqTkX2ONJFXV1vqMM5P0yqOu6r0dWzTmaW84LKQACMava2HkPO4+nVhesW94+kf1E/a+MDw==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/agents/-/agents-0.12.0.tgz",
+      "integrity": "sha512-OIKDIEU2/rhRdBytB2mWbQ91pD5GSAYGTZpCWJt7n7r74oPr0r1t5a0VHBGT3TE+uSbyJYD+py76ncDpv/1OIA==",
       "license": "MIT",
       "dependencies": {
         "@babel/plugin-proposal-decorators": "^7.29.0",
@@ -4363,35 +4328,27 @@
         "@modelcontextprotocol/sdk": "1.29.0",
         "@rolldown/plugin-babel": "^0.2.3",
         "cron-schedule": "^6.0.0",
-        "json-schema": "^0.4.0",
-        "json-schema-to-typescript": "^15.0.4",
         "mimetext": "^3.0.28",
-        "nanoid": "^5.1.7",
-        "partyserver": "^0.4.1",
-        "partysocket": "1.1.16",
-        "picomatch": "^4.0.4",
+        "nanoid": "^5.1.9",
+        "partyserver": "^0.5.5",
+        "partysocket": "1.1.18",
         "yargs": "^18.0.0"
       },
       "bin": {
         "agents": "dist/cli/index.js"
       },
       "peerDependencies": {
-        "@ai-sdk/react": "^3.0.0",
-        "@cloudflare/ai-chat": "^0.4.2",
-        "@cloudflare/codemode": "^0.3.4",
-        "@tanstack/ai": "^0.10.2",
+        "@cloudflare/ai-chat": ">=0.5.2 <1.0.0",
+        "@cloudflare/codemode": ">=0.3.4 <1.0.0",
+        "@tanstack/ai": ">=0.10.2 <1.0.0",
         "@x402/core": "^2.0.0",
         "@x402/evm": "^2.0.0",
         "ai": "^6.0.0",
         "react": "^19.0.0",
-        "viem": ">=2.0.0",
         "vite": ">=6.0.0 <9.0.0",
         "zod": "^4.0.0"
       },
       "peerDependenciesMeta": {
-        "@ai-sdk/react": {
-          "optional": true
-        },
         "@cloudflare/ai-chat": {
           "optional": true
         },
@@ -4405,9 +4362,6 @@
           "optional": true
         },
         "@x402/evm": {
-          "optional": true
-        },
-        "viem": {
           "optional": true
         },
         "vite": {
@@ -4676,6 +4630,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/aria-hidden": {
@@ -5765,6 +5720,7 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -6241,15 +6197,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/is-extglob": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -6258,18 +6205,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/is-glob": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "license": "MIT",
-      "dependencies": {
-        "is-extglob": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/is-inside-container": {
@@ -6455,6 +6390,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -6486,30 +6422,8 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
-      "license": "(AFL-2.1 OR BSD-3-Clause)"
-    },
-    "node_modules/json-schema-to-typescript": {
-      "version": "15.0.4",
-      "resolved": "https://registry.npmjs.org/json-schema-to-typescript/-/json-schema-to-typescript-15.0.4.tgz",
-      "integrity": "sha512-Su9oK8DR4xCmDsLlyvadkXzX6+GGXJpbhwoLtOGArAG61dvbW4YQmSEno2y66ahpIdmLMg6YUf/QHLgiwvkrHQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@apidevtools/json-schema-ref-parser": "^11.5.5",
-        "@types/json-schema": "^7.0.15",
-        "@types/lodash": "^4.17.7",
-        "is-glob": "^4.0.3",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "minimist": "^1.2.8",
-        "prettier": "^3.2.5",
-        "tinyglobby": "^0.2.9"
-      },
-      "bin": {
-        "json2ts": "dist/src/cli.js"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
+      "license": "(AFL-2.1 OR BSD-3-Clause)",
+      "peer": true
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -6552,12 +6466,6 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lru-cache": {
@@ -6786,6 +6694,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6957,21 +6866,21 @@
       }
     },
     "node_modules/partyserver": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/partyserver/-/partyserver-0.4.1.tgz",
-      "integrity": "sha512-StSs0oY8RmTxjGNil7VbCG4gnTN+4rYX20fiUIItAxTPpr/5rPDZT6PIvMROkk9M1Gn7GzE1wuQXwhxceaGhXA==",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/partyserver/-/partyserver-0.5.6.tgz",
+      "integrity": "sha512-/LKCqlq9nWzNXA8UXZFO/Xz15QDCjJnGAgRQVLnXJO9bA0HKt5J8VM8wLnGc814WatzuQgeG17tqzI//y5WFGA==",
       "license": "ISC",
       "dependencies": {
-        "nanoid": "^5.1.6"
+        "nanoid": "^5.1.9"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^4.20240729.0"
+        "@cloudflare/workers-types": "^4.20260424.1"
       }
     },
     "node_modules/partysocket": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/partysocket/-/partysocket-1.1.16.tgz",
-      "integrity": "sha512-d7xFv+ZC7x0p/DAHWJ5FhxQhimIx+ucyZY+kxL0cKddLBmK9c4p2tEA/L+dOOrWm6EYrRwrBjKQV0uSzOY9x1w==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/partysocket/-/partysocket-1.1.18.tgz",
+      "integrity": "sha512-SyuvH9VavWOSa14v6dYdp3yfSUDII4BQB1+TkGOFBkjfZKjnDBiba4fhdhwBlqGBkqw4ea3gTA1DYhSffX24Wg==",
       "license": "MIT",
       "dependencies": {
         "event-target-polyfill": "^0.0.4"
@@ -7092,21 +7001,6 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
-    "node_modules/prettier": {
-      "version": "3.7.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.7.4.tgz",
-      "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/prismjs": {
@@ -7890,6 +7784,7 @@
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
       "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@modelcontextprotocol/sdk": "1.27.1",
         "@sentry/cloudflare": "10.30.0",
         "@vantage-sh/vantage-client": "2.2.1",
-        "agents": "^0.5.0",
+        "agents": "^0.6.0",
         "axios": "1.13.5",
         "hono": "4.12.12",
         "jose": "^6.0.11",
@@ -3630,21 +3630,20 @@
       }
     },
     "node_modules/agents": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/agents/-/agents-0.5.0.tgz",
-      "integrity": "sha512-iECyHMROnfESwO6SO44MQ3z/BP6e6MGZgBb980Zg1ls2WdBmxUTXHeaW4qUESWUhwj5LmtYCmuewfYCgIPKzZQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/agents/-/agents-0.6.0.tgz",
+      "integrity": "sha512-BUqYwtTyNp0ksAJo0b4uSn4lmIDYkLAeXDnu3VaCHyLUPI5C/1PECOVrD0xHzHkGkbE/yL79Eaasuuk9U7kGwQ==",
       "license": "MIT",
       "dependencies": {
         "@cfworker/json-schema": "^4.1.1",
         "@modelcontextprotocol/sdk": "1.26.0",
         "cron-schedule": "^6.0.0",
-        "escape-html": "^1.0.3",
         "json-schema": "^0.4.0",
         "json-schema-to-typescript": "^15.0.4",
         "mimetext": "^3.0.28",
         "nanoid": "^5.1.6",
-        "partyserver": "^0.1.5",
-        "partysocket": "1.1.13",
+        "partyserver": "^0.3.0",
+        "partysocket": "1.1.15",
         "yargs": "^18.0.0"
       },
       "bin": {
@@ -3653,8 +3652,8 @@
       "peerDependencies": {
         "@ai-sdk/openai": "^3.0.0",
         "@ai-sdk/react": "^3.0.0",
-        "@cloudflare/ai-chat": "^0.1.0",
-        "@cloudflare/codemode": "^0.0.8",
+        "@cloudflare/ai-chat": "^0.1.4",
+        "@cloudflare/codemode": "^0.1.1",
         "@x402/core": "^2.0.0",
         "@x402/evm": "^2.0.0",
         "ai": "^6.0.0",
@@ -5914,9 +5913,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "5.1.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.7.tgz",
-      "integrity": "sha512-ua3NDgISf6jdwezAheMOk4mbE1LXjm1DfMUDMuJf4AqxLFK3ccGpgWizwa5YV7Yz9EpXwEaWoRXSb/BnV0t5dQ==",
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.11.tgz",
+      "integrity": "sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg==",
       "funding": [
         {
           "type": "github",
@@ -6063,9 +6062,9 @@
       }
     },
     "node_modules/partyserver": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/partyserver/-/partyserver-0.1.5.tgz",
-      "integrity": "sha512-kaE3GYaYWFc70EJQDQEhyYbO2Wczz/NgsFXerfjRo0t2s7ZxL1XggWT+HkMrdEyqbZOv3b66CV93WG0Lcg/ThQ==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/partyserver/-/partyserver-0.3.3.tgz",
+      "integrity": "sha512-jSGWNZ5lJj9czq+97y9N02HyZZtQH8wmgJRkTQahfGnzgL5+R12dMX3E+p7BscB2cVj6LZLv1uHpKL057rjJmw==",
       "license": "ISC",
       "dependencies": {
         "nanoid": "^5.1.6"
@@ -6075,12 +6074,20 @@
       }
     },
     "node_modules/partysocket": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/partysocket/-/partysocket-1.1.13.tgz",
-      "integrity": "sha512-RNXGzc6j0NISGE84+VTHHtbPwmnzZuOYJm9XZ+en+aZlIA2vC4AfwPlYxAHmGGGko3pQF7xRNhoe7bu1Brej4Q==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/partysocket/-/partysocket-1.1.15.tgz",
+      "integrity": "sha512-d8dvcNMqtWQU1k3OguLN+Vk3GV6uFD0PEhu9EZkCDZuE/xAsdeFlv8fCcsFefQWzoZyVNvTpAKTvutXc6exrEg==",
       "license": "MIT",
       "dependencies": {
         "event-target-polyfill": "^0.0.4"
+      },
+      "peerDependencies": {
+        "react": ">=17"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/path-is-inside": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@modelcontextprotocol/sdk": "1.27.1",
         "@sentry/cloudflare": "10.30.0",
         "@vantage-sh/vantage-client": "2.2.1",
-        "agents": "^0.9.0",
+        "agents": "^0.10.0",
         "axios": "1.13.5",
         "hono": "4.12.12",
         "jose": "^6.0.11",
@@ -4353,9 +4353,9 @@
       }
     },
     "node_modules/agents": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/agents/-/agents-0.9.0.tgz",
-      "integrity": "sha512-Ucw2gh3VMV+3oXE37I9zk/oVdy9lmAWj5ASuFY91Cf9tvlovkzYZ2k297RxnEPeKkpiAYhaCr5IA53jCCVgD2g==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/agents/-/agents-0.10.0.tgz",
+      "integrity": "sha512-N1eHE0u1ECn5yJuAr98Z9prBUTrJCK7ya9expqaGbpYat7n+lraeI9JUS0Y+ANI2msqUaDZD5gdNEpg7GoQJlA==",
       "license": "MIT",
       "dependencies": {
         "@babel/plugin-proposal-decorators": "^7.29.0",
@@ -4378,14 +4378,14 @@
       "peerDependencies": {
         "@ai-sdk/openai": "^3.0.0",
         "@ai-sdk/react": "^3.0.0",
-        "@cloudflare/ai-chat": "^0.3.2",
-        "@cloudflare/codemode": "^0.3.3",
+        "@cloudflare/ai-chat": "^0.4.0",
+        "@cloudflare/codemode": "^0.3.4",
         "@x402/core": "^2.0.0",
         "@x402/evm": "^2.0.0",
         "ai": "^6.0.0",
         "react": "^19.0.0",
         "viem": ">=2.0.0",
-        "vite": ">=6.0.0",
+        "vite": ">=6.0.0 <9.0.0",
         "zod": "^4.0.0"
       },
       "peerDependenciesMeta": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@modelcontextprotocol/sdk": "1.27.1",
         "@sentry/cloudflare": "10.30.0",
         "@vantage-sh/vantage-client": "2.2.1",
-        "agents": "^0.4.0",
+        "agents": "^0.5.0",
         "axios": "1.13.5",
         "hono": "4.12.12",
         "jose": "^6.0.11",
@@ -366,34 +366,6 @@
       "resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.1.1.tgz",
       "integrity": "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==",
       "license": "MIT"
-    },
-    "node_modules/@cloudflare/ai-chat": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@cloudflare/ai-chat/-/ai-chat-0.0.7.tgz",
-      "integrity": "sha512-yjRoM8AIFJccgSWvR7LZdf435E63oYXquyh2VpFpXsgYO3okYL1ONTIHG6QBDAnJrMf213/z6Vy47V7Py9slYw==",
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "agents": "^0.4.0",
-        "ai": "^6.0.0",
-        "react": "^19.0.0",
-        "zod": "^3.25.0 || ^4.0.0"
-      }
-    },
-    "node_modules/@cloudflare/codemode": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@cloudflare/codemode/-/codemode-0.0.7.tgz",
-      "integrity": "sha512-hzT8WWMel7CaCtEuFG1jtw1jRb6tBpIqQje5DG/dtAWobFnh+UGplGqSyLFEqD8BLknHYrMT/qxdguR94d03dg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "zod-to-ts": "^2.0.0"
-      },
-      "peerDependencies": {
-        "agents": "^0.4.0",
-        "ai": "^6.0.0",
-        "zod": "^3.25.0 || ^4.0.0"
-      }
     },
     "node_modules/@cloudflare/kv-asset-handler": {
       "version": "0.4.2",
@@ -3658,9 +3630,9 @@
       }
     },
     "node_modules/agents": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/agents/-/agents-0.4.0.tgz",
-      "integrity": "sha512-YZPNCpO9KxHsyE1HyGFHPKs2MrRiOaQ6GJ9R8uPGqjmsfGZ0WWB7mayiQDgSx7tezwckrX4ShtGGftffDCMx0Q==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/agents/-/agents-0.5.0.tgz",
+      "integrity": "sha512-iECyHMROnfESwO6SO44MQ3z/BP6e6MGZgBb980Zg1ls2WdBmxUTXHeaW4qUESWUhwj5LmtYCmuewfYCgIPKzZQ==",
       "license": "MIT",
       "dependencies": {
         "@cfworker/json-schema": "^4.1.1",
@@ -3671,7 +3643,7 @@
         "json-schema-to-typescript": "^15.0.4",
         "mimetext": "^3.0.28",
         "nanoid": "^5.1.6",
-        "partyserver": "^0.1.4",
+        "partyserver": "^0.1.5",
         "partysocket": "1.1.13",
         "yargs": "^18.0.0"
       },
@@ -3681,8 +3653,8 @@
       "peerDependencies": {
         "@ai-sdk/openai": "^3.0.0",
         "@ai-sdk/react": "^3.0.0",
-        "@cloudflare/ai-chat": "^0.0.7",
-        "@cloudflare/codemode": "^0.0.7",
+        "@cloudflare/ai-chat": "^0.1.0",
+        "@cloudflare/codemode": "^0.0.8",
         "@x402/core": "^2.0.0",
         "@x402/evm": "^2.0.0",
         "ai": "^6.0.0",
@@ -3695,6 +3667,12 @@
           "optional": true
         },
         "@ai-sdk/react": {
+          "optional": true
+        },
+        "@cloudflare/ai-chat": {
+          "optional": true
+        },
+        "@cloudflare/codemode": {
           "optional": true
         },
         "@x402/core": {
@@ -7591,6 +7569,7 @@
       "version": "5.9.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -9109,17 +9088,6 @@
       "license": "ISC",
       "peerDependencies": {
         "zod": "^3.25 || ^4"
-      }
-    },
-    "node_modules/zod-to-ts": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/zod-to-ts/-/zod-to-ts-2.0.0.tgz",
-      "integrity": "sha512-aHsUgIl+CQutKAxtRNeZslLCLXoeuSq+j5HU7q3kvi/c2KIAo6q4YjT7/lwFfACxLB923ELHYMkHmlxiqFy4lw==",
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "typescript": "^5.0.0",
-        "zod": "^3.25.0 || ^4.0.0"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@modelcontextprotocol/sdk": "1.27.1",
         "@sentry/cloudflare": "10.30.0",
         "@vantage-sh/vantage-client": "2.2.1",
-        "agents": "^0.7.0",
+        "agents": "^0.8.0",
         "axios": "1.13.5",
         "hono": "4.12.12",
         "jose": "^6.0.11",
@@ -19,7 +19,7 @@
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "workers-tagged-logger": "^1.0.0",
-        "zod": "^3.25.61"
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@biomejs/biome": "2.2.5",
@@ -1919,6 +1919,16 @@
         "mcp-inspector-client": "bin/start.js"
       }
     },
+    "node_modules/@modelcontextprotocol/inspector-client/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/@modelcontextprotocol/inspector-server": {
       "version": "0.16.7",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/inspector-server/-/inspector-server-0.16.7.tgz",
@@ -1934,6 +1944,26 @@
       },
       "bin": {
         "mcp-inspector-server": "build/index.js"
+      }
+    },
+    "node_modules/@modelcontextprotocol/inspector-server/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@modelcontextprotocol/inspector/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
@@ -3630,9 +3660,9 @@
       }
     },
     "node_modules/agents": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/agents/-/agents-0.7.0.tgz",
-      "integrity": "sha512-uK1i/NeAMSgDU2VCqy4LGY4PKGzORpXjZzEHMewkFq9urS48lyguHpmNU+ckN2+nz+OGrVQ7WRRuu/rQC8dvOA==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/agents/-/agents-0.8.0.tgz",
+      "integrity": "sha512-7yFkER0npHTowGU9gr2buqb/StpNvURqU5urG63zYQ7twZIyUs/UeZbp88f/AHJKZnLQUlM8MT0TN38Nt3m3Ag==",
       "license": "MIT",
       "dependencies": {
         "@cfworker/json-schema": "^4.1.1",
@@ -3641,9 +3671,10 @@
         "json-schema": "^0.4.0",
         "json-schema-to-typescript": "^15.0.4",
         "mimetext": "^3.0.28",
-        "nanoid": "^5.1.6",
-        "partyserver": "^0.3.2",
+        "nanoid": "^5.1.7",
+        "partyserver": "^0.3.3",
         "partysocket": "1.1.16",
+        "picomatch": "^4.0.3",
         "yargs": "^18.0.0"
       },
       "bin": {
@@ -3652,14 +3683,14 @@
       "peerDependencies": {
         "@ai-sdk/openai": "^3.0.0",
         "@ai-sdk/react": "^3.0.0",
-        "@cloudflare/ai-chat": "^0.1.6",
-        "@cloudflare/codemode": "^0.1.2",
+        "@cloudflare/ai-chat": "^0.2.0",
+        "@cloudflare/codemode": "^0.3.0",
         "@x402/core": "^2.0.0",
         "@x402/evm": "^2.0.0",
         "ai": "^6.0.0",
         "react": "^19.0.0",
         "viem": ">=2.0.0",
-        "zod": "^3.25.0 || ^4.0.0"
+        "zod": "^4.0.0"
       },
       "peerDependenciesMeta": {
         "@ai-sdk/openai": {
@@ -8395,15 +8426,6 @@
         "hono": "^4.6.16"
       }
     },
-    "node_modules/workers-tagged-logger/node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "node_modules/wrangler": {
       "version": "4.80.0",
       "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.80.0.tgz",
@@ -9080,9 +9102,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@modelcontextprotocol/sdk": "1.27.1",
     "@sentry/cloudflare": "10.30.0",
     "@vantage-sh/vantage-client": "2.2.1",
-    "agents": "^0.10.0",
+    "agents": "^0.11.0",
     "axios": "1.13.5",
     "hono": "4.12.12",
     "jose": "^6.0.11",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@modelcontextprotocol/sdk": "1.27.1",
     "@sentry/cloudflare": "10.30.0",
     "@vantage-sh/vantage-client": "2.2.1",
-    "agents": "0.3.10",
+    "agents": "^0.4.0",
     "axios": "1.13.5",
     "hono": "4.12.12",
     "jose": "^6.0.11",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@cloudflare/workers-oauth-provider": "^0.0.11",
-    "@modelcontextprotocol/sdk": "1.27.1",
+    "@modelcontextprotocol/sdk": "1.29.0",
     "@sentry/cloudflare": "10.30.0",
     "@vantage-sh/vantage-client": "2.2.1",
     "agents": "^0.13.2",
@@ -35,7 +35,6 @@
     "zod": "^4.4.3"
   },
   "overrides": {
-    "@modelcontextprotocol/sdk": "1.27.1",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"
   },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@modelcontextprotocol/sdk": "1.27.1",
     "@sentry/cloudflare": "10.30.0",
     "@vantage-sh/vantage-client": "2.2.1",
-    "agents": "^0.7.0",
+    "agents": "^0.8.0",
     "axios": "1.13.5",
     "hono": "4.12.12",
     "jose": "^6.0.11",
@@ -32,7 +32,7 @@
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "workers-tagged-logger": "^1.0.0",
-    "zod": "^3.25.61"
+    "zod": "^4.4.3"
   },
   "overrides": {
     "@modelcontextprotocol/sdk": "1.27.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@modelcontextprotocol/sdk": "1.27.1",
     "@sentry/cloudflare": "10.30.0",
     "@vantage-sh/vantage-client": "2.2.1",
-    "agents": "^0.8.0",
+    "agents": "^0.9.0",
     "axios": "1.13.5",
     "hono": "4.12.12",
     "jose": "^6.0.11",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@modelcontextprotocol/sdk": "1.27.1",
     "@sentry/cloudflare": "10.30.0",
     "@vantage-sh/vantage-client": "2.2.1",
-    "agents": "^0.11.0",
+    "agents": "^0.12.0",
     "axios": "1.13.5",
     "hono": "4.12.12",
     "jose": "^6.0.11",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@modelcontextprotocol/sdk": "1.27.1",
     "@sentry/cloudflare": "10.30.0",
     "@vantage-sh/vantage-client": "2.2.1",
-    "agents": "^0.6.0",
+    "agents": "^0.7.0",
     "axios": "1.13.5",
     "hono": "4.12.12",
     "jose": "^6.0.11",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@modelcontextprotocol/sdk": "1.27.1",
     "@sentry/cloudflare": "10.30.0",
     "@vantage-sh/vantage-client": "2.2.1",
-    "agents": "^0.5.0",
+    "agents": "^0.6.0",
     "axios": "1.13.5",
     "hono": "4.12.12",
     "jose": "^6.0.11",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@modelcontextprotocol/sdk": "1.27.1",
     "@sentry/cloudflare": "10.30.0",
     "@vantage-sh/vantage-client": "2.2.1",
-    "agents": "^0.12.0",
+    "agents": "^0.13.2",
     "axios": "1.13.5",
     "hono": "4.12.12",
     "jose": "^6.0.11",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@modelcontextprotocol/sdk": "1.27.1",
     "@sentry/cloudflare": "10.30.0",
     "@vantage-sh/vantage-client": "2.2.1",
-    "agents": "^0.9.0",
+    "agents": "^0.10.0",
     "axios": "1.13.5",
     "hono": "4.12.12",
     "jose": "^6.0.11",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@modelcontextprotocol/sdk": "1.27.1",
     "@sentry/cloudflare": "10.30.0",
     "@vantage-sh/vantage-client": "2.2.1",
-    "agents": "^0.4.0",
+    "agents": "^0.5.0",
     "axios": "1.13.5",
     "hono": "4.12.12",
     "jose": "^6.0.11",

--- a/src/tools/billing-rules/create-billing-rule.ts
+++ b/src/tools/billing-rules/create-billing-rule.ts
@@ -1,4 +1,4 @@
-import z from "zod/v4";
+import z from "zod";
 import MCPUserError from "../structure/MCPUserError";
 import registerTool from "../structure/registerTool";
 import dateValidator from "../utils/dateValidator";

--- a/src/tools/billing-rules/delete-billing-rule.ts
+++ b/src/tools/billing-rules/delete-billing-rule.ts
@@ -1,5 +1,5 @@
 import { pathEncode } from "@vantage-sh/vantage-client";
-import z from "zod/v4";
+import z from "zod";
 import MCPUserError from "../structure/MCPUserError";
 import registerTool from "../structure/registerTool";
 

--- a/src/tools/billing-rules/get-billing-rule.ts
+++ b/src/tools/billing-rules/get-billing-rule.ts
@@ -1,5 +1,5 @@
 import { pathEncode } from "@vantage-sh/vantage-client";
-import z from "zod/v4";
+import z from "zod";
 import MCPUserError from "../structure/MCPUserError";
 import registerTool from "../structure/registerTool";
 

--- a/src/tools/billing-rules/list-billing-rules.ts
+++ b/src/tools/billing-rules/list-billing-rules.ts
@@ -1,4 +1,4 @@
-import z from "zod/v4";
+import z from "zod";
 import { DEFAULT_LIMIT } from "../structure/constants";
 import MCPUserError from "../structure/MCPUserError";
 import registerTool from "../structure/registerTool";

--- a/src/tools/billing-rules/update-billing-rule.ts
+++ b/src/tools/billing-rules/update-billing-rule.ts
@@ -1,5 +1,5 @@
 import { pathEncode } from "@vantage-sh/vantage-client";
-import z from "zod/v4";
+import z from "zod";
 import MCPUserError from "../structure/MCPUserError";
 import registerTool from "../structure/registerTool";
 import dateValidator from "../utils/dateValidator";

--- a/src/tools/budgets/create-budget.ts
+++ b/src/tools/budgets/create-budget.ts
@@ -1,4 +1,4 @@
-import z from "zod/v4";
+import z from "zod";
 import MCPUserError from "../structure/MCPUserError";
 import registerTool from "../structure/registerTool";
 import { budgetPeriod } from "./schemas";

--- a/src/tools/budgets/delete-budget.ts
+++ b/src/tools/budgets/delete-budget.ts
@@ -1,5 +1,5 @@
 import { pathEncode } from "@vantage-sh/vantage-client";
-import z from "zod/v4";
+import z from "zod";
 import MCPUserError from "../structure/MCPUserError";
 import registerTool from "../structure/registerTool";
 

--- a/src/tools/budgets/get-budget.ts
+++ b/src/tools/budgets/get-budget.ts
@@ -1,5 +1,5 @@
 import { pathEncode } from "@vantage-sh/vantage-client";
-import z from "zod/v4";
+import z from "zod";
 import MCPUserError from "../structure/MCPUserError";
 import registerTool from "../structure/registerTool";
 

--- a/src/tools/budgets/list-budgets.ts
+++ b/src/tools/budgets/list-budgets.ts
@@ -1,4 +1,4 @@
-import z from "zod/v4";
+import z from "zod";
 import { DEFAULT_LIMIT } from "../structure/constants";
 import MCPUserError from "../structure/MCPUserError";
 import registerTool from "../structure/registerTool";

--- a/src/tools/budgets/schemas.ts
+++ b/src/tools/budgets/schemas.ts
@@ -1,4 +1,4 @@
-import z from "zod/v4";
+import z from "zod";
 import dateValidator from "../utils/dateValidator";
 
 export const budgetPeriod = z.object({

--- a/src/tools/budgets/update-budget.ts
+++ b/src/tools/budgets/update-budget.ts
@@ -1,5 +1,5 @@
 import { pathEncode } from "@vantage-sh/vantage-client";
-import z from "zod/v4";
+import z from "zod";
 import MCPUserError from "../structure/MCPUserError";
 import registerTool from "../structure/registerTool";
 import { budgetPeriod } from "./schemas";

--- a/src/tools/business-metrics/get-business-metric.ts
+++ b/src/tools/business-metrics/get-business-metric.ts
@@ -1,5 +1,5 @@
 import { pathEncode } from "@vantage-sh/vantage-client";
-import z from "zod/v4";
+import z from "zod";
 import MCPUserError from "../structure/MCPUserError";
 import registerTool from "../structure/registerTool";
 

--- a/src/tools/business-metrics/list-business-metrics.ts
+++ b/src/tools/business-metrics/list-business-metrics.ts
@@ -1,4 +1,4 @@
-import z from "zod/v4";
+import z from "zod";
 import MCPUserError from "../structure/MCPUserError";
 import registerTool from "../structure/registerTool";
 import paginationData from "../utils/paginationData";

--- a/src/tools/business-metrics/schemas.ts
+++ b/src/tools/business-metrics/schemas.ts
@@ -1,4 +1,4 @@
-import z from "zod/v4";
+import z from "zod";
 import dateValidator from "../utils/dateValidator";
 
 export const BUSINESS_METRICS_LIMIT = 1000;

--- a/src/tools/create-cost-alert.ts
+++ b/src/tools/create-cost-alert.ts
@@ -1,4 +1,4 @@
-import z from "zod/v4";
+import z from "zod";
 import MCPUserError from "./structure/MCPUserError";
 import registerTool from "./structure/registerTool";
 

--- a/src/tools/create-cost-report.ts
+++ b/src/tools/create-cost-report.ts
@@ -1,4 +1,4 @@
-import z from "zod/v4";
+import z from "zod";
 import MCPUserError from "./structure/MCPUserError";
 import registerTool from "./structure/registerTool";
 import { dateIntervalOptions } from "./utils/dateIntervalOptions";

--- a/src/tools/create-dashboard.ts
+++ b/src/tools/create-dashboard.ts
@@ -1,4 +1,4 @@
-import z from "zod/v4";
+import z from "zod";
 import MCPUserError from "./structure/MCPUserError";
 import registerTool from "./structure/registerTool";
 import { dateIntervalOptions } from "./utils/dateIntervalOptions";

--- a/src/tools/create-folder.ts
+++ b/src/tools/create-folder.ts
@@ -1,4 +1,4 @@
-import z from "zod/v4";
+import z from "zod";
 import MCPUserError from "./structure/MCPUserError";
 import registerTool from "./structure/registerTool";
 

--- a/src/tools/create-report-notification.ts
+++ b/src/tools/create-report-notification.ts
@@ -1,4 +1,4 @@
-import z from "zod/v4";
+import z from "zod";
 import MCPUserError from "./structure/MCPUserError";
 import registerTool from "./structure/registerTool";
 

--- a/src/tools/create-virtual-tag-config.ts
+++ b/src/tools/create-virtual-tag-config.ts
@@ -1,4 +1,4 @@
-import z from "zod/v4";
+import z from "zod";
 import MCPUserError from "./structure/MCPUserError";
 import registerTool from "./structure/registerTool";
 import dateValidator from "./utils/dateValidator";

--- a/src/tools/delete-cost-report.ts
+++ b/src/tools/delete-cost-report.ts
@@ -1,5 +1,5 @@
 import { pathEncode } from "@vantage-sh/vantage-client";
-import z from "zod/v4";
+import z from "zod";
 import MCPUserError from "./structure/MCPUserError";
 import registerTool from "./structure/registerTool";
 

--- a/src/tools/delete-folder.ts
+++ b/src/tools/delete-folder.ts
@@ -1,5 +1,5 @@
 import { pathEncode } from "@vantage-sh/vantage-client";
-import z from "zod/v4";
+import z from "zod";
 import MCPUserError from "./structure/MCPUserError";
 import registerTool from "./structure/registerTool";
 

--- a/src/tools/delete-report-notification.ts
+++ b/src/tools/delete-report-notification.ts
@@ -1,5 +1,5 @@
 import { pathEncode } from "@vantage-sh/vantage-client";
-import z from "zod/v4";
+import z from "zod";
 import MCPUserError from "./structure/MCPUserError";
 import registerTool from "./structure/registerTool";
 

--- a/src/tools/financial-commitment-reports/create-financial-commitment-report.ts
+++ b/src/tools/financial-commitment-reports/create-financial-commitment-report.ts
@@ -1,5 +1,5 @@
 import type { RequestBodyForPathAndMethod } from "@vantage-sh/vantage-client";
-import z from "zod/v4";
+import z from "zod";
 import MCPUserError from "../structure/MCPUserError";
 import registerTool from "../structure/registerTool";
 import { pastDateIntervalOptions } from "../utils/dateIntervalOptions";

--- a/src/tools/financial-commitment-reports/delete-financial-commitment-report.ts
+++ b/src/tools/financial-commitment-reports/delete-financial-commitment-report.ts
@@ -1,5 +1,5 @@
 import { pathEncode } from "@vantage-sh/vantage-client";
-import z from "zod/v4";
+import z from "zod";
 import MCPUserError from "../structure/MCPUserError";
 import registerTool from "../structure/registerTool";
 

--- a/src/tools/financial-commitment-reports/list-financial-commitment-reports.ts
+++ b/src/tools/financial-commitment-reports/list-financial-commitment-reports.ts
@@ -1,4 +1,4 @@
-import z from "zod/v4";
+import z from "zod";
 import { DEFAULT_LIMIT } from "../structure/constants";
 import MCPUserError from "../structure/MCPUserError";
 import registerTool from "../structure/registerTool";

--- a/src/tools/financial-commitment-reports/schemas.ts
+++ b/src/tools/financial-commitment-reports/schemas.ts
@@ -1,4 +1,4 @@
-import z from "zod/v4";
+import z from "zod";
 
 const financialCommitmentGroupings = [
   "provider",

--- a/src/tools/financial-commitment-reports/update-financial-commitment-report.ts
+++ b/src/tools/financial-commitment-reports/update-financial-commitment-report.ts
@@ -1,5 +1,5 @@
 import { pathEncode, type UpdateFinancialCommitmentReportRequest } from "@vantage-sh/vantage-client";
-import z from "zod/v4";
+import z from "zod";
 import MCPUserError from "../structure/MCPUserError";
 import registerTool from "../structure/registerTool";
 import { pastDateIntervalOptions } from "../utils/dateIntervalOptions";

--- a/src/tools/get-anomaly.ts
+++ b/src/tools/get-anomaly.ts
@@ -1,5 +1,5 @@
 import { pathEncode } from "@vantage-sh/vantage-client";
-import z from "zod/v4";
+import z from "zod";
 import MCPUserError from "./structure/MCPUserError";
 import registerTool from "./structure/registerTool";
 

--- a/src/tools/get-cost-alert.ts
+++ b/src/tools/get-cost-alert.ts
@@ -1,5 +1,5 @@
 import { pathEncode } from "@vantage-sh/vantage-client";
-import z from "zod/v4";
+import z from "zod";
 import MCPUserError from "./structure/MCPUserError";
 import registerTool from "./structure/registerTool";
 

--- a/src/tools/get-cost-provider-accounts.ts
+++ b/src/tools/get-cost-provider-accounts.ts
@@ -1,4 +1,4 @@
-import z from "zod/v4";
+import z from "zod";
 import MCPUserError from "./structure/MCPUserError";
 import registerTool from "./structure/registerTool";
 

--- a/src/tools/get-cost-report-forecast.ts
+++ b/src/tools/get-cost-report-forecast.ts
@@ -1,5 +1,5 @@
 import { pathEncode } from "@vantage-sh/vantage-client";
-import z from "zod/v4";
+import z from "zod";
 import { DEFAULT_LIMIT } from "./structure/constants";
 import MCPUserError from "./structure/MCPUserError";
 import registerTool from "./structure/registerTool";

--- a/src/tools/get-cost-report.ts
+++ b/src/tools/get-cost-report.ts
@@ -1,5 +1,5 @@
 import { pathEncode } from "@vantage-sh/vantage-client";
-import z from "zod/v4";
+import z from "zod";
 import MCPUserError from "./structure/MCPUserError";
 import registerTool from "./structure/registerTool";
 

--- a/src/tools/get-financial-commitment-report.ts
+++ b/src/tools/get-financial-commitment-report.ts
@@ -1,5 +1,5 @@
 import { pathEncode } from "@vantage-sh/vantage-client";
-import z from "zod/v4";
+import z from "zod";
 import MCPUserError from "./structure/MCPUserError";
 import registerTool from "./structure/registerTool";
 

--- a/src/tools/get-folder.ts
+++ b/src/tools/get-folder.ts
@@ -1,5 +1,5 @@
 import { pathEncode } from "@vantage-sh/vantage-client";
-import z from "zod/v4";
+import z from "zod";
 import MCPUserError from "./structure/MCPUserError";
 import registerTool from "./structure/registerTool";
 

--- a/src/tools/get-provider-resource.ts
+++ b/src/tools/get-provider-resource.ts
@@ -1,5 +1,5 @@
 import { pathEncode } from "@vantage-sh/vantage-client";
-import z from "zod/v4";
+import z from "zod";
 import MCPUserError from "./structure/MCPUserError";
 import registerTool from "./structure/registerTool";
 

--- a/src/tools/get-report-notification.ts
+++ b/src/tools/get-report-notification.ts
@@ -1,5 +1,5 @@
 import { pathEncode } from "@vantage-sh/vantage-client";
-import z from "zod/v4";
+import z from "zod";
 import MCPUserError from "./structure/MCPUserError";
 import registerTool from "./structure/registerTool";
 

--- a/src/tools/get-team.ts
+++ b/src/tools/get-team.ts
@@ -1,5 +1,5 @@
 import { pathEncode } from "@vantage-sh/vantage-client";
-import z from "zod/v4";
+import z from "zod";
 import MCPUserError from "./structure/MCPUserError";
 import registerTool from "./structure/registerTool";
 

--- a/src/tools/get-teams.ts
+++ b/src/tools/get-teams.ts
@@ -1,4 +1,4 @@
-import z from "zod/v4";
+import z from "zod";
 import { DEFAULT_LIMIT } from "./structure/constants";
 import MCPUserError from "./structure/MCPUserError";
 import registerTool from "./structure/registerTool";

--- a/src/tools/get-users.ts
+++ b/src/tools/get-users.ts
@@ -1,4 +1,4 @@
-import z from "zod/v4";
+import z from "zod";
 import { DEFAULT_LIMIT } from "./structure/constants";
 import MCPUserError from "./structure/MCPUserError";
 import registerTool from "./structure/registerTool";

--- a/src/tools/list-anomalies.ts
+++ b/src/tools/list-anomalies.ts
@@ -1,4 +1,4 @@
-import z from "zod/v4";
+import z from "zod";
 import { DEFAULT_LIMIT } from "./structure/constants";
 import MCPUserError from "./structure/MCPUserError";
 import registerTool from "./structure/registerTool";

--- a/src/tools/list-audit-logs.ts
+++ b/src/tools/list-audit-logs.ts
@@ -1,4 +1,4 @@
-import z from "zod/v4";
+import z from "zod";
 import { DEFAULT_LIMIT } from "./structure/constants";
 import MCPUserError from "./structure/MCPUserError";
 import registerTool from "./structure/registerTool";

--- a/src/tools/list-cost-alerts.ts
+++ b/src/tools/list-cost-alerts.ts
@@ -1,4 +1,4 @@
-import z from "zod/v4";
+import z from "zod";
 import { DEFAULT_LIMIT } from "./structure/constants";
 import MCPUserError from "./structure/MCPUserError";
 import registerTool from "./structure/registerTool";

--- a/src/tools/list-cost-integrations.ts
+++ b/src/tools/list-cost-integrations.ts
@@ -1,4 +1,4 @@
-import z from "zod/v4";
+import z from "zod";
 import { DEFAULT_LIMIT } from "./structure/constants";
 import MCPUserError from "./structure/MCPUserError";
 import registerTool from "./structure/registerTool";

--- a/src/tools/list-cost-providers.ts
+++ b/src/tools/list-cost-providers.ts
@@ -1,4 +1,4 @@
-import z from "zod/v4";
+import z from "zod";
 import MCPUserError from "./structure/MCPUserError";
 import registerTool from "./structure/registerTool";
 import paginationData from "./utils/paginationData";

--- a/src/tools/list-cost-reports.ts
+++ b/src/tools/list-cost-reports.ts
@@ -1,4 +1,4 @@
-import z from "zod/v4";
+import z from "zod";
 import { DEFAULT_LIMIT } from "./structure/constants";
 import MCPUserError from "./structure/MCPUserError";
 import registerTool from "./structure/registerTool";

--- a/src/tools/list-cost-services.ts
+++ b/src/tools/list-cost-services.ts
@@ -1,4 +1,4 @@
-import z from "zod/v4";
+import z from "zod";
 import MCPUserError from "./structure/MCPUserError";
 import registerTool from "./structure/registerTool";
 

--- a/src/tools/list-costs.ts
+++ b/src/tools/list-costs.ts
@@ -1,4 +1,4 @@
-import z from "zod/v4";
+import z from "zod";
 import { DEFAULT_LIMIT } from "./structure/constants";
 import MCPUserError from "./structure/MCPUserError";
 import registerTool from "./structure/registerTool";

--- a/src/tools/list-dashboards.ts
+++ b/src/tools/list-dashboards.ts
@@ -1,4 +1,4 @@
-import z from "zod/v4";
+import z from "zod";
 import MCPUserError from "./structure/MCPUserError";
 import registerTool from "./structure/registerTool";
 import paginationData from "./utils/paginationData";

--- a/src/tools/list-folders.ts
+++ b/src/tools/list-folders.ts
@@ -1,4 +1,4 @@
-import z from "zod/v4";
+import z from "zod";
 import { DEFAULT_LIMIT } from "./structure/constants";
 import MCPUserError from "./structure/MCPUserError";
 import registerTool from "./structure/registerTool";

--- a/src/tools/list-provider-resources.ts
+++ b/src/tools/list-provider-resources.ts
@@ -1,4 +1,4 @@
-import z from "zod/v4";
+import z from "zod";
 import MCPUserError from "./structure/MCPUserError";
 import registerTool from "./structure/registerTool";
 import paginationData from "./utils/paginationData";

--- a/src/tools/list-report-notifications.ts
+++ b/src/tools/list-report-notifications.ts
@@ -1,4 +1,4 @@
-import z from "zod/v4";
+import z from "zod";
 import { DEFAULT_LIMIT } from "./structure/constants";
 import MCPUserError from "./structure/MCPUserError";
 import registerTool from "./structure/registerTool";

--- a/src/tools/list-tag-values.ts
+++ b/src/tools/list-tag-values.ts
@@ -1,5 +1,5 @@
 import { pathEncode } from "@vantage-sh/vantage-client";
-import z from "zod/v4";
+import z from "zod";
 import { DEFAULT_LIMIT } from "./structure/constants";
 import MCPUserError from "./structure/MCPUserError";
 import registerTool from "./structure/registerTool";

--- a/src/tools/list-tags.ts
+++ b/src/tools/list-tags.ts
@@ -1,4 +1,4 @@
-import z from "zod/v4";
+import z from "zod";
 import { DEFAULT_LIMIT } from "./structure/constants";
 import MCPUserError from "./structure/MCPUserError";
 import registerTool from "./structure/registerTool";

--- a/src/tools/list-unit-costs.ts
+++ b/src/tools/list-unit-costs.ts
@@ -1,4 +1,4 @@
-import z from "zod/v4";
+import z from "zod";
 import MCPUserError from "./structure/MCPUserError";
 import registerTool from "./structure/registerTool";
 import dateValidator from "./utils/dateValidator";

--- a/src/tools/query-costs.ts
+++ b/src/tools/query-costs.ts
@@ -1,4 +1,4 @@
-import z from "zod/v4";
+import z from "zod";
 import MCPUserError from "./structure/MCPUserError";
 import registerTool from "./structure/registerTool";
 import dateValidator from "./utils/dateValidator";

--- a/src/tools/recommendation-views/create-recommendation-view.ts
+++ b/src/tools/recommendation-views/create-recommendation-view.ts
@@ -1,5 +1,5 @@
 import type { RequestBodyForPathAndMethod } from "@vantage-sh/vantage-client";
-import z from "zod/v4";
+import z from "zod";
 import MCPUserError from "../structure/MCPUserError";
 import registerTool from "../structure/registerTool";
 import dateValidator from "../utils/dateValidator";

--- a/src/tools/recommendation-views/delete-recommendation-view.ts
+++ b/src/tools/recommendation-views/delete-recommendation-view.ts
@@ -1,5 +1,5 @@
 import { pathEncode } from "@vantage-sh/vantage-client";
-import z from "zod/v4";
+import z from "zod";
 import MCPUserError from "../structure/MCPUserError";
 import registerTool from "../structure/registerTool";
 

--- a/src/tools/recommendation-views/get-recommendation-view.ts
+++ b/src/tools/recommendation-views/get-recommendation-view.ts
@@ -1,5 +1,5 @@
 import { pathEncode } from "@vantage-sh/vantage-client";
-import z from "zod/v4";
+import z from "zod";
 import MCPUserError from "../structure/MCPUserError";
 import registerTool from "../structure/registerTool";
 

--- a/src/tools/recommendation-views/list-recommendation-views.ts
+++ b/src/tools/recommendation-views/list-recommendation-views.ts
@@ -1,4 +1,4 @@
-import z from "zod/v4";
+import z from "zod";
 import { DEFAULT_LIMIT } from "../structure/constants";
 import MCPUserError from "../structure/MCPUserError";
 import registerTool from "../structure/registerTool";

--- a/src/tools/recommendation-views/update-recommendation-view.ts
+++ b/src/tools/recommendation-views/update-recommendation-view.ts
@@ -1,5 +1,5 @@
 import { pathEncode, type UpdateRecommendationViewRequest } from "@vantage-sh/vantage-client";
-import z from "zod/v4";
+import z from "zod";
 import MCPUserError from "../structure/MCPUserError";
 import registerTool from "../structure/registerTool";
 import dateValidator from "../utils/dateValidator";

--- a/src/tools/recommendations/get-recommendation-details.ts
+++ b/src/tools/recommendations/get-recommendation-details.ts
@@ -1,5 +1,5 @@
 import { pathEncode } from "@vantage-sh/vantage-client";
-import z from "zod/v4";
+import z from "zod";
 import MCPUserError from "../structure/MCPUserError";
 import registerTool from "../structure/registerTool";
 

--- a/src/tools/recommendations/get-recommendation-resource-details.ts
+++ b/src/tools/recommendations/get-recommendation-resource-details.ts
@@ -1,5 +1,5 @@
 import { pathEncode } from "@vantage-sh/vantage-client";
-import z from "zod/v4";
+import z from "zod";
 import MCPUserError from "../structure/MCPUserError";
 import registerTool from "../structure/registerTool";
 

--- a/src/tools/recommendations/get-recommendation-resources.ts
+++ b/src/tools/recommendations/get-recommendation-resources.ts
@@ -1,5 +1,5 @@
 import { pathEncode } from "@vantage-sh/vantage-client";
-import z from "zod/v4";
+import z from "zod";
 import { DEFAULT_LIMIT } from "../structure/constants";
 import MCPUserError from "../structure/MCPUserError";
 import registerTool from "../structure/registerTool";

--- a/src/tools/recommendations/list-recommendations.ts
+++ b/src/tools/recommendations/list-recommendations.ts
@@ -1,4 +1,4 @@
-import z from "zod/v4";
+import z from "zod";
 import { DEFAULT_LIMIT } from "../structure/constants";
 import MCPUserError from "../structure/MCPUserError";
 import registerTool from "../structure/registerTool";

--- a/src/tools/structure/registerTool.test.ts
+++ b/src/tools/structure/registerTool.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, test, vi } from "vitest";
-import z from "zod/v4";
+import z from "zod";
 import MCPUserError from "./MCPUserError";
 import registerTool, { clearRegisteredToolsForTesting, setupRegisteredTools } from "./registerTool";
 

--- a/src/tools/structure/registerTool.ts
+++ b/src/tools/structure/registerTool.ts
@@ -7,7 +7,7 @@ import type {
   ResponseBodyForPathAndMethod,
   SupportedMethods,
 } from "@vantage-sh/vantage-client";
-import type z from "zod/v4";
+import type z from "zod";
 import type { AppEnv } from "../../env";
 import { tracer, type WaitUntil } from "../../tracing";
 import MCPUserError from "./MCPUserError";

--- a/src/tools/submit-user-feedback.ts
+++ b/src/tools/submit-user-feedback.ts
@@ -1,4 +1,4 @@
-import z from "zod/v4";
+import z from "zod";
 import MCPUserError from "./structure/MCPUserError";
 import registerTool from "./structure/registerTool";
 

--- a/src/tools/update-anomaly.ts
+++ b/src/tools/update-anomaly.ts
@@ -1,5 +1,5 @@
 import { pathEncode } from "@vantage-sh/vantage-client";
-import z from "zod/v4";
+import z from "zod";
 import MCPUserError from "./structure/MCPUserError";
 import registerTool from "./structure/registerTool";
 

--- a/src/tools/update-folder.ts
+++ b/src/tools/update-folder.ts
@@ -1,5 +1,5 @@
 import { pathEncode } from "@vantage-sh/vantage-client";
-import z from "zod/v4";
+import z from "zod";
 import MCPUserError from "./structure/MCPUserError";
 import registerTool from "./structure/registerTool";
 

--- a/src/tools/update-report-notification.ts
+++ b/src/tools/update-report-notification.ts
@@ -1,5 +1,5 @@
 import { pathEncode } from "@vantage-sh/vantage-client";
-import z from "zod/v4";
+import z from "zod";
 import MCPUserError from "./structure/MCPUserError";
 import registerTool from "./structure/registerTool";
 

--- a/src/tools/utils/dateValidator.ts
+++ b/src/tools/utils/dateValidator.ts
@@ -1,4 +1,4 @@
-import z from "zod/v4";
+import z from "zod";
 
 const ERR_BAD_DATE = "Invalid date input, must be YYYY-MM-DD format and a reasonable date.";
 

--- a/src/tools/utils/testing.ts
+++ b/src/tools/utils/testing.ts
@@ -5,7 +5,7 @@ import type {
   SupportedMethods,
 } from "@vantage-sh/vantage-client";
 import { describe, expect, it, test, vi } from "vitest";
-import z from "zod/v4";
+import z from "zod";
 import MCPUserError from "../structure/MCPUserError";
 import { setupRegisteredTools, type ToolCallContext, type ToolProperties } from "../structure/registerTool";
 


### PR DESCRIPTION
## What Changed

Catching this repo up on the `agents` package. Through that process we have to migrate explicitly to `zod` v4. We're already using v4 everywhere so now we can drop the `zod/v4` import for just `zod`. 

## Testing Done

- [x] All lints / unit tests pass
- [x] Tested again local agent harness to ensure everything still works

<img width="746" height="670" alt="image" src="https://github.com/user-attachments/assets/b1acdbf0-e950-47b7-85f7-1a4e9ac9486b" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Major bumps to `agents` and Zod v4 plus a large lockfile refresh can affect runtime validation and agent/MCP behavior; changes are mostly dependency and import paths with no intentional tool logic edits.
> 
> **Overview**
> This PR **bumps core dependencies** and **standardizes Zod imports** across the MCP server.
> 
> **`package.json`** raises **`agents`** from `0.3.10` to `^0.13.2`, **`zod`** from v3 to `^4.4.3`, and **`@modelcontextprotocol/sdk`** to `1.29.0`. The npm **`overrides`** entry that pinned the MCP SDK is removed. **`package-lock.json`** is regenerated with the new transitive tree (including tooling pulled in by the newer `agents` stack).
> 
> Across **`src/tools/**`**, every former **`import … from "zod/v4"`** is switched to **`import … from "zod"`** (including **`registerTool`**, tests, and **`dateValidator`**). Tool schemas and API behavior are unchanged—this is an import and dependency alignment pass, not new MCP capabilities.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4dec47103ed588a5448bcb8024a5ddbc5981343. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->