### PR TITLE
Add tools to find drift between the API spec and tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "prepare": "husky",
     "local": "tsx src/local.ts",
     "local:dist": "tsx build/npm.ts",
-    "print-version": "tsx src/tools/bin/print-version.ts"
+    "print-version": "tsx src/tools/bin/print-version.ts",
+    "audit-schema-drift": "tsx src/tools/bin/audit-schema-drift.ts"
   },
   "dependencies": {
     "@cloudflare/workers-oauth-provider": "^0.0.11",

--- a/src/tools/billing-rules/update-billing-rule.test.ts
+++ b/src/tools/billing-rules/update-billing-rule.test.ts
@@ -34,6 +34,7 @@ const minimalValidInputArguments: InferValidators<Validators> = {
 };
 
 const validInputArguments: InferValidators<Validators> = {
+  ...undefineds,
   billing_rule_token: "blng_rl_123",
   title: "Updated Rule",
   start_date: "2024-01-01",

--- a/src/tools/bin/audit-schema-drift-exclusions.ts
+++ b/src/tools/bin/audit-schema-drift-exclusions.ts
@@ -40,4 +40,18 @@ export const SCHEMA_DRIFT_EXCLUSIONS: SchemaDriftExclusion[] = [
     kind: "missing",
     reason: "Deprecated API field; MCP uses start_date only",
   },
+  {
+    operation: "getCostProviderAccounts",
+    tool: "get-cost-provider-accounts",
+    apiKey: "page",
+    kind: "extra",
+    reason: "API supports pagination, but the generated client types do not expose page yet",
+  },
+  {
+    operation: "getCostProviderAccounts",
+    tool: "get-cost-provider-accounts",
+    apiKey: "limit",
+    kind: "extra",
+    reason: "API supports pagination, but the generated client types do not expose limit yet",
+  },
 ];

--- a/src/tools/bin/audit-schema-drift-exclusions.ts
+++ b/src/tools/bin/audit-schema-drift-exclusions.ts
@@ -26,4 +26,18 @@ export const SCHEMA_DRIFT_EXCLUSIONS: SchemaDriftExclusion[] = [
     kind: "missing",
     reason: "Superseded by type in MCP; category remains on the API for backwards compatibility",
   },
+  {
+    operation: "createBillingRule",
+    tool: "create-billing-rule",
+    apiKey: "start_period",
+    kind: "missing",
+    reason: "Deprecated API field; MCP uses start_date only",
+  },
+  {
+    operation: "updateBillingRule",
+    tool: "update-billing-rule",
+    apiKey: "start_period",
+    kind: "missing",
+    reason: "Deprecated API field; MCP uses start_date only",
+  },
 ];

--- a/src/tools/bin/audit-schema-drift-exclusions.ts
+++ b/src/tools/bin/audit-schema-drift-exclusions.ts
@@ -1,0 +1,29 @@
+/**
+ * Intentional gaps between MCP tool schemas and the OpenAPI spec.
+ * Add entries here when the API keeps a field for backwards compatibility (or similar)
+ * but the MCP tool deliberately does not expose it.
+ *
+ * Match rules (all optional fields are AND filters when present):
+ * - operation: OpenAPI operation id (e.g. getRecommendations)
+ * - tool: MCP tool name (e.g. list-recommendations)
+ * - apiKey: parameter name as it appears in the client types
+ * - kind: "missing" = do not report "Missing from tool schema"; "extra" = do not report "Extra in tool schema"
+ */
+
+export type SchemaDriftExclusion = {
+  operation?: string;
+  tool?: string;
+  apiKey: string;
+  kind: "missing" | "extra";
+  reason?: string;
+};
+
+export const SCHEMA_DRIFT_EXCLUSIONS: SchemaDriftExclusion[] = [
+  {
+    operation: "getRecommendations",
+    tool: "list-recommendations",
+    apiKey: "category",
+    kind: "missing",
+    reason: "Superseded by type in MCP; category remains on the API for backwards compatibility",
+  },
+];

--- a/src/tools/bin/audit-schema-drift.ts
+++ b/src/tools/bin/audit-schema-drift.ts
@@ -164,24 +164,30 @@ function normalizeEndpoint(template: string): string {
   return ENDPOINT_ALIASES[normalized] ?? normalized;
 }
 
-function extractEndpoint(source: string): string | undefined {
-  const callIndex = source.indexOf("callVantageApi(");
+function extractCallVantageApiSlice(source: string): string | undefined {
+  const callIndex = source.lastIndexOf("callVantageApi(");
   if (callIndex === -1) {
     return undefined;
   }
-  const slice = source.slice(callIndex);
+  return source.slice(callIndex, callIndex + 1200);
+}
+
+function extractEndpoint(source: string): string | undefined {
+  const slice = extractCallVantageApiSlice(source);
+  if (!slice) {
+    return undefined;
+  }
   const match = slice.match(/callVantageApi\(\s*(?:\n\s*)?[`"]([^`"]+)[`"]/);
   return match?.[1];
 }
 
 function extractHttpMethod(source: string): HttpMethod | undefined {
-  const callIndex = source.lastIndexOf("callVantageApi(");
-  if (callIndex === -1) {
+  const slice = extractCallVantageApiSlice(source);
+  if (!slice) {
     return undefined;
   }
-  const slice = source.slice(callIndex, callIndex + 1200);
   const methods = [...slice.matchAll(/"(GET|POST|PUT|DELETE)"/g)];
-  return methods.at(-1)?.[1] as HttpMethod | undefined;
+  return methods[methods.length - 1]?.[1] as HttpMethod | undefined;
 }
 
 function addArgKeysFromBlock(keys: Set<string>, block: string, indent: "  " | "    "): void {
@@ -475,7 +481,11 @@ function compareTool(tool: ToolRecord, typesContent: string, pathMethodToOp: Map
 }
 
 function hasDrift(row: DriftRow): boolean {
-  return row.unmapped || row.missingInSchema.length > 0 || row.extraInSchema.length > 0;
+  return row.unmapped || hasParameterDrift(row);
+}
+
+function hasParameterDrift(row: DriftRow): boolean {
+  return row.missingInSchema.length > 0 || row.extraInSchema.length > 0;
 }
 
 function printHumanReport(rows: DriftRow[], clientVersion: string): void {
@@ -549,7 +559,7 @@ function main(): void {
     printHumanReport(rows, clientVersion);
   }
 
-  const failing = rows.filter((r) => r.unmapped || r.missingInSchema.length > 0 || r.extraInSchema.length > 0);
+  const failing = rows.filter(hasParameterDrift);
   if (failing.length > 0 && !jsonOutput) {
     process.exit(1);
   }

--- a/src/tools/bin/audit-schema-drift.ts
+++ b/src/tools/bin/audit-schema-drift.ts
@@ -208,12 +208,30 @@ function resolveImportedArgsBlock(toolFilePath: string, source: string, exportNa
   }
 }
 
+function resolveSpreadArgKeys(
+  toolFilePath: string | undefined,
+  source: string,
+  block: string,
+  keys: Set<string>
+): void {
+  if (!toolFilePath) {
+    return;
+  }
+  for (const ref of block.matchAll(/\.\.(\w+)/g)) {
+    const spreadBlock = resolveImportedArgsBlock(toolFilePath, source, ref[1]);
+    if (spreadBlock) {
+      addArgKeysFromBlock(keys, spreadBlock, "  ");
+    }
+  }
+}
+
 function extractToolArgKeys(source: string, toolFilePath?: string): Set<string> {
   const keys = new Set<string>();
 
   const constArgsMatch = source.match(/const args = \{([\s\S]*?)\n\};/);
   if (constArgsMatch) {
     addArgKeysFromBlock(keys, constArgsMatch[1], "  ");
+    resolveSpreadArgKeys(toolFilePath, source, constArgsMatch[1], keys);
   }
 
   const inlineArgsMatch =
@@ -221,6 +239,7 @@ function extractToolArgKeys(source: string, toolFilePath?: string): Set<string> 
     source.match(/args:\s*\{([\s\S]*?)\n\s*\},?\s*\n\s*async execute/);
   if (inlineArgsMatch) {
     addArgKeysFromBlock(keys, inlineArgsMatch[1], "    ");
+    resolveSpreadArgKeys(toolFilePath, source, inlineArgsMatch[1], keys);
   }
 
   const externalArgsRef = source.match(/args:\s*(\w+),/);
@@ -360,7 +379,6 @@ function apiKeysForTool(typesContent: string, method: HttpMethod, operation: str
 
   return keys;
 }
-
 
 function isSchemaDriftExcluded(
   toolName: string,

--- a/src/tools/bin/audit-schema-drift.ts
+++ b/src/tools/bin/audit-schema-drift.ts
@@ -560,7 +560,7 @@ function main(): void {
   }
 
   const failing = rows.filter(hasParameterDrift);
-  if (failing.length > 0 && !jsonOutput) {
+  if (failing.length > 0) {
     process.exit(1);
   }
 }

--- a/src/tools/bin/audit-schema-drift.ts
+++ b/src/tools/bin/audit-schema-drift.ts
@@ -1,0 +1,540 @@
+/**
+ * Compare MCP tool Zod input schemas against @vantage-sh/vantage-client OpenAPI types.
+ *
+ * Usage:
+ *   npm run audit-schema-drift
+ *   npm run audit-schema-drift -- --json
+ *   npm run audit-schema-drift -- --only-drift
+ *
+ * Exit code 1 when any tool has missing/extra parameter drift (not unmapped endpoints).
+ *
+ * Limitations: parses exported `const args` objects from sibling schema files when tools use
+ * `args: someArgs` imports; does not evaluate Zod transforms (e.g. groupings arrays joined to strings).
+ * Intentional omissions: see audit-schema-drift-exclusions.ts.
+ */
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { SCHEMA_DRIFT_EXCLUSIONS, type SchemaDriftExclusion } from "./audit-schema-drift-exclusions.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, "../../..");
+const TOOLS_DIR = join(REPO_ROOT, "src/tools");
+const VC_TYPES_PATH = join(REPO_ROOT, "node_modules/@vantage-sh/vantage-client/dist/index.d.ts");
+
+const SKIP_DIRS = new Set(["structure", "utils", "bin"]);
+type HttpMethod = "GET" | "POST" | "PUT" | "DELETE";
+
+/** Normalized paths whose brace segment names differ from the OpenAPI path template. */
+const ENDPOINT_ALIASES: Record<string, string> = {
+  "/v2/teams/{token}": "/v2/teams/{team_token}",
+};
+
+/** OpenAPI path param name -> tool arg name(s) that supply the segment. */
+const PATH_PARAM_TOOL_ARG_ALIASES: Record<string, string[]> = {
+  team_token: ["token"],
+};
+
+/** Query keys tools add in execute() but often omit from Zod (informational, not counted as drift). */
+const COMMONLY_INJECTED_QUERY_KEYS = new Set(["limit", "page"]);
+
+/** Tool arg -> API query key (intentional renames — do not report as drift). */
+const TOOL_ARG_ALIASES: Record<string, string[]> = {
+  settings_include_credits: ["settings[include_credits]"],
+  settings_include_refunds: ["settings[include_refunds]"],
+  settings_include_discounts: ["settings[include_discounts]"],
+  settings_include_tax: ["settings[include_tax]"],
+  settings_amortize: ["settings[amortize]"],
+  settings_unallocated: ["settings[unallocated]"],
+  settings_aggregate_by: ["settings[aggregate_by]"],
+  settings_show_previous_period: ["settings[show_previous_period]"],
+};
+
+type OpParams = {
+  query: string[];
+  pathParams: string[];
+  bodySchema: string | null;
+};
+
+type ToolRecord = {
+  file: string;
+  name: string;
+  endpoint: string;
+  method: HttpMethod;
+  argKeys: Set<string>;
+  injectedKeys: Set<string>;
+  source: string;
+};
+
+type DriftRow = {
+  tool: string;
+  file: string;
+  endpoint: string;
+  method: HttpMethod;
+  operation: string | null;
+  missingInSchema: string[];
+  extraInSchema: string[];
+  injectedNotInSchema: string[];
+  unmapped: boolean;
+};
+
+function readVantageClientTypes(): string {
+  try {
+    return readFileSync(VC_TYPES_PATH, "utf8");
+  } catch {
+    console.error(`Could not read ${VC_TYPES_PATH}. Run npm install first.`);
+    process.exit(2);
+  }
+}
+
+function buildPathMethodToOperation(typesContent: string): Map<string, string> {
+  const map = new Map<string, string>();
+  const pathBlockRe = /"(\/[^"]+)":\s*\{([\s\S]*?)\n {4}\};/g;
+  let match = pathBlockRe.exec(typesContent);
+  while (match !== null) {
+    const swaggerPath = match[1];
+    const block = match[2];
+    const v2Path = `/v2${swaggerPath}`;
+    for (const method of ["get", "post", "put", "delete"] as const) {
+      const opMatch = block.match(new RegExp(`\\s+${method}:\\s+operations\\["([^"]+)"\\]`));
+      if (opMatch) {
+        map.set(`${v2Path}:${method.toUpperCase()}`, opMatch[1]);
+      }
+    }
+    match = pathBlockRe.exec(typesContent);
+  }
+  return map;
+}
+
+function parseOperationParams(typesContent: string, opName: string): OpParams | null {
+  const opRe = new RegExp(`\\n    ${opName}: \\{([\\s\\S]*?)^    \\};`, "m");
+  const opMatch = typesContent.match(opRe);
+  if (!opMatch) {
+    return null;
+  }
+  const block = opMatch[1];
+
+  const query: string[] = [];
+  const queryBlock = block.match(/query\?:\s*\{([\s\S]*?)\n {12}\};/);
+  if (queryBlock) {
+    for (const key of queryBlock[1].matchAll(/^\s{16}([a-z_][a-z0-9_]*)\??:/gm)) {
+      query.push(key[1]);
+    }
+    for (const key of queryBlock[1].matchAll(/"([^"]+)"\?:/g)) {
+      if (!query.includes(key[1])) {
+        query.push(key[1]);
+      }
+    }
+  }
+
+  const pathParams: string[] = [];
+  const pathBlock = block.match(/path:\s*\{([\s\S]*?)\n {12}\};/);
+  if (pathBlock) {
+    for (const key of pathBlock[1].matchAll(/^\s{16}([a-z_]+):/gm)) {
+      pathParams.push(key[1]);
+    }
+  }
+
+  let bodySchema: string | null = null;
+  const requestSection = block.match(/requestBody:[\s\S]*?(?=responses:|$)/)?.[0];
+  if (requestSection) {
+    const bodyMatch = requestSection.match(/components\["schemas"\]\["([^"]+)"\]/);
+    if (bodyMatch) {
+      bodySchema = bodyMatch[1];
+    }
+  }
+
+  return { query, pathParams, bodySchema };
+}
+
+function parseSchemaProperties(typesContent: string, schemaName: string): string[] {
+  const schemaRe = new RegExp(`\\n        ${schemaName}: \\{([\\s\\S]*?)^        \\};`, "m");
+  const match = typesContent.match(schemaRe);
+  if (!match) {
+    return [];
+  }
+  return [...match[1].matchAll(/\n {12}([a-z_][a-z0-9_]*)(\?)?:/g)].map((m) => m[1]);
+}
+
+function normalizeEndpoint(template: string): string {
+  const normalized = template
+    .replace(/\$\{pathEncode\(args\.([a-z_]+)\)\}/g, "{$1}")
+    .replace(/\$\{pathEncode\(([a-z_]+)\)\}/g, "{$1}");
+  return ENDPOINT_ALIASES[normalized] ?? normalized;
+}
+
+function extractEndpoint(source: string): string | undefined {
+  const callIndex = source.indexOf("callVantageApi(");
+  if (callIndex === -1) {
+    return undefined;
+  }
+  const slice = source.slice(callIndex);
+  const match = slice.match(/callVantageApi\(\s*(?:\n\s*)?[`"]([^`"]+)[`"]/);
+  return match?.[1];
+}
+
+function extractHttpMethod(source: string): HttpMethod | undefined {
+  const callIndex = source.lastIndexOf("callVantageApi(");
+  if (callIndex === -1) {
+    return undefined;
+  }
+  const slice = source.slice(callIndex, callIndex + 1200);
+  const methods = [...slice.matchAll(/"(GET|POST|PUT|DELETE)"/g)];
+  return methods.at(-1)?.[1] as HttpMethod | undefined;
+}
+
+function addArgKeysFromBlock(keys: Set<string>, block: string, indent: "  " | "    "): void {
+  const pattern = indent === "  " ? /\n {2}([a-z][a-z0-9_]*):/g : /\n {4}([a-z][a-z0-9_]*):/g;
+  for (const key of block.matchAll(pattern)) {
+    keys.add(key[1]);
+  }
+}
+
+function resolveImportedArgsBlock(toolFilePath: string, source: string, exportName: string): string | null {
+  const importMatch = source.match(
+    new RegExp(`import\\s*\\{[^}]*\\b${exportName}\\b[^}]*\\}\\s*from\\s*["']([^"']+)["']`)
+  );
+  if (!importMatch) {
+    return null;
+  }
+  const resolved = join(dirname(toolFilePath), `${importMatch[1].replace(/\.js$/, "")}.ts`);
+  try {
+    const imported = readFileSync(resolved, "utf8");
+    const exportMatch = imported.match(new RegExp(`export const ${exportName} = \\{([\\s\\S]*?)\\n\\};`));
+    return exportMatch?.[1] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function extractToolArgKeys(source: string, toolFilePath?: string): Set<string> {
+  const keys = new Set<string>();
+
+  const constArgsMatch = source.match(/const args = \{([\s\S]*?)\n\};/);
+  if (constArgsMatch) {
+    addArgKeysFromBlock(keys, constArgsMatch[1], "  ");
+  }
+
+  const inlineArgsMatch =
+    source.match(/args:\s*\{([\s\S]*?)\n\s*\},?\s*\n\s*(?:annotations:|async execute)/) ??
+    source.match(/args:\s*\{([\s\S]*?)\n\s*\},?\s*\n\s*async execute/);
+  if (inlineArgsMatch) {
+    addArgKeysFromBlock(keys, inlineArgsMatch[1], "    ");
+  }
+
+  const externalArgsRef = source.match(/args:\s*(\w+),/);
+  if (externalArgsRef && toolFilePath && !source.includes(`const ${externalArgsRef[1]} =`)) {
+    const block = resolveImportedArgsBlock(toolFilePath, source, externalArgsRef[1]);
+    if (block) {
+      addArgKeysFromBlock(keys, block, "  ");
+    }
+  }
+
+  return keys;
+}
+
+function extractInjectedRequestKeys(source: string): Set<string> {
+  const injected = new Set<string>();
+  if (/\blimit:\s*(?:DEFAULT_LIMIT|\d+)/.test(source)) {
+    injected.add("limit");
+  }
+  if (/\bpage:\s*/.test(source) && /requestParams|callVantageApi/.test(source)) {
+    injected.add("page");
+  }
+  for (const key of source.matchAll(/requestParams\[["']([^"']+)["']\]/g)) {
+    injected.add(key[1]);
+  }
+  for (const key of source.matchAll(/requestParams\[`([^`]+)`\]/g)) {
+    injected.add(key[1]);
+  }
+  return injected;
+}
+
+function walkToolFiles(dir: string, acc: string[] = []): string[] {
+  for (const ent of readdirSync(dir)) {
+    const full = join(dir, ent);
+    if (statSync(full).isDirectory()) {
+      if (!SKIP_DIRS.has(ent)) {
+        walkToolFiles(full, acc);
+      }
+      continue;
+    }
+    if (ent.endsWith(".ts") && !ent.endsWith(".test.ts") && ent !== "index.ts") {
+      acc.push(full);
+    }
+  }
+  return acc;
+}
+
+function discoverTools(): ToolRecord[] {
+  const tools: ToolRecord[] = [];
+
+  for (const filePath of walkToolFiles(TOOLS_DIR)) {
+    const source = readFileSync(filePath, "utf8");
+    if (!source.includes("registerTool")) {
+      continue;
+    }
+
+    const nameMatch = source.match(/name:\s*"([^"]+)"/);
+    const endpointRaw = extractEndpoint(source);
+    const method = extractHttpMethod(source);
+
+    if (!nameMatch || !endpointRaw || !method) {
+      continue;
+    }
+
+    tools.push({
+      file: relative(REPO_ROOT, filePath),
+      name: nameMatch[1],
+      endpoint: normalizeEndpoint(endpointRaw),
+      method,
+      argKeys: extractToolArgKeys(source, filePath),
+      injectedKeys: extractInjectedRequestKeys(source),
+      source,
+    });
+  }
+
+  return tools.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function expandToolKeys(tool: ToolRecord): Set<string> {
+  const expanded = new Set(tool.argKeys);
+  for (const key of tool.argKeys) {
+    for (const alias of TOOL_ARG_ALIASES[key] ?? []) {
+      expanded.add(alias);
+    }
+  }
+  const pathParam = tool.endpoint.match(/\{([^}]+)\}/)?.[1];
+  if (pathParam) {
+    for (const key of tool.argKeys) {
+      if (key === pathParam || key === pathParam.replace(/_token$/, "") || `${key}_token` === pathParam) {
+        expanded.add(pathParam);
+      }
+    }
+    for (const alias of PATH_PARAM_TOOL_ARG_ALIASES[pathParam] ?? []) {
+      if (tool.argKeys.has(alias)) {
+        expanded.add(pathParam);
+      }
+    }
+  }
+  return expanded;
+}
+
+function toolArgRepresentedInApi(apiKeys: Set<string>, toolKey: string): boolean {
+  if (apiKeys.has(toolKey)) {
+    return true;
+  }
+  for (const alias of TOOL_ARG_ALIASES[toolKey] ?? []) {
+    if (apiKeys.has(alias)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function apiKeysForTool(typesContent: string, method: HttpMethod, operation: string | null): Set<string> {
+  if (!operation) {
+    return new Set();
+  }
+  const op = parseOperationParams(typesContent, operation);
+  if (!op) {
+    return new Set();
+  }
+
+  const keys = new Set<string>();
+  for (const k of op.query) {
+    keys.add(k);
+  }
+  for (const k of op.pathParams) {
+    keys.add(k);
+  }
+
+  if (method === "POST" || method === "PUT") {
+    if (op.bodySchema) {
+      for (const k of parseSchemaProperties(typesContent, op.bodySchema)) {
+        keys.add(k);
+      }
+    }
+  }
+
+  return keys;
+}
+
+
+function isSchemaDriftExcluded(
+  toolName: string,
+  operation: string | null,
+  apiKey: string,
+  kind: SchemaDriftExclusion["kind"]
+): boolean {
+  return SCHEMA_DRIFT_EXCLUSIONS.some((exclusion) => {
+    if (exclusion.kind !== kind) {
+      return false;
+    }
+    if (exclusion.apiKey !== apiKey) {
+      return false;
+    }
+    if (exclusion.tool !== undefined && exclusion.tool !== toolName) {
+      return false;
+    }
+    if (exclusion.operation !== undefined && exclusion.operation !== operation) {
+      return false;
+    }
+    return true;
+  });
+}
+
+function compareTool(tool: ToolRecord, typesContent: string, pathMethodToOp: Map<string, string>): DriftRow {
+  const lookupKey = `${tool.endpoint}:${tool.method}`;
+  const operation = pathMethodToOp.get(lookupKey) ?? null;
+  const apiKeys = apiKeysForTool(typesContent, tool.method, operation);
+  const toolExpanded = expandToolKeys(tool);
+
+  const missingInSchema: string[] = [];
+  const injectedNotInSchema: string[] = [];
+  const extraInSchema: string[] = [];
+
+  if (!operation) {
+    return {
+      tool: tool.name,
+      file: tool.file,
+      endpoint: tool.endpoint,
+      method: tool.method,
+      operation: null,
+      missingInSchema: [],
+      extraInSchema: [],
+      injectedNotInSchema: [],
+      unmapped: true,
+    };
+  }
+
+  for (const apiKey of apiKeys) {
+    if (toolExpanded.has(apiKey)) {
+      continue;
+    }
+    if (tool.injectedKeys.has(apiKey) || COMMONLY_INJECTED_QUERY_KEYS.has(apiKey)) {
+      if (!tool.argKeys.has(apiKey)) {
+        injectedNotInSchema.push(apiKey);
+      }
+      continue;
+    }
+    if (isSchemaDriftExcluded(tool.name, operation, apiKey, "missing")) {
+      continue;
+    }
+    missingInSchema.push(apiKey);
+  }
+
+  const pathParam = tool.endpoint.match(/\{([^}]+)\}/)?.[1];
+  for (const toolKey of tool.argKeys) {
+    if (toolKey.startsWith("settings[")) {
+      continue;
+    }
+    if (apiKeys.size === 0) {
+      continue;
+    }
+    if (pathParam && (PATH_PARAM_TOOL_ARG_ALIASES[pathParam] ?? []).includes(toolKey) && apiKeys.has(pathParam)) {
+      continue;
+    }
+    if (!toolArgRepresentedInApi(apiKeys, toolKey)) {
+      if (!isSchemaDriftExcluded(tool.name, operation, toolKey, "extra")) {
+        extraInSchema.push(toolKey);
+      }
+    }
+  }
+
+  return {
+    tool: tool.name,
+    file: tool.file,
+    endpoint: tool.endpoint,
+    method: tool.method,
+    operation,
+    missingInSchema: missingInSchema.sort(),
+    extraInSchema: extraInSchema.sort(),
+    injectedNotInSchema: injectedNotInSchema.sort(),
+    unmapped: false,
+  };
+}
+
+function hasDrift(row: DriftRow): boolean {
+  return row.unmapped || row.missingInSchema.length > 0 || row.extraInSchema.length > 0;
+}
+
+function printHumanReport(rows: DriftRow[], clientVersion: string): void {
+  console.log(`Schema drift audit (@vantage-sh/vantage-client from ${VC_TYPES_PATH})`);
+  console.log(`Tools scanned: ${rows.length}\n`);
+
+  const driftRows = rows.filter(hasDrift);
+  const unmapped = driftRows.filter((r) => r.unmapped);
+  const paramDrift = driftRows.filter((r) => !r.unmapped);
+
+  if (unmapped.length > 0) {
+    console.log("=== Unmapped endpoints ===\n");
+    for (const row of unmapped) {
+      console.log(`  ${row.tool}`);
+      console.log(`    ${row.method} ${row.endpoint}`);
+      console.log(`    ${row.file}\n`);
+    }
+  }
+
+  if (paramDrift.length > 0) {
+    console.log("=== Parameter drift ===\n");
+    for (const row of paramDrift) {
+      console.log(`${row.tool} (${row.operation})`);
+      console.log(`  ${row.method} ${row.endpoint}`);
+      console.log(`  ${row.file}`);
+      if (row.missingInSchema.length > 0) {
+        console.log(`  Missing from tool schema (in API): ${row.missingInSchema.join(", ")}`);
+      }
+      if (row.extraInSchema.length > 0) {
+        console.log(`  Extra in tool schema (not in API): ${row.extraInSchema.join(", ")}`);
+      }
+      if (row.injectedNotInSchema.length > 0) {
+        console.log(`  Injected in execute only (OK): ${row.injectedNotInSchema.join(", ")}`);
+      }
+      console.log();
+    }
+  }
+
+  const clean = rows.length - driftRows.length;
+  console.log(
+    `Summary: ${paramDrift.length} tool(s) with parameter drift, ${unmapped.length} unmapped, ${clean} aligned (or injection-only).`
+  );
+  console.log(`Client package version in package.json: ${clientVersion}`);
+}
+
+function readClientVersion(): string {
+  const pkg = JSON.parse(readFileSync(join(REPO_ROOT, "package.json"), "utf8")) as {
+    dependencies?: Record<string, string>;
+  };
+  return pkg.dependencies?.["@vantage-sh/vantage-client"] ?? "unknown";
+}
+
+function main(): void {
+  const jsonOutput = process.argv.includes("--json");
+  const onlyDrift = process.argv.includes("--only-drift");
+
+  const typesContent = readVantageClientTypes();
+  const pathMethodToOp = buildPathMethodToOperation(typesContent);
+  const tools = discoverTools();
+  let rows = tools.map((tool) => compareTool(tool, typesContent, pathMethodToOp));
+
+  if (onlyDrift) {
+    rows = rows.filter(hasDrift);
+  }
+
+  const clientVersion = readClientVersion();
+
+  if (jsonOutput) {
+    console.log(JSON.stringify({ clientVersion, tools: rows }, null, 2));
+  } else {
+    printHumanReport(rows, clientVersion);
+  }
+
+  const failing = rows.filter((r) => r.unmapped || r.missingInSchema.length > 0 || r.extraInSchema.length > 0);
+  if (failing.length > 0 && !jsonOutput) {
+    process.exit(1);
+  }
+}
+
+main();

--- a/src/tools/cost-reports/update-cost-report.test.ts
+++ b/src/tools/cost-reports/update-cost-report.test.ts
@@ -23,6 +23,7 @@ const undefineds = {
   saved_filter_tokens: undefined,
   business_metric_tokens_with_metadata: undefined,
   folder_token: undefined,
+  default_forecast: undefined,
   settings: undefined,
   previous_period_start_date: undefined,
   previous_period_end_date: undefined,
@@ -54,6 +55,7 @@ const validInputArguments: InferValidators<Validators> = {
     },
   ],
   folder_token: "folder_123",
+  default_forecast: { kind: "baseline" as const },
   settings: {
     include_credits: true,
     include_refunds: false,
@@ -99,6 +101,14 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
       ...undefineds,
       cost_report_token: "rprt_123",
       date_interval: "last_30_days",
+    },
+  },
+  {
+    name: "report forecast requires token",
+    data: {
+      ...undefineds,
+      cost_report_token: "rprt_123",
+      default_forecast: { kind: "report_forecast" },
     },
   },
   poisonOneValue(validInputArguments, "start_date", dateValidatorPoisoner),
@@ -167,6 +177,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
             },
           ],
           folder_token: "folder_123",
+          default_forecast: { kind: "baseline" },
           settings: {
             include_credits: true,
             include_refunds: false,
@@ -198,6 +209,20 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
     handler: async ({ callExpectingSuccess }) => {
       const res = await callExpectingSuccess(validInputArguments);
       expect(res).toEqual(successData);
+    },
+  },
+  {
+    name: "report forecast requires token",
+    apiCallHandler: requestsInOrder([]),
+    handler: async ({ callExpectingMCPUserError }) => {
+      const err = await callExpectingMCPUserError({
+        ...undefineds,
+        cost_report_token: "rprt_123",
+        default_forecast: { kind: "report_forecast" },
+      });
+      expect(err.exception).toEqual({
+        errors: [{ message: "report_forecast_token is required when default_forecast kind is report_forecast" }],
+      });
     },
   },
   {

--- a/src/tools/cost-reports/update-cost-report.ts
+++ b/src/tools/cost-reports/update-cost-report.ts
@@ -53,6 +53,13 @@ export default registerTool({
       .string()
       .optional()
       .describe("Updated Folder token. Determines the Workspace the report is assigned to."),
+    default_forecast: z
+      .object({
+        kind: z.enum(["baseline", "report_forecast"]),
+        report_forecast_token: z.string().optional(),
+      })
+      .optional()
+      .describe("Updated default forecast selection."),
     settings: costReportSettingsForUpdate.optional().describe("Updated report settings."),
     previous_period_start_date: dateValidator(
       "Updated previous period start date. ISO 8601 formatted (YYYY-MM-DD)."
@@ -75,6 +82,11 @@ export default registerTool({
     date_bin: z.enum(dateBins).optional().describe("Updated date bin for how costs are bucketed over time."),
   },
   async execute(args, ctx) {
+    if (args.default_forecast?.kind === "report_forecast" && !args.default_forecast.report_forecast_token) {
+      throw new MCPUserError({
+        errors: [{ message: "report_forecast_token is required when default_forecast kind is report_forecast" }],
+      });
+    }
     if (!!args.previous_period_start_date !== !!args.previous_period_end_date) {
       throw new MCPUserError({
         errors: [{ message: "previous_period_start_date and previous_period_end_date must both be provided together" }],

--- a/src/tools/create-folder.test.ts
+++ b/src/tools/create-folder.test.ts
@@ -22,6 +22,7 @@ const undefineds = {
 const minimalValidInputArguments: InferValidators<Validators> = {
   ...undefineds,
   title: "My Folder",
+  type: "CostFolder",
 };
 
 const validInputArguments: InferValidators<Validators> = {
@@ -29,6 +30,7 @@ const validInputArguments: InferValidators<Validators> = {
   parent_folder_token: "fldr_123",
   saved_filter_tokens: ["svd_fltr_abc", "svd_fltr_def"],
   workspace_token: "wrkspc_123",
+  type: "CostFolder",
 };
 
 const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
@@ -45,6 +47,7 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
     data: {
       ...undefineds,
       title: "",
+      type: "CostFolder",
     },
     expectedIssues: ["Too small: expected string to have >=1 characters"],
   },

--- a/src/tools/create-folder.ts
+++ b/src/tools/create-folder.ts
@@ -29,6 +29,11 @@ export default registerTool({
       .describe(
         "The token of the Workspace to add the Folder to. Ignored if 'parent_folder_token' is set. Required if the API token is associated with multiple Workspaces."
       ),
+    type: z
+      .enum(["CostFolder", "ProviderResourceFolder"])
+      .optional()
+      .default("CostFolder")
+      .describe("Folder type. CostFolder for cost reports; ProviderResourceFolder for resource reports."),
   },
   async execute(args, ctx) {
     const res = await ctx.callVantageApi("/v2/folders", args, "POST");

--- a/src/tools/dashboards/update-dashboard.test.ts
+++ b/src/tools/dashboards/update-dashboard.test.ts
@@ -24,6 +24,7 @@ const undefineds = {
   start_date: undefined,
   end_date: undefined,
   date_interval: undefined,
+  workspace_token: undefined,
 };
 
 const minimalValidInputArguments: InferValidators<Validators> = {

--- a/src/tools/dashboards/update-dashboard.ts
+++ b/src/tools/dashboards/update-dashboard.ts
@@ -29,6 +29,7 @@ export default registerTool({
     start_date: startDateSchema,
     end_date: endDateSchema,
     date_interval: updateDateIntervalSchema,
+    workspace_token: z.string().min(1).optional().describe("Move the dashboard to a different workspace."),
   },
   async execute(args, ctx) {
     const { dashboard_token, ...body } = args;

--- a/src/tools/get-cost-provider-accounts.test.ts
+++ b/src/tools/get-cost-provider-accounts.test.ts
@@ -14,13 +14,18 @@ import {
 type Validators = ExtractValidators<typeof tool>;
 type OutputSchema = ExtractOutputSchema<typeof tool>;
 
+const undefineds = {
+  account_id: undefined,
+  provider: undefined,
+  account_name: undefined,
+};
+
 const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
   {
     name: "just workspace_token",
     data: {
       workspace_token: "wt_123",
-      account_id: undefined,
-      provider: undefined,
+      ...undefineds,
       page: undefined,
       limit: undefined,
     },
@@ -31,6 +36,7 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
       workspace_token: "wt_123",
       account_id: "acct_123",
       provider: undefined,
+      account_name: undefined,
       page: undefined,
       limit: undefined,
     },
@@ -41,6 +47,7 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
       workspace_token: "wt_123",
       account_id: undefined,
       provider: "aws",
+      account_name: undefined,
       page: undefined,
       limit: undefined,
     },
@@ -51,6 +58,7 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
       workspace_token: "wt_123",
       account_id: "acct_123",
       provider: "aws",
+      account_name: undefined,
       page: 2,
       limit: 50,
     },
@@ -96,6 +104,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
           workspace_token: "wt_123",
           account_id: undefined,
           provider: undefined,
+          account_name: undefined,
           ...defaultPaginationParams,
         },
         method: "GET",
@@ -110,6 +119,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
         workspace_token: "wt_123",
         account_id: undefined,
         provider: undefined,
+        account_name: undefined,
         page: undefined,
         limit: undefined,
       });
@@ -131,6 +141,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
           workspace_token: "wt_123",
           account_id: "acct_123",
           provider: undefined,
+          account_name: undefined,
           ...defaultPaginationParams,
         },
         method: "GET",
@@ -145,6 +156,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
         workspace_token: "wt_123",
         account_id: "acct_123",
         provider: undefined,
+        account_name: undefined,
         page: undefined,
         limit: undefined,
       });
@@ -166,6 +178,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
           workspace_token: "wt_123",
           account_id: undefined,
           provider: "aws",
+          account_name: undefined,
           ...defaultPaginationParams,
         },
         method: "GET",
@@ -180,6 +193,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
         workspace_token: "wt_123",
         account_id: undefined,
         provider: "aws",
+        account_name: undefined,
         page: undefined,
         limit: undefined,
       });
@@ -201,6 +215,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
           workspace_token: "wt_123",
           account_id: undefined,
           provider: undefined,
+          account_name: undefined,
           ...({ page: 2, limit: 50 } as Record<string, unknown>),
         },
         method: "GET",
@@ -215,6 +230,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
         workspace_token: "wt_123",
         account_id: undefined,
         provider: undefined,
+        account_name: undefined,
         page: 2,
         limit: 50,
       });
@@ -236,6 +252,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
           workspace_token: "wt_123",
           account_id: undefined,
           provider: undefined,
+          account_name: undefined,
           ...defaultPaginationParams,
         },
         method: "GET",
@@ -250,6 +267,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
         workspace_token: "wt_123",
         account_id: undefined,
         provider: undefined,
+        account_name: undefined,
         page: undefined,
         limit: undefined,
       });

--- a/src/tools/get-cost-provider-accounts.ts
+++ b/src/tools/get-cost-provider-accounts.ts
@@ -1,5 +1,6 @@
 import z from "zod";
 import { DEFAULT_LIMIT } from "./structure/constants";
+import { costProviderSchema } from "./utils/costProviderSchema";
 import MCPUserError from "./structure/MCPUserError";
 import registerTool from "./structure/registerTool";
 import paginationData from "./utils/paginationData";
@@ -18,9 +19,10 @@ export default registerTool({
   args: {
     workspace_token: z.string().describe("Workspace token to list cost provider accounts for"),
     account_id: z.string().optional().describe("Filter by a specific account ID"),
-    provider: z.string().optional().describe("Provider to filter provider accounts to"),
+    provider: costProviderSchema.optional().describe("Filter by provider type."),
     page: z.number().optional().default(1).describe("The page number to return, defaults to 1"),
     limit: z.number().optional().default(DEFAULT_LIMIT).describe("The number of results to return per page"),
+    account_name: z.string().optional().describe("Filter by account display name (exact match)."),
   },
   annotations: {
     destructive: false,
@@ -28,15 +30,7 @@ export default registerTool({
     readOnly: true,
   },
   async execute(args, ctx) {
-    const response = await ctx.callVantageApi(
-      "/v2/cost_provider_accounts",
-      {
-        ...args,
-        // @ts-expect-error: This is a workaround so we don't have to keep patching the type here
-        provider: args.provider,
-      },
-      "GET"
-    );
+    const response = await ctx.callVantageApi("/v2/cost_provider_accounts", args, "GET");
     if (!response.ok) {
       throw new MCPUserError({ errors: response.errors });
     }

--- a/src/tools/get-cost-provider-accounts.ts
+++ b/src/tools/get-cost-provider-accounts.ts
@@ -1,8 +1,8 @@
 import z from "zod";
 import { DEFAULT_LIMIT } from "./structure/constants";
-import { costProviderSchema } from "./utils/costProviderSchema";
 import MCPUserError from "./structure/MCPUserError";
 import registerTool from "./structure/registerTool";
+import { costProviderSchema } from "./utils/costProviderSchema";
 import paginationData from "./utils/paginationData";
 
 const description = `

--- a/src/tools/list-cost-integrations.test.ts
+++ b/src/tools/list-cost-integrations.test.ts
@@ -17,6 +17,8 @@ type OutputSchema = ExtractOutputSchema<typeof tool>;
 
 const validArguments: InferValidators<Validators> = {
   page: 1,
+  provider: undefined,
+  account_identifier: undefined,
 };
 
 const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
@@ -24,6 +26,8 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
     name: "default page",
     data: {
       page: undefined,
+      provider: undefined,
+      account_identifier: undefined,
     },
   },
   {

--- a/src/tools/list-cost-integrations.ts
+++ b/src/tools/list-cost-integrations.ts
@@ -22,9 +22,7 @@ const args = {
   account_identifier: z
     .string()
     .optional()
-    .describe(
-      "Filter by account identifier (e.g. AWS account ID, Azure subscription ID). Must be used with provider."
-    ),
+    .describe("Filter by account identifier (e.g. AWS account ID, Azure subscription ID). Must be used with provider."),
 };
 
 export default registerTool({

--- a/src/tools/list-cost-integrations.ts
+++ b/src/tools/list-cost-integrations.ts
@@ -2,6 +2,7 @@ import z from "zod";
 import { DEFAULT_LIMIT } from "./structure/constants";
 import MCPUserError from "./structure/MCPUserError";
 import registerTool from "./structure/registerTool";
+import { costProviderSchema } from "./utils/costProviderSchema";
 import paginationData from "./utils/paginationData";
 
 const description = `
@@ -15,6 +16,15 @@ Note that when 'provider' is 'custom_provider', that has a special case. When do
 
 const args = {
   page: z.number().optional().default(1).describe("The page number to return, defaults to 1"),
+  provider: costProviderSchema
+    .optional()
+    .describe("Filter integrations by provider. Required when using account_identifier."),
+  account_identifier: z
+    .string()
+    .optional()
+    .describe(
+      "Filter by account identifier (e.g. AWS account ID, Azure subscription ID). Must be used with provider."
+    ),
 };
 
 export default registerTool({
@@ -28,6 +38,11 @@ export default registerTool({
   },
   args,
   async execute(args, ctx) {
+    if (args.account_identifier && !args.provider) {
+      throw new MCPUserError({
+        errors: [{ message: "provider is required when account_identifier is provided" }],
+      });
+    }
     const requestParams = { ...args, limit: DEFAULT_LIMIT };
     const response = await ctx.callVantageApi("/v2/integrations", requestParams, "GET");
     if (!response.ok) {

--- a/src/tools/list-costs.test.ts
+++ b/src/tools/list-costs.test.ts
@@ -33,6 +33,9 @@ const baseApiParams = {
 const validArguments: InferValidators<Validators> = {
   page: 1,
   cost_report_token: "crt_123",
+  filter: undefined,
+  workspace_token: undefined,
+  order: undefined,
   start_date: "2023-01-01",
   end_date: "2023-01-31",
   date_bin: "month",

--- a/src/tools/list-costs.ts
+++ b/src/tools/list-costs.ts
@@ -21,7 +21,7 @@ Only provide these parameters if you need to override the report's defaults.
 
 const args = {
   page: z.number().optional().default(1).describe("The page number to return, defaults to 1"),
-  cost_report_token: z.string().describe("The workspace token to scope the query to"),
+  cost_report_token: z.string().describe("The Cost Report token to list costs for"),
   start_date: dateValidator("Start date to filter costs by, format=YYYY-MM-DD").optional(),
   end_date: dateValidator("End date to filter costs by, format=YYYY-MM-DD").optional(),
   date_bin: z
@@ -70,6 +70,17 @@ const args = {
     .describe(
       "Group the results by specific field(s). Defaults to provider, service, account_id. Valid groupings: account_id, billing_account_id, charge_type, cost_category, cost_subcategory, provider, region, resource_id, service, tagged, tag:<tag_value>. Let Groupings default unless explicitly asked for."
     ),
+  order: z.enum(["asc", "desc"]).optional().describe("Sort costs by date ascending or descending."),
+  workspace_token: z
+    .string()
+    .optional()
+    .describe(
+      "Workspace token. Ignored when cost_report_token is set; required for multi-workspace tokens otherwise."
+    ),
+  filter: z
+    .string()
+    .optional()
+    .describe("VQL filter. Use query-costs instead when querying without a cost_report_token."),
 };
 
 export default registerTool({

--- a/src/tools/list-costs.ts
+++ b/src/tools/list-costs.ts
@@ -74,9 +74,7 @@ const args = {
   workspace_token: z
     .string()
     .optional()
-    .describe(
-      "Workspace token. Ignored when cost_report_token is set; required for multi-workspace tokens otherwise."
-    ),
+    .describe("Workspace token. Ignored when cost_report_token is set; required for multi-workspace tokens otherwise."),
   filter: z
     .string()
     .optional()

--- a/src/tools/list-folders.test.ts
+++ b/src/tools/list-folders.test.ts
@@ -16,6 +16,7 @@ type OutputSchema = ExtractOutputSchema<typeof tool>;
 
 const validArguments: InferValidators<Validators> = {
   page: 1,
+  type: undefined,
 };
 
 const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
@@ -23,6 +24,7 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
     name: "default page",
     data: {
       page: undefined,
+      type: undefined,
     },
   },
   {

--- a/src/tools/list-folders.ts
+++ b/src/tools/list-folders.ts
@@ -14,6 +14,10 @@ The 'token' of a Folder can be used to generate a link in the Vantage Web UI: ht
 
 const args = {
   page: z.number().optional().default(1).describe("The page number to return, defaults to 1"),
+  type: z
+    .enum(["CostFolder", "ProviderResourceFolder"])
+    .optional()
+    .describe("Filter folders by type."),
 };
 
 export default registerTool({

--- a/src/tools/list-folders.ts
+++ b/src/tools/list-folders.ts
@@ -14,10 +14,7 @@ The 'token' of a Folder can be used to generate a link in the Vantage Web UI: ht
 
 const args = {
   page: z.number().optional().default(1).describe("The page number to return, defaults to 1"),
-  type: z
-    .enum(["CostFolder", "ProviderResourceFolder"])
-    .optional()
-    .describe("Filter folders by type."),
+  type: z.enum(["CostFolder", "ProviderResourceFolder"]).optional().describe("Filter folders by type."),
 };
 
 export default registerTool({

--- a/src/tools/list-tag-values.test.ts
+++ b/src/tools/list-tag-values.test.ts
@@ -15,11 +15,16 @@ import {
 type Validators = ExtractValidators<typeof tool>;
 type OutputSchema = ExtractOutputSchema<typeof tool>;
 
+const tagListUndefineds = {
+  providers: undefined,
+  search_query: undefined,
+  sort_direction: undefined,
+};
+
 const validArguments: InferValidators<Validators> = {
   key: "environment",
   page: 1,
-  search_query: undefined,
-  providers: undefined,
+  ...tagListUndefineds,
 };
 
 const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
@@ -28,8 +33,7 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
     data: {
       key: "",
       page: 1,
-      search_query: undefined,
-      providers: undefined,
+      ...tagListUndefineds,
     },
     expectedIssues: ["Too small: expected string to have >=1 characters"],
   },

--- a/src/tools/list-tag-values.ts
+++ b/src/tools/list-tag-values.ts
@@ -1,5 +1,6 @@
 import { type GetTagValuesRequest, pathEncode } from "@vantage-sh/vantage-client";
 import z from "zod";
+import { tagListQueryFields } from "./utils/tagListQuerySchema";
 import { DEFAULT_LIMIT } from "./structure/constants";
 import MCPUserError from "./structure/MCPUserError";
 import registerTool from "./structure/registerTool";
@@ -14,11 +15,7 @@ Requires integration settings permission; callers without it receive 403 from th
 const args = {
   page: z.number().optional().default(1).describe("The page number to return, defaults to 1"),
   key: z.string().min(1).describe("Tag key name to list values for (matches API path parameter `key`)"),
-  search_query: z.string().optional().describe("Search query to filter tag values by value name"),
-  providers: z
-    .array(z.string())
-    .optional()
-    .describe("Filter values to those present on the given cost providers (e.g. aws, azure, gcp)"),
+  ...tagListQueryFields,
 };
 
 export default registerTool({

--- a/src/tools/list-tag-values.ts
+++ b/src/tools/list-tag-values.ts
@@ -1,10 +1,10 @@
 import { type GetTagValuesRequest, pathEncode } from "@vantage-sh/vantage-client";
 import z from "zod";
-import { tagListQueryFields } from "./utils/tagListQuerySchema";
 import { DEFAULT_LIMIT } from "./structure/constants";
 import MCPUserError from "./structure/MCPUserError";
 import registerTool from "./structure/registerTool";
 import paginationData from "./utils/paginationData";
+import { tagListQueryFields } from "./utils/tagListQuerySchema";
 
 const description = `
 List values for a tag key. The argument is \`key\` (the tag key name); the API response fields use \`tag_value\`.

--- a/src/tools/list-tags.test.ts
+++ b/src/tools/list-tags.test.ts
@@ -15,10 +15,15 @@ import {
 type Validators = ExtractValidators<typeof tool>;
 type OutputSchema = ExtractOutputSchema<typeof tool>;
 
+const tagListUndefineds = {
+  providers: undefined,
+  search_query: undefined,
+  sort_direction: undefined,
+};
+
 const validArguments: InferValidators<Validators> = {
   page: 1,
-  search_query: undefined,
-  providers: undefined,
+  ...tagListUndefineds,
 };
 
 const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
@@ -26,8 +31,7 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
     name: "default page",
     data: {
       page: undefined,
-      search_query: undefined,
-      providers: undefined,
+      ...tagListUndefineds,
     },
   },
   {

--- a/src/tools/list-tags.ts
+++ b/src/tools/list-tags.ts
@@ -1,10 +1,10 @@
 import type { GetTagsRequest } from "@vantage-sh/vantage-client";
 import z from "zod";
-import { tagListQueryFields } from "./utils/tagListQuerySchema";
 import { DEFAULT_LIMIT } from "./structure/constants";
 import MCPUserError from "./structure/MCPUserError";
 import registerTool from "./structure/registerTool";
 import paginationData from "./utils/paginationData";
+import { tagListQueryFields } from "./utils/tagListQuerySchema";
 
 const description = `
 List tags that can be used to filter costs and cost reports.

--- a/src/tools/list-tags.ts
+++ b/src/tools/list-tags.ts
@@ -1,5 +1,6 @@
 import type { GetTagsRequest } from "@vantage-sh/vantage-client";
 import z from "zod";
+import { tagListQueryFields } from "./utils/tagListQuerySchema";
 import { DEFAULT_LIMIT } from "./structure/constants";
 import MCPUserError from "./structure/MCPUserError";
 import registerTool from "./structure/registerTool";
@@ -16,11 +17,7 @@ Each tag in the response uses the field \`tag_key\` (not \`key\`).
 
 const args = {
   page: z.number().optional().default(1).describe("The page number to return, defaults to 1"),
-  search_query: z.string().optional().describe("Search query to filter tags by tag key name"),
-  providers: z
-    .array(z.string())
-    .optional()
-    .describe("Filter tags to those present on the given cost providers (e.g. aws, azure, gcp)"),
+  ...tagListQueryFields,
 };
 
 export default registerTool({

--- a/src/tools/query-costs.test.ts
+++ b/src/tools/query-costs.test.ts
@@ -404,6 +404,19 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
       });
     },
   },
+  {
+    name: "rejects filter and cost_report_token together",
+    apiCallHandler: requestsInOrder([]),
+    handler: async ({ callExpectingMCPUserError }) => {
+      const err = await callExpectingMCPUserError({
+        ...validInputArguments,
+        cost_report_token: "rprt_123",
+      });
+      expect(err.exception).toEqual({
+        errors: [{ message: "Provide either filter or cost_report_token, not both" }],
+      });
+    },
+  },
 ];
 
 testTool(tool, argumentSchemaTests, executionTests);

--- a/src/tools/query-costs.test.ts
+++ b/src/tools/query-costs.test.ts
@@ -86,6 +86,15 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
     data: validInputArguments,
   },
   {
+    name: "cost report token without filter or workspace_token",
+    data: {
+      ...validInputArguments,
+      cost_report_token: "rprt_123",
+      filter: undefined,
+      workspace_token: undefined,
+    },
+  },
+  {
     name: "aggregate by usage",
     data: {
       ...validInputArguments,
@@ -159,7 +168,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
     handler: async ({ callExpectingSuccess }) => {
       const res = await callExpectingSuccess({
         page: 1,
-                cost_report_token: undefined,
+        cost_report_token: undefined,
         order: undefined,
         filter: "(costs.provider = 'aws')",
         start_date: undefined,
@@ -185,6 +194,39 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
           nextPage: 0,
         },
       });
+    },
+  },
+  {
+    name: "successful call with cost_report_token and no filter",
+    apiCallHandler: requestsInOrder([
+      {
+        endpoint: "/v2/costs",
+        params: {
+          page: 1,
+          cost_report_token: "rprt_123",
+          order: undefined,
+          filter: undefined,
+          start_date: undefined,
+          end_date: undefined,
+          workspace_token: undefined,
+          date_bin: "month",
+          groupings: GROUPINGS_API,
+          limit: 1000,
+        },
+        method: "GET",
+        result: { ok: true, data: successData },
+      },
+    ]),
+    handler: async ({ callExpectingSuccess }) => {
+      const res = await callExpectingSuccess({
+        ...validInputArguments,
+        cost_report_token: "rprt_123",
+        filter: undefined,
+        workspace_token: undefined,
+        start_date: undefined,
+        end_date: undefined,
+      });
+      expect(res.costs).toEqual(successData.costs);
     },
   },
   {
@@ -326,7 +368,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
     handler: async ({ callExpectingMCPUserError }) => {
       const err = await callExpectingMCPUserError({
         page: 1,
-                cost_report_token: undefined,
+        cost_report_token: undefined,
         order: undefined,
         filter: "(costs.provider = 'aws')",
         start_date: undefined,
@@ -345,6 +387,20 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
       });
       expect(err.exception).toEqual({
         errors: [{ message: "Invalid VQL query" }],
+      });
+    },
+  },
+  {
+    name: "requires filter or cost_report_token",
+    apiCallHandler: requestsInOrder([]),
+    handler: async ({ callExpectingMCPUserError }) => {
+      const err = await callExpectingMCPUserError({
+        ...validInputArguments,
+        cost_report_token: undefined,
+        filter: undefined,
+      });
+      expect(err.exception).toEqual({
+        errors: [{ message: "filter or cost_report_token must be provided" }],
       });
     },
   },

--- a/src/tools/query-costs.test.ts
+++ b/src/tools/query-costs.test.ts
@@ -417,6 +417,19 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
       });
     },
   },
+  {
+    name: "requires workspace_token when filter is provided",
+    apiCallHandler: requestsInOrder([]),
+    handler: async ({ callExpectingMCPUserError }) => {
+      const err = await callExpectingMCPUserError({
+        ...validInputArguments,
+        workspace_token: undefined,
+      });
+      expect(err.exception).toEqual({
+        errors: [{ message: "workspace_token is required when filter is provided" }],
+      });
+    },
+  },
 ];
 
 testTool(tool, argumentSchemaTests, executionTests);

--- a/src/tools/query-costs.test.ts
+++ b/src/tools/query-costs.test.ts
@@ -32,6 +32,8 @@ const baseApiParams = {
 
 const validInputArguments = {
   page: 1,
+  cost_report_token: undefined,
+  order: undefined,
   filter: "(costs.provider = 'aws')",
   start_date: "2023-01-01",
   end_date: "2023-01-31",
@@ -53,6 +55,8 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
     name: "minimal valid arguments",
     data: {
       page: 1,
+      cost_report_token: undefined,
+      order: undefined,
       filter: "(costs.provider = 'aws')",
       start_date: undefined,
       end_date: undefined,
@@ -155,6 +159,8 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
     handler: async ({ callExpectingSuccess }) => {
       const res = await callExpectingSuccess({
         page: 1,
+                cost_report_token: undefined,
+        order: undefined,
         filter: "(costs.provider = 'aws')",
         start_date: undefined,
         end_date: undefined,
@@ -320,6 +326,8 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
     handler: async ({ callExpectingMCPUserError }) => {
       const err = await callExpectingMCPUserError({
         page: 1,
+                cost_report_token: undefined,
+        order: undefined,
         filter: "(costs.provider = 'aws')",
         start_date: undefined,
         end_date: undefined,

--- a/src/tools/query-costs.ts
+++ b/src/tools/query-costs.ts
@@ -48,10 +48,17 @@ Only provide these parameters if you need to override those defaults.
 
 const args = {
   page: z.number().optional().default(1).describe("The page number to return, defaults to 1"),
-  filter: z.string().describe("A VQL query to run against your vantage account"),
+  filter: z
+    .string()
+    .optional()
+    .describe("A VQL query to run against your Vantage account. Optional when cost_report_token is set."),
   start_date: dateValidator("Start date to filter costs by, format=YYYY-MM-DD").optional(),
   end_date: dateValidator("End date to filter costs by, format=YYYY-MM-DD").optional(),
-  workspace_token: z.string().min(1).describe("The workspace token to scope the query to"),
+  workspace_token: z
+    .string()
+    .min(1)
+    .optional()
+    .describe("Workspace token to scope the query to. Ignored when cost_report_token is set."),
   date_bin: z
     .enum(["day", "week", "month"])
     .optional()
@@ -116,6 +123,12 @@ export default registerTool({
   },
   args,
   async execute(args, ctx) {
+    if (!args.filter && !args.cost_report_token) {
+      throw new MCPUserError({
+        errors: [{ message: "filter or cost_report_token must be provided" }],
+      });
+    }
+
     // Build request params. Settings that are not explicitly provided are left out
     // so the API uses the workspace's default report settings.
     const requestParams: Record<string, unknown> = {

--- a/src/tools/query-costs.ts
+++ b/src/tools/query-costs.ts
@@ -128,6 +128,11 @@ export default registerTool({
         errors: [{ message: "filter or cost_report_token must be provided" }],
       });
     }
+    if (args.filter && args.cost_report_token) {
+      throw new MCPUserError({
+        errors: [{ message: "Provide either filter or cost_report_token, not both" }],
+      });
+    }
 
     // Build request params. Settings that are not explicitly provided are left out
     // so the API uses the workspace's default report settings.

--- a/src/tools/query-costs.ts
+++ b/src/tools/query-costs.ts
@@ -133,6 +133,11 @@ export default registerTool({
         errors: [{ message: "Provide either filter or cost_report_token, not both" }],
       });
     }
+    if (args.filter && !args.workspace_token) {
+      throw new MCPUserError({
+        errors: [{ message: "workspace_token is required when filter is provided" }],
+      });
+    }
 
     // Build request params. Settings that are not explicitly provided are left out
     // so the API uses the workspace's default report settings.

--- a/src/tools/query-costs.ts
+++ b/src/tools/query-costs.ts
@@ -98,6 +98,11 @@ const args = {
     .describe(
       "Group the results by specific field(s). Defaults to provider, service, region. Valid groupings: account_id, billing_account_id, charge_type, cost_category, cost_subcategory, provider, region, resource_id, service, tagged, tag:<tag_value>. Include every grouping you need in one call rather than issuing separate calls per grouping."
     ),
+  cost_report_token: z
+    .string()
+    .optional()
+    .describe("Cost Report token. When set, returns costs for that report instead of using filter."),
+  order: z.enum(["asc", "desc"]).optional().describe("Sort costs by date ascending or descending."),
 };
 
 export default registerTool({

--- a/src/tools/recommendation-views/update-recommendation-view.test.ts
+++ b/src/tools/recommendation-views/update-recommendation-view.test.ts
@@ -24,6 +24,8 @@ const undefineds = {
   tag_value: undefined,
   start_date: undefined,
   end_date: undefined,
+  types: undefined,
+  min_savings: undefined,
 };
 
 const minimalValidInputArguments: InferValidators<Validators> = {
@@ -32,6 +34,7 @@ const minimalValidInputArguments: InferValidators<Validators> = {
 };
 
 const validInputArguments: InferValidators<Validators> = {
+  ...undefineds,
   recommendation_view_token: "rec_vw_123",
   title: "Production Recommendations",
   provider_ids: ["aws"],

--- a/src/tools/recommendation-views/update-recommendation-view.ts
+++ b/src/tools/recommendation-views/update-recommendation-view.ts
@@ -44,11 +44,7 @@ export default registerTool({
       .array(z.string().min(1))
       .optional()
       .describe("Updated recommendation type slugs (e.g. aws:ec2:rightsizing)."),
-    min_savings: z
-      .number()
-      .min(0)
-      .optional()
-      .describe("Updated minimum potential savings filter."),
+    min_savings: z.number().min(0).optional().describe("Updated minimum potential savings filter."),
   },
   async execute(args, ctx) {
     if (!!args.tag_key !== !!args.tag_value) {

--- a/src/tools/recommendation-views/update-recommendation-view.ts
+++ b/src/tools/recommendation-views/update-recommendation-view.ts
@@ -40,6 +40,15 @@ export default registerTool({
       "Updated start date for recommendation creation filtering. YYYY-MM-DD formatted."
     ).optional(),
     end_date: dateValidator("Updated end date for recommendation creation filtering. YYYY-MM-DD formatted.").optional(),
+    types: z
+      .array(z.string().min(1))
+      .optional()
+      .describe("Updated recommendation type slugs (e.g. aws:ec2:rightsizing)."),
+    min_savings: z
+      .number()
+      .min(0)
+      .optional()
+      .describe("Updated minimum potential savings filter."),
   },
   async execute(args, ctx) {
     if (!!args.tag_key !== !!args.tag_value) {

--- a/src/tools/recommendations/list-recommendations.test.ts
+++ b/src/tools/recommendations/list-recommendations.test.ts
@@ -16,7 +16,7 @@ type OutputSchema = ExtractOutputSchema<typeof tool>;
 
 const validArguments: InferValidators<Validators> = {
   page: 1,
-  filter: "open",
+  status: "active",
   provider: "aws",
   workspace_token: "wt_123",
   provider_account_id: "123456789",
@@ -34,7 +34,7 @@ const validArguments: InferValidators<Validators> = {
 
 const minimalArgs: InferValidators<Validators> = {
   page: 1,
-  filter: undefined,
+  status: undefined,
   provider: undefined,
   workspace_token: undefined,
   provider_account_id: undefined,
@@ -60,17 +60,10 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
     data: validArguments,
   },
   {
-    name: "filter resolved",
+    name: "status archived",
     data: {
       ...validArguments,
-      filter: "resolved",
-    },
-  },
-  {
-    name: "filter dismissed",
-    data: {
-      ...validArguments,
-      filter: "dismissed",
+      status: "archived",
     },
   },
   {
@@ -233,11 +226,22 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
       {
         endpoint: "/v2/recommendations",
         params: {
-          ...validArguments,
+          page: 1,
+          status: "active",
+          provider: "aws",
+          workspace_token: "wt_123",
+          provider_account_id: "123456789",
+          type: "aws",
+          min_savings: 100,
+          tag_key: undefined,
+          tag_value: undefined,
+          regions: undefined,
+          provider_ids: undefined,
+          account_ids: undefined,
+          billing_account_ids: undefined,
+          start_date: undefined,
+          end_date: undefined,
           limit: DEFAULT_LIMIT,
-          provider: validArguments.provider as any,
-          type: validArguments.type as string | undefined,
-          provider_ids: validArguments.provider_ids as any,
         },
         method: "GET",
         result: {
@@ -327,7 +331,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
         endpoint: "/v2/recommendations",
         params: {
           page: 1,
-          filter: undefined,
+          status: undefined,
           provider: "aws",
           workspace_token: undefined,
           provider_account_id: undefined,
@@ -363,7 +367,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
         endpoint: "/v2/recommendations",
         params: {
           page: 1,
-          filter: undefined,
+          status: undefined,
           provider: undefined,
           workspace_token: undefined,
           provider_account_id: undefined,
@@ -398,7 +402,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
         endpoint: "/v2/recommendations",
         params: {
           page: 1,
-          filter: undefined,
+          status: undefined,
           provider: undefined,
           workspace_token: undefined,
           provider_account_id: undefined,
@@ -433,7 +437,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
         endpoint: "/v2/recommendations",
         params: {
           page: 1,
-          filter: undefined,
+          status: undefined,
           provider: undefined,
           workspace_token: undefined,
           provider_account_id: undefined,
@@ -468,7 +472,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
         endpoint: "/v2/recommendations",
         params: {
           page: 1,
-          filter: undefined,
+          status: undefined,
           provider: undefined,
           workspace_token: undefined,
           provider_account_id: undefined,

--- a/src/tools/recommendations/list-recommendations.ts
+++ b/src/tools/recommendations/list-recommendations.ts
@@ -145,10 +145,10 @@ Each recommendation includes:
 - Description of what can be optimized
 - Provider and service information
 - Number of resources affected
-- Current status (open, resolved, dismissed)
+- Current status (active or archived)
 
 Recommendations can be filtered by:
-- Status (open shows active recommendations, resolved shows implemented ones, dismissed shows ignored ones)
+- Status: active or archived
 - Cloud provider via provider (single) or provider_ids (multiple; requires workspace_token) — only use these when the user explicitly specifies cloud providers; do not infer or default to all providers
 - Specific workspace via workspace_token
 - Provider account ID via provider_account_id (single) or account_ids (multiple; requires workspace_token)
@@ -180,10 +180,10 @@ const args = {
     .describe(
       "Filter recommendations by type with case-insensitive fuzzy matching (e.g., aws, aws:ec2, aws:ec2:rightsizing). Natural language values like 'AWS recommendations' are normalized."
     ),
-  filter: z
-    .enum(["open", "resolved", "dismissed"])
+  status: z
+    .enum(["active", "archived"])
     .optional()
-    .describe("Filter recommendations by status: open (default), resolved, or dismissed"),
+    .describe("Filter by status: active or archived."),
   min_savings: z
     .number()
     .nonnegative()
@@ -254,7 +254,6 @@ export default registerTool({
     const requestParams = {
       ...args,
       limit: DEFAULT_LIMIT,
-      provider: args.provider as any,
     };
     const response = await ctx.callVantageApi("/v2/recommendations", requestParams, "GET");
     if (!response.ok) {

--- a/src/tools/recommendations/list-recommendations.ts
+++ b/src/tools/recommendations/list-recommendations.ts
@@ -180,10 +180,7 @@ const args = {
     .describe(
       "Filter recommendations by type with case-insensitive fuzzy matching (e.g., aws, aws:ec2, aws:ec2:rightsizing). Natural language values like 'AWS recommendations' are normalized."
     ),
-  status: z
-    .enum(["active", "archived"])
-    .optional()
-    .describe("Filter by status: active or archived."),
+  status: z.enum(["active", "archived"]).optional().describe("Filter by status: active or archived."),
   min_savings: z
     .number()
     .nonnegative()

--- a/src/tools/utils/costProviderSchema.ts
+++ b/src/tools/utils/costProviderSchema.ts
@@ -1,0 +1,41 @@
+import z from "zod";
+
+/** Provider slugs from @vantage-sh/vantage-client (getTags / getIntegrations query). */
+export const costProviderIds = [
+  "aws",
+  "azure",
+  "gcp",
+  "snowflake",
+  "databricks",
+  "mongo",
+  "datadog",
+  "fastly",
+  "new_relic",
+  "opencost",
+  "open_ai",
+  "oracle",
+  "confluent",
+  "planetscale",
+  "coralogix",
+  "kubernetes",
+  "custom_provider",
+  "github",
+  "linode",
+  "grafana",
+  "clickhouse",
+  "temporal",
+  "twilio",
+  "azure_csp",
+  "kubernetes_agent",
+  "anthropic",
+  "anyscale",
+  "cursor",
+  "elastic",
+  "vercel",
+  "redis_cloud",
+  "circle_ci",
+] as const;
+
+export const costProviderSchema = z.enum(costProviderIds);
+
+export const costProvidersSchema = z.array(costProviderSchema);

--- a/src/tools/utils/tagListQuerySchema.ts
+++ b/src/tools/utils/tagListQuerySchema.ts
@@ -1,0 +1,13 @@
+import z from "zod";
+import { costProvidersSchema } from "./costProviderSchema";
+
+export const tagListQueryFields = {
+  providers: costProvidersSchema
+    .optional()
+    .describe("Scope results to one or more cost providers (e.g. aws, azure, gcp)."),
+  search_query: z.string().optional().describe("Filter tag keys or values by a search string."),
+  sort_direction: z
+    .enum(["asc", "desc"])
+    .optional()
+    .describe("Sort direction for results. Defaults to asc."),
+};

--- a/src/tools/utils/tagListQuerySchema.ts
+++ b/src/tools/utils/tagListQuerySchema.ts
@@ -6,8 +6,5 @@ export const tagListQueryFields = {
     .optional()
     .describe("Scope results to one or more cost providers (e.g. aws, azure, gcp)."),
   search_query: z.string().optional().describe("Filter tag keys or values by a search string."),
-  sort_direction: z
-    .enum(["asc", "desc"])
-    .optional()
-    .describe("Sort direction for results. Defaults to asc."),
+  sort_direction: z.enum(["asc", "desc"]).optional().describe("Sort direction for results. Defaults to asc."),
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,20 +1,20 @@
 {
-	"compilerOptions": {
-		"target": "es2021",
-		"lib": ["es2021"],
-		"jsx": "react-jsx",
-		"module": "es2022",
-		"moduleResolution": "bundler",
-		"resolveJsonModule": true,
-		"allowJs": true,
-		"checkJs": false,
-		"noEmit": true,
-		"isolatedModules": true,
-		"allowSyntheticDefaultImports": true,
-		"forceConsistentCasingInFileNames": true,
-		"strict": true,
-		"skipLibCheck": true,
-		"types": ["./worker-configuration.d.ts", "node"]
-	},
-	"include": ["src/**/*.ts"]
+  "compilerOptions": {
+    "target": "es2022",
+    "lib": ["es2022"],
+    "jsx": "react-jsx",
+    "module": "es2022",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "allowJs": true,
+    "checkJs": false,
+    "noEmit": true,
+    "isolatedModules": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["./worker-configuration.d.ts", "node"],
+  },
+  "include": ["src/**/*.ts"],
 }


### PR DESCRIPTION
## What Changed

Adding in a tool that can be run to find drift between what our tools are surfacing and what our API actually looks like. Additionally has an exclusion list for things that are still in the API for backwards compatibility but aren't the preferred way of querying data.

## Current drift list

```
=== Parameter drift ===

create-billing-rule (createBillingRule)
  POST /v2/billing_rules
  src/tools/billing-rules/create-billing-rule.ts
  Missing from tool schema (in API): start_period

create-folder (createFolder)
  POST /v2/folders
  src/tools/create-folder.ts
  Missing from tool schema (in API): type

get-cost-provider-accounts (getCostProviderAccounts)
  GET /v2/cost_provider_accounts
  src/tools/get-cost-provider-accounts.ts
  Missing from tool schema (in API): account_name

list-cost-integrations (getIntegrations)
  GET /v2/integrations
  src/tools/list-cost-integrations.ts
  Missing from tool schema (in API): account_identifier, provider
  Injected in execute only (OK): limit

list-costs (getCosts)
  GET /v2/costs
  src/tools/list-costs.ts
  Missing from tool schema (in API): filter, order, workspace_token
  Injected in execute only (OK): limit

list-folders (getFolders)
  GET /v2/folders
  src/tools/list-folders.ts
  Missing from tool schema (in API): type
  Injected in execute only (OK): limit

list-recommendations (getRecommendations)
  GET /v2/recommendations
  src/tools/recommendations/list-recommendations.ts
  Missing from tool schema (in API): status
  Extra in tool schema (not in API): filter
  Injected in execute only (OK): limit

list-tag-values (getTagValues)
  GET /v2/tags/{key}/values
  src/tools/list-tag-values.ts
  Missing from tool schema (in API): providers, search_query, sort_direction
  Injected in execute only (OK): limit

list-tags (getTags)
  GET /v2/tags
  src/tools/list-tags.ts
  Missing from tool schema (in API): providers, search_query, sort_direction
  Injected in execute only (OK): limit

query-costs (getCosts)
  GET /v2/costs
  src/tools/query-costs.ts
  Missing from tool schema (in API): cost_report_token, order
  Injected in execute only (OK): limit

update-billing-rule (updateBillingRule)
  PUT /v2/billing_rules/{billing_rule_token}
  src/tools/billing-rules/update-billing-rule.ts
  Missing from tool schema (in API): start_period

update-dashboard (updateDashboard)
  PUT /v2/dashboards/{dashboard_token}
  src/tools/dashboards/update-dashboard.ts
  Missing from tool schema (in API): workspace_token

update-recommendation-view (updateRecommendationView)
  PUT /v2/recommendation_views/{recommendation_view_token}
  src/tools/recommendation-views/update-recommendation-view.ts
  Missing from tool schema (in API): min_savings, types
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide changes to cost query and recommendations filtering semantics could surprise MCP clients; the drift script is additive CI surface but tool argument changes affect live API calls.
> 
> **Overview**
> Adds **`npm run audit-schema-drift`**, a CLI that walks registered MCP tools, maps them to `@vantage-sh/vantage-client` operations, and reports missing/extra parameters (exit 1 on drift). **`audit-schema-drift-exclusions.ts`** documents intentional gaps (e.g. deprecated `start_period`, client types missing pagination on cost provider accounts).
> 
> **Tool schemas** are expanded to match the API across costs, folders, integrations, tags, dashboards, recommendation views, and cost reports— including shared **`costProviderSchema`** / **`tagListQueryFields`**, typed provider filters, and new execute-time validation where the API has mutual requirements.
> 
> Notable behavior changes: **`list-recommendations`** replaces legacy **`filter`** (`open`/`resolved`/`dismissed`) with API **`status`** (`active`/`archived`); **`query-costs`** allows **`cost_report_token`** instead of VQL **`filter`** (mutually exclusive) and requires **`workspace_token`** when using **`filter`**; **`update-cost-report`** adds **`default_forecast`** with a token check for `report_forecast` kind.
> 
> Tests are updated throughout; **`tsconfig`** target/lib bump to **ES2022**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2e054154afc98780555dc8ba23d36366ec858b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->