### PR TITLE
fix: Add date bins to create cost report tool.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
         "@cloudflare/workers-oauth-provider": "^0.0.11",
         "@modelcontextprotocol/sdk": "1.29.0",
         "@sentry/cloudflare": "10.30.0",
-        "@vantage-sh/vantage-client": "2.3.0",
+        "@vantage-sh/vantage-client": "2.4.0",
         "agents": "^0.13.2",
         "axios": "1.13.5",
         "hono": "4.12.12",
@@ -4120,9 +4120,9 @@
       }
     },
     "node_modules/@vantage-sh/vantage-client": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@vantage-sh/vantage-client/-/vantage-client-2.3.0.tgz",
-      "integrity": "sha512-rPB9xlEyI2MJQd+g7oRd9wTmXfteZGmbyqXRE1636plu+wulbTiKqUZoSmgEXDuB7ShEcE0qIKaKECmtp+4NWA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@vantage-sh/vantage-client/-/vantage-client-2.4.0.tgz",
+      "integrity": "sha512-fW0tlCpT3Mo2m35SZ4DTgl0ka9NSfRPbXrNSEdIzd4pVCN431/EhK7GyVI6CbaZqiZoWVAnxk7UA3q/HuPQvjw==",
       "license": "MIT"
     },
     "node_modules/@vercel/oidc": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
         "@cloudflare/workers-oauth-provider": "^0.0.11",
         "@modelcontextprotocol/sdk": "1.29.0",
         "@sentry/cloudflare": "10.30.0",
-        "@vantage-sh/vantage-client": "2.2.1",
+        "@vantage-sh/vantage-client": "2.3.0",
         "agents": "^0.13.2",
         "axios": "1.13.5",
         "hono": "4.12.12",
@@ -4120,9 +4120,9 @@
       }
     },
     "node_modules/@vantage-sh/vantage-client": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@vantage-sh/vantage-client/-/vantage-client-2.2.1.tgz",
-      "integrity": "sha512-QIHC+/9+QvGNgFwoDmZwM9y5KbNcF5gMQvKJYuMKGOtA+Cl16O59gwX49Wb7qa8STRQlRhJLmxnc/duFE8VAIg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@vantage-sh/vantage-client/-/vantage-client-2.3.0.tgz",
+      "integrity": "sha512-rPB9xlEyI2MJQd+g7oRd9wTmXfteZGmbyqXRE1636plu+wulbTiKqUZoSmgEXDuB7ShEcE0qIKaKECmtp+4NWA==",
       "license": "MIT"
     },
     "node_modules/@vercel/oidc": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@cloudflare/workers-oauth-provider": "^0.0.11",
     "@modelcontextprotocol/sdk": "1.29.0",
     "@sentry/cloudflare": "10.30.0",
-    "@vantage-sh/vantage-client": "2.3.0",
+    "@vantage-sh/vantage-client": "2.4.0",
     "agents": "^0.13.2",
     "axios": "1.13.5",
     "hono": "4.12.12",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@cloudflare/workers-oauth-provider": "^0.0.11",
     "@modelcontextprotocol/sdk": "1.29.0",
     "@sentry/cloudflare": "10.30.0",
-    "@vantage-sh/vantage-client": "2.2.1",
+    "@vantage-sh/vantage-client": "2.3.0",
     "agents": "^0.13.2",
     "axios": "1.13.5",
     "hono": "4.12.12",

--- a/src/tools/cost-reports/create-cost-report.test.ts
+++ b/src/tools/cost-reports/create-cost-report.test.ts
@@ -155,9 +155,7 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
       title: "Test Report",
       date_bin: "year" as any,
     },
-    expectedIssues: [
-      "Invalid enum value. Expected 'cumulative' | 'day' | 'week' | 'month' | 'quarter' | 'hour', received 'year'",
-    ],
+    expectedIssues: ['Invalid option: expected one of "cumulative"|"day"|"week"|"month"|"quarter"|"hour"'],
   },
   {
     name: "aggregate by usage",

--- a/src/tools/cost-reports/create-cost-report.test.ts
+++ b/src/tools/cost-reports/create-cost-report.test.ts
@@ -20,6 +20,7 @@ const undefineds = {
   business_metric_tokens_with_metadata: undefined,
   chart_settings: undefined,
   chart_type: undefined,
+  date_bin: undefined,
   date_interval: undefined,
   end_date: undefined,
   start_date: undefined,
@@ -55,6 +56,7 @@ const validInputArguments = {
     unallocated: false,
     aggregate_by: "cost" as const,
     show_previous_period: true,
+    complete_period: false,
   },
   previous_period_start_date: "2023-01-01",
   previous_period_end_date: "2023-01-31",
@@ -62,6 +64,7 @@ const validInputArguments = {
   end_date: "2023-02-28",
   date_interval: "custom" as const,
   chart_type: "line" as const,
+  date_bin: "day" as const,
   chart_settings: {
     x_axis_dimension: ["date"],
     y_axis_dimension: "cost",
@@ -136,6 +139,23 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
       chart_type: "invalid" as any,
     },
     expectedIssues: ['Invalid option: expected one of "area"|"line"|"bar"|"multi_bar"|"pie"'],
+  },
+  {
+    name: "valid date_bin",
+    data: {
+      ...undefineds,
+      title: "Test Report",
+      date_bin: "quarter",
+    },
+  },
+  {
+    name: "invalid date_bin",
+    data: {
+      ...undefineds,
+      title: "Test Report",
+      date_bin: "year" as any,
+    },
+    expectedIssues: ["Invalid enum value. Expected 'cumulative' | 'day' | 'week' | 'month' | 'quarter' | 'hour', received 'year'"],
   },
   {
     name: "aggregate by usage",
@@ -302,6 +322,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
         endpoint: "/v2/cost_reports",
         params: {
           title: "Minimal Report",
+          date_bin: "day",
           previous_period_end_date: "2025-01-31",
           end_date: "2025-02-01",
         },
@@ -316,6 +337,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
       const res = await callExpectingSuccess({
         ...undefineds,
         title: "Minimal Report",
+        date_bin: "day",
         end_date: "2025-02-01",
         previous_period_end_date: "2025-01-31",
       });

--- a/src/tools/cost-reports/create-cost-report.test.ts
+++ b/src/tools/cost-reports/create-cost-report.test.ts
@@ -155,7 +155,9 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
       title: "Test Report",
       date_bin: "year" as any,
     },
-    expectedIssues: ["Invalid enum value. Expected 'cumulative' | 'day' | 'week' | 'month' | 'quarter' | 'hour', received 'year'"],
+    expectedIssues: [
+      "Invalid enum value. Expected 'cumulative' | 'day' | 'week' | 'month' | 'quarter' | 'hour', received 'year'",
+    ],
   },
   {
     name: "aggregate by usage",

--- a/src/tools/cost-reports/create-cost-report.ts
+++ b/src/tools/cost-reports/create-cost-report.ts
@@ -8,6 +8,7 @@ import {
   chartSettings,
   chartTypes,
   costReportSettingsForCreate,
+  dateBins,
 } from "./schemas";
 
 const description = `
@@ -99,6 +100,10 @@ export default registerTool({
       .enum(chartTypes)
       .optional()
       .describe("The chart type to use in the CostReport. Defaults to 'line' if not provided."),
+    date_bin: z
+      .enum(dateBins)
+      .optional()
+      .describe("The date bin of the CostReport. Defaults to 'cumulative' if not provided."),
     chart_settings: chartSettings.optional().describe("Report chart settings."),
   },
   async execute(args, ctx) {

--- a/src/tools/cost-reports/schemas.ts
+++ b/src/tools/cost-reports/schemas.ts
@@ -17,7 +17,7 @@ export const chartSettings = z.object({
     ),
 });
 
-export const dateBins = ["cumulative", "day", "week", "month", "quarter"] as const;
+export const dateBins = ["cumulative", "day", "week", "month", "quarter", "hour"] as const;
 
 const businessMetricUnitScale = z.enum(["per_unit", "per_hundred", "per_thousand", "per_million", "per_billion"]);
 
@@ -49,6 +49,10 @@ export const costReportSettingsForCreate = z.object({
     .boolean()
     .default(true)
     .describe("Report will show previous period costs or usage comparison."),
+  complete_period: z
+    .boolean()
+    .default(false)
+    .describe("Report will restrict date ranges to completed periods only."),
 });
 
 export const costReportSettingsForUpdate = z.object({

--- a/src/tools/cost-reports/schemas.ts
+++ b/src/tools/cost-reports/schemas.ts
@@ -49,10 +49,7 @@ export const costReportSettingsForCreate = z.object({
     .boolean()
     .default(true)
     .describe("Report will show previous period costs or usage comparison."),
-  complete_period: z
-    .boolean()
-    .default(false)
-    .describe("Report will restrict date ranges to completed periods only."),
+  complete_period: z.boolean().default(false).describe("Report will restrict date ranges to completed periods only."),
 });
 
 export const costReportSettingsForUpdate = z.object({

--- a/src/tools/create-folder.test.ts
+++ b/src/tools/create-folder.test.ts
@@ -53,6 +53,7 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
 const successData = {
   token: "fldr_789",
   title: "Platform Team Reports",
+  type: "cost_reports",
   parent_folder_token: "fldr_123",
   saved_filter_tokens: ["svd_fltr_abc", "svd_fltr_def"],
   workspace_token: "wrkspc_123",

--- a/src/tools/create-virtual-tag-config.test.ts
+++ b/src/tools/create-virtual-tag-config.test.ts
@@ -86,6 +86,7 @@ const successData = {
   key: "cost_center",
   overridable: true,
   backfill_until: "2024-01-01",
+  collapsed_tag_keys: [],
   values: [],
 };
 

--- a/src/tools/get-folder.test.ts
+++ b/src/tools/get-folder.test.ts
@@ -6,6 +6,7 @@ import { requestsInOrder, testTool } from "./utils/testing";
 const success: GetFolderResponse = {
   token: "fldr_123",
   title: "Platform Team Reports",
+  type: "cost_reports",
   saved_filter_tokens: [],
   created_at: "2023-01-01T00:00:00Z",
   updated_at: "2023-01-01T00:00:00Z",

--- a/src/tools/get-provider-resource.test.ts
+++ b/src/tools/get-provider-resource.test.ts
@@ -69,6 +69,7 @@ const successData: GetResourceResponse = {
   region: "us-east-1",
   created_at: "2023-01-15T10:30:00Z",
   metadata: null,
+  tags: {},
 };
 
 const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [

--- a/src/tools/get-team.test.ts
+++ b/src/tools/get-team.test.ts
@@ -10,6 +10,7 @@ export const success = {
   workspace_tokens: ["wrkspc_232345678", "wrkspc_987654321", "wrkspc_123456789"],
   user_emails: ["hello@test.com"],
   user_tokens: ["usr_wfergthyjukiop", "usr_987654321asdfghj"],
+  default_dashboard_token: null,
 };
 
 testTool(

--- a/src/tools/list-folders.test.ts
+++ b/src/tools/list-folders.test.ts
@@ -36,6 +36,7 @@ const successData = {
     {
       token: "fldr_123",
       title: "Platform Team Reports",
+      type: "cost_reports",
       parent_folder_token: undefined,
       saved_filter_tokens: [],
       workspace_token: "wrkspc_123",
@@ -45,6 +46,7 @@ const successData = {
     {
       token: "fldr_456",
       title: "Sub Folder",
+      type: "cost_reports",
       parent_folder_token: "fldr_123",
       saved_filter_tokens: ["svd_fltr_abc"],
       workspace_token: "wrkspc_123",

--- a/src/tools/list-provider-resources.test.ts
+++ b/src/tools/list-provider-resources.test.ts
@@ -82,6 +82,7 @@ const successData: GetReportResourcesResponse = {
       provider: "aws",
       region: "us-east-1",
       created_at: "2023-01-15T10:30:00Z",
+      tags: {},
     },
     {
       token: "prvdr_rsrc_456",
@@ -94,6 +95,7 @@ const successData: GetReportResourcesResponse = {
       provider: "aws",
       region: "us-east-1",
       created_at: "2023-01-15T10:30:00Z",
+      tags: {},
     },
   ],
   links: {},

--- a/src/tools/list-tags.test.ts
+++ b/src/tools/list-tags.test.ts
@@ -34,9 +34,9 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
 
 const successData: GetTagsResponse = {
   tags: [
-    { tag_key: "environment", hidden: false, providers: ["aws", "azure"] },
-    { tag_key: "project", hidden: false, providers: ["aws", "gcp"] },
-    { tag_key: "team", hidden: false, providers: ["aws"] },
+    { tag_key: "environment", hidden: false, preferred: false, providers: ["aws", "azure"] },
+    { tag_key: "project", hidden: false, preferred: false, providers: ["aws", "gcp"] },
+    { tag_key: "team", hidden: false, preferred: false, providers: ["aws"] },
   ],
   links: {},
 };

--- a/src/tools/recommendations/get-recommendation-details.test.ts
+++ b/src/tools/recommendations/get-recommendation-details.test.ts
@@ -41,6 +41,7 @@ const successData: GetRecommendationResponse = {
   resources_affected_count: 10,
   workspace_token: "wt_123",
   type: "suggestion",
+  documentation_url: null,
 };
 
 const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [

--- a/src/tools/recommendations/get-recommendation-resource-details.test.ts
+++ b/src/tools/recommendations/get-recommendation-resource-details.test.ts
@@ -1,4 +1,4 @@
-import { pathEncode } from "@vantage-sh/vantage-client";
+import { type GetRecommendationResourceResponse, pathEncode } from "@vantage-sh/vantage-client";
 import { expect } from "vitest";
 import {
   type ExecutionTestTableItem,
@@ -42,10 +42,19 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
   },
 ];
 
-const successData = {
-  resource_id: "i-1234567890abcdef0",
-  account_id: "123456789012",
+const successData: GetRecommendationResourceResponse = {
   token: "res_456",
+  uuid: "i-1234567890abcdef0",
+  type: "aws_instance",
+  label: "i-1234567890abcdef0",
+  metadata: null,
+  account_id: "123456789012",
+  billing_account_id: "123456789012",
+  provider: "aws",
+  region: "us-east-1",
+  created_at: "2023-01-15T10:30:00Z",
+  tags: {},
+  resource_id: "i-1234567890abcdef0",
 };
 
 const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [

--- a/src/tools/recommendations/get-recommendation-resources.test.ts
+++ b/src/tools/recommendations/get-recommendation-resources.test.ts
@@ -1,4 +1,4 @@
-import { pathEncode } from "@vantage-sh/vantage-client";
+import { type GetRecommendationResourcesResponse, pathEncode } from "@vantage-sh/vantage-client";
 import { expect } from "vitest";
 import { DEFAULT_LIMIT } from "../structure/constants";
 import {
@@ -35,19 +35,35 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
   },
 ];
 
-const successData = {
+const successData: GetRecommendationResourcesResponse = {
   resources: [
     {
       token: "res_123",
-      resource_type: "ec2_instance",
+      uuid: "i-1234567890abcdef0",
+      type: "aws_instance",
+      label: "i-1234567890abcdef0",
+      metadata: { instance_type: "m5.large" },
+      account_id: "123456789012",
+      billing_account_id: "123456789012",
+      provider: "aws",
+      region: "us-east-1",
+      created_at: "2023-01-15T10:30:00Z",
+      tags: {},
       resource_id: "i-1234567890abcdef0",
-      configuration: { instance_type: "m5.large" },
     },
     {
       token: "res_456",
-      resource_type: "ebs_volume",
+      uuid: "vol-1234567890abcdef0",
+      type: "aws_volume",
+      label: "vol-1234567890abcdef0",
+      metadata: { volume_type: "gp2", size: 100 },
+      account_id: "123456789012",
+      billing_account_id: "123456789012",
+      provider: "aws",
+      region: "us-east-1",
+      created_at: "2023-01-15T10:30:00Z",
+      tags: {},
       resource_id: "vol-1234567890abcdef0",
-      configuration: { volume_type: "gp2", size: 100 },
     },
   ],
   links: {},

--- a/src/tools/recommendations/list-recommendations.test.ts
+++ b/src/tools/recommendations/list-recommendations.test.ts
@@ -201,6 +201,7 @@ const successData = {
       currency_code: "USD",
       currency_symbol: "$",
       workspace_token: "wt_123",
+      documentation_url: null,
     },
     {
       token: "rec_456",
@@ -216,6 +217,7 @@ const successData = {
       currency_code: "USD",
       currency_symbol: "$",
       workspace_token: "wt_123",
+      documentation_url: null,
     },
   ],
   links: {},

--- a/src/tools/update-folder.test.ts
+++ b/src/tools/update-folder.test.ts
@@ -46,6 +46,7 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
 const successData: GetFolderResponse = {
   token: "fldr_123",
   title: "Updated Team Reports",
+  type: "cost_reports",
   parent_folder_token: "fldr_parent",
   saved_filter_tokens: ["svd_fltr_abc"],
   created_at: "2023-01-01T00:00:00Z",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are dependency bump, optional MCP args, and test fixtures; no auth or infra changes, with limited blast radius to cost-report creation validation.
> 
> **Overview**
> Upgrades **`@vantage-sh/vantage-client`** to **2.4.0** and aligns MCP tools/tests with the newer API shapes.
> 
> The main product change is **`create-cost-report`**: it now accepts optional **`date_bin`** (including new **`hour`** granularity in shared `dateBins`) and forwards it on `POST /v2/cost_reports`. Create settings also gain **`complete_period`** in the cost-report schema so callers can restrict ranges to completed periods.
> 
> Remaining diff is mostly **test fixture updates** for new response fields (e.g. folder `type`, resource `tags`, tag `preferred`, recommendation `documentation_url`, richer recommendation resource payloads).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a18124bc4710f1958c2eb140482ece46625f882. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->