### PR TITLE
Resource Report MCP tools

### DIFF
--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -39,6 +39,7 @@ import "./list-unit-costs";
 import "./query-costs";
 import "./recommendation-views";
 import "./recommendations";
+import "./resource-reports";
 import "./submit-user-feedback";
 import "./update-anomaly";
 import "./update-folder";

--- a/src/tools/resource-reports/create-resource-report.test.ts
+++ b/src/tools/resource-reports/create-resource-report.test.ts
@@ -1,0 +1,132 @@
+import type { CreateResourceReportResponse } from "@vantage-sh/vantage-client";
+import { expect } from "vitest";
+import {
+  type ExecutionTestTableItem,
+  type ExtractOutputSchema,
+  type ExtractValidators,
+  type InferValidators,
+  requestsInOrder,
+  type SchemaTestTableItem,
+  testTool,
+} from "../utils/testing";
+import tool from "./create-resource-report";
+
+const WORKSPACE_TOKEN: string = "wrkspc_2ed2f1a59293a996";
+const BAD_WORKSPACE_TOKEN: string = "wrkspc_nonexistent";
+
+type Validators = ExtractValidators<typeof tool>;
+type OutputSchema = ExtractOutputSchema<typeof tool>;
+
+const undefineds = {
+  title: undefined,
+  filter: undefined,
+  columns: undefined,
+  folder_token: undefined,
+};
+
+const validInputArguments: InferValidators<Validators> = {
+  ...undefineds,
+  workspace_token: WORKSPACE_TOKEN,
+  title: "Production EC2",
+  filter: "resources.provider = 'aws' AND resources.type = 'aws_instance'",
+  columns: ["provider", "label", "type", "region", "account"],
+};
+
+const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
+  {
+    name: "minimal valid arguments",
+    data: {
+      ...undefineds,
+      workspace_token: WORKSPACE_TOKEN,
+    },
+  },
+  {
+    name: "all valid arguments",
+    data: validInputArguments,
+  },
+  {
+    name: "empty workspace_token",
+    data: {
+      ...validInputArguments,
+      workspace_token: "",
+    },
+    expectedIssues: ["Too small: expected string to have >=1 characters"],
+  },
+  {
+    name: "empty title",
+    data: {
+      ...validInputArguments,
+      title: "",
+    },
+    expectedIssues: ["Too small: expected string to have >=1 characters"],
+  },
+  {
+    name: "empty column name",
+    data: {
+      ...validInputArguments,
+      columns: ["provider", ""],
+    },
+    expectedIssues: ["Too small: expected string to have >=1 characters"],
+  },
+];
+
+const successData: CreateResourceReportResponse = {
+  token: "prvdr_rsrc_rprt_d881b5362adab1c2",
+  title: "Production EC2",
+  filter: "resources.provider = 'aws' AND resources.type = 'aws_instance'",
+  created_at: "2025-08-14T19:13:32Z",
+  workspace_token: WORKSPACE_TOKEN,
+  user_token: null,
+  created_by_token: "team_16f0d31149f3254a",
+  columns: ["provider", "label", "type", "region", "account"],
+};
+
+const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
+  {
+    name: "successful call",
+    apiCallHandler: requestsInOrder([
+      {
+        endpoint: "/v2/resource_reports",
+        params: validInputArguments,
+        method: "POST",
+        result: {
+          ok: true,
+          data: successData,
+        },
+      },
+    ]),
+    handler: async ({ callExpectingSuccess }) => {
+      const res = await callExpectingSuccess(validInputArguments);
+      expect(res).toEqual(successData);
+    },
+  },
+  {
+    name: "unsuccessful call",
+    apiCallHandler: requestsInOrder([
+      {
+        endpoint: "/v2/resource_reports",
+        params: {
+          workspace_token: BAD_WORKSPACE_TOKEN,
+          title: "Invalid Report",
+        },
+        method: "POST",
+        result: {
+          ok: false,
+          errors: [{ message: "Workspace not found" }],
+        },
+      },
+    ]),
+    handler: async ({ callExpectingMCPUserError }) => {
+      const err = await callExpectingMCPUserError({
+        ...undefineds,
+        workspace_token: BAD_WORKSPACE_TOKEN,
+        title: "Invalid Report",
+      });
+      expect(err.exception).toEqual({
+        errors: [{ message: "Workspace not found" }],
+      });
+    },
+  },
+];
+
+testTool(tool, argumentSchemaTests, executionTests);

--- a/src/tools/resource-reports/create-resource-report.ts
+++ b/src/tools/resource-reports/create-resource-report.ts
@@ -22,7 +22,10 @@ export default registerTool({
     readOnly: false,
   },
   args: {
-    workspace_token: z.string().min(1).describe("Workspace token. Use get-myself to discover. Required when the API token spans multiple workspaces."),
+    workspace_token: z
+      .string()
+      .min(1)
+      .describe("Workspace token. Use get-myself to discover. Required when the API token spans multiple workspaces."),
     title: z.string().min(1).optional().describe("Title for the new Resource Report."),
     filter: z
       .string()
@@ -37,11 +40,7 @@ export default registerTool({
       .describe("Folder token. When set, determines workspace (workspace_token is ignored)."),
   },
   async execute(args, ctx) {
-    const response = await ctx.callVantageApi(
-      "/v2/resource_reports",
-      args as CreateResourceReportRequest,
-      "POST"
-    );
+    const response = await ctx.callVantageApi("/v2/resource_reports", args as CreateResourceReportRequest, "POST");
     if (!response.ok) {
       throw new MCPUserError({ errors: response.errors });
     }

--- a/src/tools/resource-reports/create-resource-report.ts
+++ b/src/tools/resource-reports/create-resource-report.ts
@@ -1,0 +1,50 @@
+import type { RequestBodyForPathAndMethod } from "@vantage-sh/vantage-client";
+import z from "zod";
+import MCPUserError from "../structure/MCPUserError";
+import registerTool from "../structure/registerTool";
+import { resourceReportColumns } from "./schemas";
+
+const description = `
+Create a saved Resource Report in Vantage. Resource Reports persist a VQL filter over cloud infrastructure resources so the view can be reopened, shared, added to dashboards, and queried later with list-provider-resources via resource_report_token. Returns the report token; link users to https://console.vantage.sh/go/<token>.
+
+Resource Report VQL uses the resources and tags namespaces — not Cost Report costs VQL (create-cost-report). Use list-provider-resources for one-off resource queries without saving a report; use list-resource-reports to browse existing reports.
+`.trim();
+
+type CreateResourceReportRequest = RequestBodyForPathAndMethod<"/v2/resource_reports", "POST">;
+
+export default registerTool({
+  name: "create-resource-report",
+  title: "Create Resource Report",
+  description,
+  annotations: {
+    destructive: false,
+    openWorld: false,
+    readOnly: false,
+  },
+  args: {
+    workspace_token: z.string().min(1).describe("Workspace token. Use get-myself to discover. Required when the API token spans multiple workspaces."),
+    title: z.string().min(1).optional().describe("Title for the new Resource Report."),
+    filter: z
+      .string()
+      .optional()
+      .describe(
+        "VQL filter using resources and tags namespaces (e.g. resources.provider = 'aws' AND resources.type = 'aws_instance')."
+      ),
+    columns: resourceReportColumns,
+    folder_token: z
+      .string()
+      .optional()
+      .describe("Folder token. When set, determines workspace (workspace_token is ignored)."),
+  },
+  async execute(args, ctx) {
+    const response = await ctx.callVantageApi(
+      "/v2/resource_reports",
+      args as CreateResourceReportRequest,
+      "POST"
+    );
+    if (!response.ok) {
+      throw new MCPUserError({ errors: response.errors });
+    }
+    return response.data;
+  },
+});

--- a/src/tools/resource-reports/delete-resource-report.test.ts
+++ b/src/tools/resource-reports/delete-resource-report.test.ts
@@ -1,0 +1,63 @@
+import { pathEncode } from "@vantage-sh/vantage-client";
+import { expect } from "vitest";
+import { requestsInOrder, testTool } from "../utils/testing";
+import tool from "./delete-resource-report";
+
+const RESOURCE_REPORT_TOKEN: string = "prvdr_rsrc_rprt_5270d2a0708fd74f";
+const BAD_RESOURCE_REPORT_TOKEN: string = "prvdr_rsrc_rprt_missing";
+
+testTool(
+  tool,
+  [
+    {
+      name: "takes resource_report_token",
+      data: {
+        resource_report_token: RESOURCE_REPORT_TOKEN,
+      },
+    },
+  ],
+  [
+    {
+      name: "successful call",
+      apiCallHandler: requestsInOrder([
+        {
+          endpoint: `/v2/resource_reports/${pathEncode(RESOURCE_REPORT_TOKEN)}`,
+          params: {},
+          method: "DELETE",
+          result: {
+            ok: true,
+            data: undefined,
+          },
+        },
+      ]),
+      handler: async ({ callExpectingSuccess }) => {
+        const res = await callExpectingSuccess({
+          resource_report_token: RESOURCE_REPORT_TOKEN,
+        });
+        expect(res).toEqual({ token: RESOURCE_REPORT_TOKEN });
+      },
+    },
+    {
+      name: "unsuccessful call",
+      apiCallHandler: requestsInOrder([
+        {
+          endpoint: `/v2/resource_reports/${pathEncode(BAD_RESOURCE_REPORT_TOKEN)}`,
+          params: {},
+          method: "DELETE",
+          result: {
+            ok: false,
+            errors: [{ message: "resource report not found" }],
+          },
+        },
+      ]),
+      handler: async ({ callExpectingMCPUserError }) => {
+        const err = await callExpectingMCPUserError({
+          resource_report_token: BAD_RESOURCE_REPORT_TOKEN,
+        });
+        expect(err.exception).toEqual({
+          errors: [{ message: "resource report not found" }],
+        });
+      },
+    },
+  ]
+);

--- a/src/tools/resource-reports/delete-resource-report.ts
+++ b/src/tools/resource-reports/delete-resource-report.ts
@@ -22,7 +22,11 @@ export default registerTool({
   },
   args,
   async execute(args, ctx) {
-    const response = await ctx.callVantageApi(`/v2/resource_reports/${pathEncode(args.resource_report_token)}`, {}, "DELETE");
+    const response = await ctx.callVantageApi(
+      `/v2/resource_reports/${pathEncode(args.resource_report_token)}`,
+      {},
+      "DELETE"
+    );
     if (!response.ok) {
       throw new MCPUserError({ errors: response.errors });
     }

--- a/src/tools/resource-reports/delete-resource-report.ts
+++ b/src/tools/resource-reports/delete-resource-report.ts
@@ -1,0 +1,31 @@
+import { pathEncode } from "@vantage-sh/vantage-client";
+import z from "zod";
+import MCPUserError from "../structure/MCPUserError";
+import registerTool from "../structure/registerTool";
+
+const description = `
+Deletes a resource report by its token. This action is irreversible.
+`.trim();
+
+const args = {
+  resource_report_token: z.string().describe("Token of the resource report to delete"),
+};
+
+export default registerTool({
+  name: "delete-resource-report",
+  title: "Delete Resource Report",
+  description,
+  annotations: {
+    destructive: true,
+    openWorld: false,
+    readOnly: false,
+  },
+  args,
+  async execute(args, ctx) {
+    const response = await ctx.callVantageApi(`/v2/resource_reports/${pathEncode(args.resource_report_token)}`, {}, "DELETE");
+    if (!response.ok) {
+      throw new MCPUserError({ errors: response.errors });
+    }
+    return { token: args.resource_report_token };
+  },
+});

--- a/src/tools/resource-reports/get-resource-report.test.ts
+++ b/src/tools/resource-reports/get-resource-report.test.ts
@@ -1,0 +1,83 @@
+import { type GetResourceReportResponse, pathEncode } from "@vantage-sh/vantage-client";
+import { expect } from "vitest";
+import { requestsInOrder, testTool } from "../utils/testing";
+import tool from "./get-resource-report";
+
+const RESOURCE_REPORT_TOKEN: string = "prvdr_rsrc_rprt_5270d2a0708fd74f";
+const BAD_RESOURCE_REPORT_TOKEN: string = "prvdr_rsrc_rprt_nonexistent";
+
+const success: GetResourceReportResponse = {
+  "token": RESOURCE_REPORT_TOKEN,
+  "title": "Resource Report 84541657",
+  "filter": "(resources.provider = 'aws')",
+  "created_at": "2025-08-14T19:13:30Z",
+  "workspace_token": "wrkspc_2ed2f1a59293a996",
+  "user_token": null,
+  "created_by_token": null,
+  "columns": [
+    "provider",
+    "label",
+    "accrued_costs",
+    "recommendation_savings",
+    "resource",
+    "type",
+    "region",
+    "account"
+  ]
+};
+
+testTool(
+  tool,
+  [
+    {
+      name: "takes resource_report_token",
+      data: {
+        resource_report_token: RESOURCE_REPORT_TOKEN,
+      },
+    },
+  ],
+  [
+    {
+      name: "successful call",
+      apiCallHandler: requestsInOrder([
+        {
+          endpoint: `/v2/resource_reports/${pathEncode(RESOURCE_REPORT_TOKEN)}`,
+          params: {},
+          method: "GET",
+          result: {
+            ok: true,
+            data: success,
+          },
+        },
+      ]),
+      handler: async ({ callExpectingSuccess }) => {
+        const res = await callExpectingSuccess({
+          resource_report_token: RESOURCE_REPORT_TOKEN,
+        });
+        expect(res).toEqual(success);
+      },
+    },
+    {
+      name: "unsuccessful call",
+      apiCallHandler: requestsInOrder([
+        {
+          endpoint: `/v2/resource_reports/${pathEncode(BAD_RESOURCE_REPORT_TOKEN)}`,
+          params: {},
+          method: "GET",
+          result: {
+            ok: false,
+            errors: [{ message: "Resource report not found" }],
+          },
+        },
+      ]),
+      handler: async ({ callExpectingMCPUserError }) => {
+        const err = await callExpectingMCPUserError({
+          resource_report_token: BAD_RESOURCE_REPORT_TOKEN,
+        });
+        expect(err.exception).toEqual({
+          errors: [{ message: "Resource report not found" }],
+        });
+      },
+    },
+  ]
+);

--- a/src/tools/resource-reports/get-resource-report.test.ts
+++ b/src/tools/resource-reports/get-resource-report.test.ts
@@ -7,23 +7,14 @@ const RESOURCE_REPORT_TOKEN: string = "prvdr_rsrc_rprt_5270d2a0708fd74f";
 const BAD_RESOURCE_REPORT_TOKEN: string = "prvdr_rsrc_rprt_nonexistent";
 
 const success: GetResourceReportResponse = {
-  "token": RESOURCE_REPORT_TOKEN,
-  "title": "Resource Report 84541657",
-  "filter": "(resources.provider = 'aws')",
-  "created_at": "2025-08-14T19:13:30Z",
-  "workspace_token": "wrkspc_2ed2f1a59293a996",
-  "user_token": null,
-  "created_by_token": null,
-  "columns": [
-    "provider",
-    "label",
-    "accrued_costs",
-    "recommendation_savings",
-    "resource",
-    "type",
-    "region",
-    "account"
-  ]
+  token: RESOURCE_REPORT_TOKEN,
+  title: "Resource Report 84541657",
+  filter: "(resources.provider = 'aws')",
+  created_at: "2025-08-14T19:13:30Z",
+  workspace_token: "wrkspc_2ed2f1a59293a996",
+  user_token: null,
+  created_by_token: null,
+  columns: ["provider", "label", "accrued_costs", "recommendation_savings", "resource", "type", "region", "account"],
 };
 
 testTool(

--- a/src/tools/resource-reports/get-resource-report.ts
+++ b/src/tools/resource-reports/get-resource-report.ts
@@ -22,7 +22,11 @@ export default registerTool({
   },
   args,
   async execute(args, ctx) {
-    const response = await ctx.callVantageApi(`/v2/resource_reports/${pathEncode(args.resource_report_token)}`, {}, "GET");
+    const response = await ctx.callVantageApi(
+      `/v2/resource_reports/${pathEncode(args.resource_report_token)}`,
+      {},
+      "GET"
+    );
     if (!response.ok) {
       throw new MCPUserError({ errors: response.errors });
     }

--- a/src/tools/resource-reports/get-resource-report.ts
+++ b/src/tools/resource-reports/get-resource-report.ts
@@ -1,0 +1,31 @@
+import { pathEncode } from "@vantage-sh/vantage-client";
+import z from "zod";
+import MCPUserError from "../structure/MCPUserError";
+import registerTool from "../structure/registerTool";
+
+const description = `
+Gets a specific resource report by its token. The token of a report can be used to generate a link to the resource report in the Vantage Web UI: https://console.vantage.sh/go/<token>
+`.trim();
+
+const args = {
+  resource_report_token: z.string().describe("The resource report token to retrieve"),
+};
+
+export default registerTool({
+  name: "get-resource-report",
+  title: "Get Resource Report",
+  description,
+  annotations: {
+    destructive: false,
+    openWorld: false,
+    readOnly: true,
+  },
+  args,
+  async execute(args, ctx) {
+    const response = await ctx.callVantageApi(`/v2/resource_reports/${pathEncode(args.resource_report_token)}`, {}, "GET");
+    if (!response.ok) {
+      throw new MCPUserError({ errors: response.errors });
+    }
+    return response.data;
+  },
+});

--- a/src/tools/resource-reports/index.ts
+++ b/src/tools/resource-reports/index.ts
@@ -1,0 +1,7 @@
+import "./create-resource-report";
+import "./delete-resource-report";
+import "./get-resource-report";
+import "./list-resource-report-columns";
+import "./list-resource-reports";
+import "./update-resource-report";
+

--- a/src/tools/resource-reports/index.ts
+++ b/src/tools/resource-reports/index.ts
@@ -4,4 +4,3 @@ import "./get-resource-report";
 import "./list-resource-report-columns";
 import "./list-resource-reports";
 import "./update-resource-report";
-

--- a/src/tools/resource-reports/list-resource-report-columns.test.ts
+++ b/src/tools/resource-reports/list-resource-report-columns.test.ts
@@ -1,0 +1,117 @@
+import type { GetResourceReportColumnsResponse } from "@vantage-sh/vantage-client";
+import { expect } from "vitest";
+import { requestsInOrder, testTool } from "../utils/testing";
+import tool from "./list-resource-report-columns";
+
+const success: GetResourceReportColumnsResponse = {
+  "columns": [
+    "provider",
+    "label",
+    "accruedCosts",
+    "recommendationSavings",
+    "resource",
+    "type",
+    "region",
+    "account",
+    "provisionedState",
+    "maxCpu",
+    "maxMemory",
+    "maxGpu",
+    "maxGpuMemory",
+    "maxEbsReadOpsPerSecond",
+    "maxEbsWriteOpsPerSecond",
+    "maxEbsReadBytesPerSecond",
+    "maxEbsWriteBytesPerSecond",
+    "maxDiskReadOpsPerSecond",
+    "maxDiskWriteOpsPerSecond",
+    "maxDiskReadBytesPerSecond",
+    "maxDiskWriteBytesPerSecond",
+    "maxNetworkInBytesPerSecond",
+    "maxNetworkOutBytesPerSecond",
+    "maxNetworkPacketsInPerSecond",
+    "maxNetworkPacketsOutPerSecond",
+    "maxNetworkThroughputDailyByte",
+    "maxDatabaseConnections",
+    "instanceId",
+    "imageId",
+    "vpcId",
+    "subnetId",
+    "publicIpAddress",
+    "privateIpAddress",
+    "publicDnsName",
+    "instanceType",
+    "instanceFamily",
+    "platform",
+    "spotInstanceRequestId",
+    "launchTime",
+    "instanceLifecycle",
+    "state",
+    "name",
+    "platformType",
+    "platformDetails",
+    "spotInfo",
+    "spotPrice",
+    "datadogAgentInstalled",
+    "networkInterfaces",
+    "tags"
+  ]
+}
+
+const RESOURCE_TYPE: string = "aws_instance"
+const INVALID_RESOURCE_TYPE: string = "invalid"
+
+testTool(
+  tool,
+  [
+    {
+      name: "takes resource_type",
+      data: {
+        resource_type: RESOURCE_TYPE,
+      },
+    },
+  ],
+  [
+    {
+      name: "successful call",
+      apiCallHandler: requestsInOrder([
+        {
+          endpoint: `/v2/resource_reports/columns`,
+          params: {resource_type: RESOURCE_TYPE},
+          method: "GET",
+          result: {
+            ok: true,
+            data: success,
+          },
+        },
+      ]),
+      handler: async ({ callExpectingSuccess }) => {
+        const res = await callExpectingSuccess({
+          resource_type: RESOURCE_TYPE,
+        });
+        expect(res).toEqual(success);
+      },
+    },
+    {
+      name: "unsuccessful call",
+      apiCallHandler: requestsInOrder([
+        {
+          endpoint: `/v2/resource_reports/columns`,
+          params: {resource_type: INVALID_RESOURCE_TYPE},
+          method: "GET",
+          result: {
+            ok: false,
+            errors: [{ message: "resource_type is missing" }],
+          },
+        },
+      ]),
+      handler: async ({ callExpectingMCPUserError }) => {
+        const err = await callExpectingMCPUserError({
+            resource_type: INVALID_RESOURCE_TYPE
+        });
+        expect(err.exception).toEqual({
+          errors: [{ message: "resource_type is missing" }],
+        });
+      },
+    },
+  ]
+);

--- a/src/tools/resource-reports/list-resource-report-columns.test.ts
+++ b/src/tools/resource-reports/list-resource-report-columns.test.ts
@@ -4,7 +4,7 @@ import { requestsInOrder, testTool } from "../utils/testing";
 import tool from "./list-resource-report-columns";
 
 const success: GetResourceReportColumnsResponse = {
-  "columns": [
+  columns: [
     "provider",
     "label",
     "accruedCosts",
@@ -53,12 +53,12 @@ const success: GetResourceReportColumnsResponse = {
     "spotPrice",
     "datadogAgentInstalled",
     "networkInterfaces",
-    "tags"
-  ]
-}
+    "tags",
+  ],
+};
 
-const RESOURCE_TYPE: string = "aws_instance"
-const INVALID_RESOURCE_TYPE: string = "invalid"
+const RESOURCE_TYPE: string = "aws_instance";
+const INVALID_RESOURCE_TYPE: string = "invalid";
 
 testTool(
   tool,
@@ -76,7 +76,7 @@ testTool(
       apiCallHandler: requestsInOrder([
         {
           endpoint: `/v2/resource_reports/columns`,
-          params: {resource_type: RESOURCE_TYPE},
+          params: { resource_type: RESOURCE_TYPE },
           method: "GET",
           result: {
             ok: true,
@@ -96,7 +96,7 @@ testTool(
       apiCallHandler: requestsInOrder([
         {
           endpoint: `/v2/resource_reports/columns`,
-          params: {resource_type: INVALID_RESOURCE_TYPE},
+          params: { resource_type: INVALID_RESOURCE_TYPE },
           method: "GET",
           result: {
             ok: false,
@@ -106,7 +106,7 @@ testTool(
       ]),
       handler: async ({ callExpectingMCPUserError }) => {
         const err = await callExpectingMCPUserError({
-            resource_type: INVALID_RESOURCE_TYPE
+          resource_type: INVALID_RESOURCE_TYPE,
         });
         expect(err.exception).toEqual({
           errors: [{ message: "resource_type is missing" }],

--- a/src/tools/resource-reports/list-resource-report-columns.ts
+++ b/src/tools/resource-reports/list-resource-report-columns.ts
@@ -7,7 +7,11 @@ List available columns for a resource type. The resource_type is a required para
 `.trim();
 
 const args = {
-  resource_type: z.string().describe("The resource type to retrieve available columns for. This parameter must be a valid VQL resource type name."),
+  resource_type: z
+    .string()
+    .describe(
+      "The resource type to retrieve available columns for. This parameter must be a valid VQL resource type name."
+    ),
 };
 
 export default registerTool({
@@ -21,7 +25,7 @@ export default registerTool({
   },
   args,
   async execute(args, ctx) {
-    const response = await ctx.callVantageApi(`/v2/resource_reports/columns`, {...args}, "GET");
+    const response = await ctx.callVantageApi(`/v2/resource_reports/columns`, { ...args }, "GET");
     if (!response.ok) {
       throw new MCPUserError({ errors: response.errors });
     }

--- a/src/tools/resource-reports/list-resource-report-columns.ts
+++ b/src/tools/resource-reports/list-resource-report-columns.ts
@@ -1,0 +1,30 @@
+import z from "zod";
+import MCPUserError from "../structure/MCPUserError";
+import registerTool from "../structure/registerTool";
+
+const description = `
+List available columns for a resource type. The resource_type is a required parameter, and must be a valid VQL resource type name.
+`.trim();
+
+const args = {
+  resource_type: z.string().describe("The resource type to retrieve available columns for. This parameter must be a valid VQL resource type name."),
+};
+
+export default registerTool({
+  name: "list-resource-report-columns",
+  title: "List Resource Report Columns",
+  description,
+  annotations: {
+    destructive: false,
+    openWorld: false,
+    readOnly: true,
+  },
+  args,
+  async execute(args, ctx) {
+    const response = await ctx.callVantageApi(`/v2/resource_reports/columns`, {...args}, "GET");
+    if (!response.ok) {
+      throw new MCPUserError({ errors: response.errors });
+    }
+    return response.data;
+  },
+});

--- a/src/tools/resource-reports/list-resource-reports.test.ts
+++ b/src/tools/resource-reports/list-resource-reports.test.ts
@@ -34,17 +34,17 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
 ];
 
 const successData = {
-  "links": {},
-  "resource_reports": [
+  links: {},
+  resource_reports: [
     {
-      "token": "prvdr_rsrc_rprt_955ad21703b22099",
-      "title": "Resource Report 1274a351",
-      "filter": "(resources.provider = 'aws')",
-      "created_at": "2025-08-14T19:13:30Z",
-      "workspace_token": "wrkspc_490ea5f144c3896c",
-      "user_token": null,
-      "created_by_token": null,
-      "columns": [
+      token: "prvdr_rsrc_rprt_955ad21703b22099",
+      title: "Resource Report 1274a351",
+      filter: "(resources.provider = 'aws')",
+      created_at: "2025-08-14T19:13:30Z",
+      workspace_token: "wrkspc_490ea5f144c3896c",
+      user_token: null,
+      created_by_token: null,
+      columns: [
         "provider",
         "label",
         "accrued_costs",
@@ -52,10 +52,10 @@ const successData = {
         "resource",
         "type",
         "region",
-        "account"
-      ]
-    }
-  ]
+        "account",
+      ],
+    },
+  ],
 };
 
 const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [

--- a/src/tools/resource-reports/list-resource-reports.test.ts
+++ b/src/tools/resource-reports/list-resource-reports.test.ts
@@ -1,0 +1,114 @@
+import { expect } from "vitest";
+import { DEFAULT_LIMIT } from "../structure/constants";
+import {
+  type ExecutionTestTableItem,
+  type ExtractOutputSchema,
+  type ExtractValidators,
+  type InferValidators,
+  requestsInOrder,
+  type SchemaTestTableItem,
+  testTool,
+} from "../utils/testing";
+import tool from "./list-resource-reports";
+
+type Validators = ExtractValidators<typeof tool>;
+type OutputSchema = ExtractOutputSchema<typeof tool>;
+
+const validArguments: InferValidators<Validators> = {
+  page: 1,
+  limit: DEFAULT_LIMIT,
+};
+
+const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
+  {
+    name: "default page",
+    data: {
+      page: undefined,
+      limit: DEFAULT_LIMIT,
+    },
+  },
+  {
+    name: "valid page number",
+    data: validArguments,
+  },
+];
+
+const successData = {
+  "links": {},
+  "resource_reports": [
+    {
+      "token": "prvdr_rsrc_rprt_955ad21703b22099",
+      "title": "Resource Report 1274a351",
+      "filter": "(resources.provider = 'aws')",
+      "created_at": "2025-08-14T19:13:30Z",
+      "workspace_token": "wrkspc_490ea5f144c3896c",
+      "user_token": null,
+      "created_by_token": null,
+      "columns": [
+        "provider",
+        "label",
+        "accrued_costs",
+        "recommendation_savings",
+        "resource",
+        "type",
+        "region",
+        "account"
+      ]
+    }
+  ]
+};
+
+const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
+  {
+    name: "successful call",
+    apiCallHandler: requestsInOrder([
+      {
+        endpoint: "/v2/resource_reports",
+        params: {
+          page: 1,
+          limit: DEFAULT_LIMIT,
+        },
+        method: "GET",
+        result: {
+          ok: true,
+          data: successData,
+        },
+      },
+    ]),
+    handler: async ({ callExpectingSuccess }) => {
+      const res = await callExpectingSuccess(validArguments);
+      expect(res).toEqual({
+        resource_reports: successData.resource_reports,
+        pagination: {
+          hasNextPage: false,
+          nextPage: 0,
+        },
+      });
+    },
+  },
+  {
+    name: "unsuccessful call",
+    apiCallHandler: requestsInOrder([
+      {
+        endpoint: "/v2/resource_reports",
+        params: {
+          page: 1,
+          limit: DEFAULT_LIMIT,
+        },
+        method: "GET",
+        result: {
+          ok: false,
+          errors: [{ message: "Access denied" }],
+        },
+      },
+    ]),
+    handler: async ({ callExpectingMCPUserError }) => {
+      const err = await callExpectingMCPUserError(validArguments);
+      expect(err.exception).toEqual({
+        errors: [{ message: "Access denied" }],
+      });
+    },
+  },
+];
+
+testTool(tool, argumentSchemaTests, executionTests);

--- a/src/tools/resource-reports/list-resource-reports.ts
+++ b/src/tools/resource-reports/list-resource-reports.ts
@@ -1,0 +1,42 @@
+import z from "zod";
+import { DEFAULT_LIMIT } from "../structure/constants";
+import MCPUserError from "../structure/MCPUserError";
+import registerTool from "../structure/registerTool";
+import paginationData from "../utils/paginationData";
+
+const description = `
+List all resource reports available. Resource reports are already created reports authored by a user in Vantage.
+When you first call this function, use the "Page" parameter of 1.
+The 'Title' of a report is a good way to know what the report is about.
+The 'filter' of a report also gives clues to the data it provides.
+The 'token' of a report is a unique identifier for the report. It can be used to generate a link to the report in the Vantage Web UI.
+If a user wants to see a report, you can link them like this: https://console.vantage.sh/go/<token>
+`.trim();
+
+const args = {
+  page: z.number().optional().default(1).describe("The page number to return, defaults to 1"),
+  limit: z.number().optional().default(DEFAULT_LIMIT).describe(`The maximum number of returned resource reports this call, defaults to ${DEFAULT_LIMIT}`),
+};
+
+export default registerTool({
+  name: "list-resource-reports",
+  title: "List Resource Reports",
+  description,
+  annotations: {
+    destructive: false,
+    openWorld: false,
+    readOnly: true,
+  },
+  args,
+  async execute(args, ctx) {
+    const requestParams = args;
+    const response = await ctx.callVantageApi("/v2/resource_reports", requestParams, "GET");
+    if (!response.ok) {
+      throw new MCPUserError({ errors: response.errors });
+    }
+    return {
+      resource_reports: response.data.resource_reports,
+      pagination: paginationData(response.data),
+    };
+  },
+});

--- a/src/tools/resource-reports/list-resource-reports.ts
+++ b/src/tools/resource-reports/list-resource-reports.ts
@@ -15,7 +15,11 @@ If a user wants to see a report, you can link them like this: https://console.va
 
 const args = {
   page: z.number().optional().default(1).describe("The page number to return, defaults to 1"),
-  limit: z.number().optional().default(DEFAULT_LIMIT).describe(`The maximum number of returned resource reports this call, defaults to ${DEFAULT_LIMIT}`),
+  limit: z
+    .number()
+    .optional()
+    .default(DEFAULT_LIMIT)
+    .describe(`The maximum number of returned resource reports this call, defaults to ${DEFAULT_LIMIT}`),
 };
 
 export default registerTool({

--- a/src/tools/resource-reports/schemas.ts
+++ b/src/tools/resource-reports/schemas.ts
@@ -1,0 +1,12 @@
+import z from "zod";
+
+export const resourceReportColumns = z
+  .array(z.string().min(1))
+  .optional()
+  .describe(
+    `Table columns in display order. Names must match list-resource-report-columns for the report's resource type.
+    Names that are not one of [provider, label, accruedCosts, resource, type, resource, account] must be formatted as lowercase strictly-alpha strings.
+    Remove 'metadata.*' prefixes. Only valid when filter targets a single resource type.
+    Important: Always use the column name format from this description when setting columns. Do NOT reuse column names from API responses, as the API may normalize names differently on output (e.g., accruedCosts on input becomes accrued_costs on output)
+    `
+  );

--- a/src/tools/resource-reports/update-resource-report.test.ts
+++ b/src/tools/resource-reports/update-resource-report.test.ts
@@ -1,0 +1,139 @@
+import { pathEncode, type UpdateResourceReportResponse } from "@vantage-sh/vantage-client";
+import { expect } from "vitest";
+import {
+  type ExecutionTestTableItem,
+  type ExtractOutputSchema,
+  type ExtractValidators,
+  type InferValidators,
+  requestsInOrder,
+  type SchemaTestTableItem,
+  testTool,
+} from "../utils/testing";
+import tool from "./update-resource-report";
+
+const RESOURCE_REPORT_TOKEN: string = "prvdr_rsrc_rprt_d881b5362adab1c2";
+const BAD_RESOURCE_REPORT_TOKEN: string = "prvdr_rsrc_rprt_nonexistent";
+
+type Validators = ExtractValidators<typeof tool>;
+type OutputSchema = ExtractOutputSchema<typeof tool>;
+
+const undefineds = {
+  title: undefined,
+  filter: undefined,
+  columns: undefined,
+  folder_token: undefined,
+};
+
+const minimalValidInputArguments: InferValidators<Validators> = {
+  ...undefineds,
+  resource_report_token: RESOURCE_REPORT_TOKEN,
+};
+
+const validInputArguments: InferValidators<Validators> = {
+  ...undefineds,
+  resource_report_token: RESOURCE_REPORT_TOKEN,
+  title: "EC2 Edited Report",
+  filter: "resources.provider = 'aws' and resources.type = 'aws_ebs_volume'",
+  columns: ["provider", "label", "type", "region", "account"],
+  folder_token: "fldr_abc123",
+};
+
+const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
+  {
+    name: "minimal valid arguments",
+    data: minimalValidInputArguments,
+  },
+  {
+    name: "all valid arguments",
+    data: validInputArguments,
+  },
+  {
+    name: "empty resource_report_token",
+    data: {
+      ...validInputArguments,
+      resource_report_token: "",
+    },
+    expectedIssues: ["Too small: expected string to have >=1 characters"],
+  },
+  {
+    name: "empty title",
+    data: {
+      ...validInputArguments,
+      title: "",
+    },
+    expectedIssues: ["Too small: expected string to have >=1 characters"],
+  },
+  {
+    name: "empty column name",
+    data: {
+      ...validInputArguments,
+      columns: ["provider", ""],
+    },
+    expectedIssues: ["Too small: expected string to have >=1 characters"],
+  },
+];
+
+const successData: UpdateResourceReportResponse = {
+  token: RESOURCE_REPORT_TOKEN,
+  title: "EC2 Edited Report",
+  filter: "resources.provider = 'aws' and resources.type = 'aws_ebs_volume'",
+  created_at: "2025-08-14T19:13:31Z",
+  workspace_token: "wrkspc_2ed2f1a59293a996",
+  user_token: null,
+  created_by_token: null,
+  columns: ["provider", "label", "type", "region", "account"],
+};
+
+const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
+  {
+    name: "successful call",
+    apiCallHandler: requestsInOrder([
+      {
+        endpoint: `/v2/resource_reports/${pathEncode(RESOURCE_REPORT_TOKEN)}`,
+        params: {
+          title: validInputArguments.title,
+          filter: validInputArguments.filter,
+          columns: validInputArguments.columns,
+          folder_token: validInputArguments.folder_token,
+        },
+        method: "PUT",
+        result: {
+          ok: true,
+          data: successData,
+        },
+      },
+    ]),
+    handler: async ({ callExpectingSuccess }) => {
+      const res = await callExpectingSuccess(validInputArguments);
+      expect(res).toEqual(successData);
+    },
+  },
+  {
+    name: "unsuccessful call",
+    apiCallHandler: requestsInOrder([
+      {
+        endpoint: `/v2/resource_reports/${pathEncode(BAD_RESOURCE_REPORT_TOKEN)}`,
+        params: {
+          title: "Invalid Update",
+        },
+        method: "PUT",
+        result: {
+          ok: false,
+          errors: [{ message: "Resource report not found" }],
+        },
+      },
+    ]),
+    handler: async ({ callExpectingMCPUserError }) => {
+      const err = await callExpectingMCPUserError({
+        ...undefineds,
+        resource_report_token: BAD_RESOURCE_REPORT_TOKEN,
+        title: "Invalid Update",
+      });
+      expect(err.exception).toEqual({
+        errors: [{ message: "Resource report not found" }],
+      });
+    },
+  },
+];
+
+testTool(tool, argumentSchemaTests, executionTests);

--- a/src/tools/resource-reports/update-resource-report.ts
+++ b/src/tools/resource-reports/update-resource-report.ts
@@ -1,0 +1,46 @@
+import { pathEncode, type UpdateResourceReportRequest } from "@vantage-sh/vantage-client";
+import z from "zod";
+import MCPUserError from "../structure/MCPUserError";
+import registerTool from "../structure/registerTool";
+import { resourceReportColumns } from "./schemas";
+
+const description = `
+Updates an existing Resource Report. Use to change the title, VQL filter, table columns, or folder.
+
+Do not use create-resource-report (creates a new report) or get-resource-report (reads without changing). Use list-resource-reports or get-resource-report to find the resource_report_token.
+`.trim();
+
+export default registerTool({
+  name: "update-resource-report",
+  title: "Update Resource Report",
+  description,
+  annotations: {
+    destructive: true,
+    openWorld: false,
+    readOnly: false,
+  },
+  args: {
+    resource_report_token: z.string().min(1).describe("The token of the Resource Report to update."),
+    title: z.string().min(1).optional().describe("Updated title for the Resource Report."),
+    filter: z
+      .string()
+      .optional()
+      .describe(
+        "Updated VQL filter using resources and tags namespaces (e.g. resources.provider = 'aws' AND resources.type = 'aws_instance')."
+      ),
+    columns: resourceReportColumns,
+    folder_token: z.string().optional().describe("Updated Folder token to move the Resource Report into."),
+  },
+  async execute(args, ctx) {
+    const { resource_report_token, ...body } = args;
+    const response = await ctx.callVantageApi(
+      `/v2/resource_reports/${pathEncode(resource_report_token)}`,
+      body as UpdateResourceReportRequest,
+      "PUT"
+    );
+    if (!response.ok) {
+      throw new MCPUserError({ errors: response.errors });
+    }
+    return response.data;
+  },
+});


### PR DESCRIPTION
Add resource-report mcp tools as described here: [ENG-1782: Resource Reports](https://linear.app/vantage-sh/issue/ENG-1782/resource-reports)
encompasses:
- [ENG-1894: `get-resource-report` tool](https://linear.app/vantage-sh/issue/ENG-1894/get-resource-report-tool)
- [ENG-1892: `create-resource-report` tool](https://linear.app/vantage-sh/issue/ENG-1892/create-resource-report-tool)
- [ENG-1896: `delete-resource-report` tool](https://linear.app/vantage-sh/issue/ENG-1896/delete-resource-report-tool)
- [ENG-1895: `update-resource-report` tool](https://linear.app/vantage-sh/issue/ENG-1895/update-resource-report-tool)
- [ENG-1891: `list-resource-reports` tool](https://linear.app/vantage-sh/issue/ENG-1891/list-resource-reports-tool)
- [ENG-1893: `list-resource-report-columns` tool](https://linear.app/vantage-sh/issue/ENG-1893/list-resource-report-columns-tool)