### PR TITLE
Paginate tool call results for `get-cost-provider-accounts`

### DIFF
--- a/src/tools/get-cost-provider-accounts.test.ts
+++ b/src/tools/get-cost-provider-accounts.test.ts
@@ -1,6 +1,7 @@
 import type { GetCostProviderAccountsResponse } from "@vantage-sh/vantage-client";
 import { expect } from "vitest";
 import tool from "./get-cost-provider-accounts";
+import { DEFAULT_LIMIT } from "./structure/constants";
 import {
   type ExecutionTestTableItem,
   type ExtractOutputSchema,
@@ -20,6 +21,8 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
       workspace_token: "wt_123",
       account_id: undefined,
       provider: undefined,
+      page: undefined,
+      limit: undefined,
     },
   },
   {
@@ -28,6 +31,8 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
       workspace_token: "wt_123",
       account_id: "acct_123",
       provider: undefined,
+      page: undefined,
+      limit: undefined,
     },
   },
   {
@@ -36,6 +41,8 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
       workspace_token: "wt_123",
       account_id: undefined,
       provider: "aws",
+      page: undefined,
+      limit: undefined,
     },
   },
   {
@@ -44,6 +51,8 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
       workspace_token: "wt_123",
       account_id: "acct_123",
       provider: "aws",
+      page: 2,
+      limit: 50,
     },
   },
 ];
@@ -65,9 +74,19 @@ const successData: GetCostProviderAccountsResponse = {
   ],
 };
 
-const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
-  // Success cases
+const successDataWithNextPage: GetCostProviderAccountsResponse = {
+  ...successData,
+  links: {
+    next: "https://api.vantage.sh/v2/cost_provider_accounts?page=3",
+  },
+};
 
+// The API type for /v2/cost_provider_accounts doesn't include page/limit yet,
+// but they are passed through via ...args at runtime. We cast params to satisfy
+// the test framework's strict typing while matching actual runtime behavior.
+const defaultPaginationParams = { page: 1, limit: DEFAULT_LIMIT } as Record<string, unknown>;
+
+const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
   {
     name: "successful call without filters",
     apiCallHandler: requestsInOrder([
@@ -77,6 +96,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
           workspace_token: "wt_123",
           account_id: undefined,
           provider: undefined,
+          ...defaultPaginationParams,
         },
         method: "GET",
         result: {
@@ -90,8 +110,16 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
         workspace_token: "wt_123",
         account_id: undefined,
         provider: undefined,
+        page: undefined,
+        limit: undefined,
       });
-      expect(res).toEqual(successData);
+      expect(res).toEqual({
+        cost_provider_accounts: successData.cost_provider_accounts,
+        pagination: {
+          hasNextPage: false,
+          nextPage: 0,
+        },
+      });
     },
   },
   {
@@ -103,6 +131,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
           workspace_token: "wt_123",
           account_id: "acct_123",
           provider: undefined,
+          ...defaultPaginationParams,
         },
         method: "GET",
         result: {
@@ -116,8 +145,16 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
         workspace_token: "wt_123",
         account_id: "acct_123",
         provider: undefined,
+        page: undefined,
+        limit: undefined,
       });
-      expect(res).toEqual(successData);
+      expect(res).toEqual({
+        cost_provider_accounts: successData.cost_provider_accounts,
+        pagination: {
+          hasNextPage: false,
+          nextPage: 0,
+        },
+      });
     },
   },
   {
@@ -129,6 +166,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
           workspace_token: "wt_123",
           account_id: undefined,
           provider: "aws",
+          ...defaultPaginationParams,
         },
         method: "GET",
         result: {
@@ -142,13 +180,53 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
         workspace_token: "wt_123",
         account_id: undefined,
         provider: "aws",
+        page: undefined,
+        limit: undefined,
       });
-      expect(res).toEqual(successData);
+      expect(res).toEqual({
+        cost_provider_accounts: successData.cost_provider_accounts,
+        pagination: {
+          hasNextPage: false,
+          nextPage: 0,
+        },
+      });
     },
   },
-
-  // Failure case
-
+  {
+    name: "successful call with pagination params and next page",
+    apiCallHandler: requestsInOrder([
+      {
+        endpoint: "/v2/cost_provider_accounts",
+        params: {
+          workspace_token: "wt_123",
+          account_id: undefined,
+          provider: undefined,
+          ...({ page: 2, limit: 50 } as Record<string, unknown>),
+        },
+        method: "GET",
+        result: {
+          ok: true,
+          data: successDataWithNextPage,
+        },
+      },
+    ]),
+    handler: async ({ callExpectingSuccess }) => {
+      const res = await callExpectingSuccess({
+        workspace_token: "wt_123",
+        account_id: undefined,
+        provider: undefined,
+        page: 2,
+        limit: 50,
+      });
+      expect(res).toEqual({
+        cost_provider_accounts: successDataWithNextPage.cost_provider_accounts,
+        pagination: {
+          hasNextPage: true,
+          nextPage: 3,
+        },
+      });
+    },
+  },
   {
     name: "unsuccessful call",
     apiCallHandler: requestsInOrder([
@@ -158,6 +236,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
           workspace_token: "wt_123",
           account_id: undefined,
           provider: undefined,
+          ...defaultPaginationParams,
         },
         method: "GET",
         result: {
@@ -171,6 +250,8 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
         workspace_token: "wt_123",
         account_id: undefined,
         provider: undefined,
+        page: undefined,
+        limit: undefined,
       });
       expect(err.exception).toEqual({
         errors: [{ message: "Invalid token" }],

--- a/src/tools/get-cost-provider-accounts.ts
+++ b/src/tools/get-cost-provider-accounts.ts
@@ -1,11 +1,14 @@
 import z from "zod";
+import { DEFAULT_LIMIT } from "./structure/constants";
 import MCPUserError from "./structure/MCPUserError";
 import registerTool from "./structure/registerTool";
+import paginationData from "./utils/paginationData";
 
 const description = `
 Get the list of Cost Provider Accounts that the current user has access to in their workspace and their names.
 This is useful for mapping IDs you have gotten from other endpoints to human-readable names, or if you need to get the
 ID of a Cost Provider Account to use in places. The account_id in this result can be passed as the account_id in VQL queries.
+When possible, use the provider or account_id filters to narrow results. Results are paginated for large accounts.
 `.trim();
 
 export default registerTool({
@@ -16,6 +19,8 @@ export default registerTool({
     workspace_token: z.string().describe("Workspace token to list cost provider accounts for"),
     account_id: z.string().optional().describe("Filter by a specific account ID"),
     provider: z.string().optional().describe("Provider to filter provider accounts to"),
+    page: z.number().optional().default(1).describe("The page number to return, defaults to 1"),
+    limit: z.number().optional().default(DEFAULT_LIMIT).describe("The number of results to return per page"),
   },
   annotations: {
     destructive: false,
@@ -37,6 +42,7 @@ export default registerTool({
     }
     return {
       cost_provider_accounts: response.data.cost_provider_accounts,
+      pagination: paginationData(response.data),
     };
   },
 });


### PR DESCRIPTION
Large accounts with thousands of provider accounts return multi-megabyte responses that exceed the LLM's context window. Adding page/limit params and pagination metadata keeps each response bounded. Also updated the description to recommend using provider/account_id filters.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only MCP tool change aligned with existing pagination patterns; no auth or data-mutation impact.
> 
> **Overview**
> Adds **pagination** to the `get-cost-provider-accounts` MCP tool so large workspaces no longer return unbounded account lists in a single call.
> 
> The tool now accepts optional **`page`** and **`limit`** (defaults from `DEFAULT_LIMIT`), forwards them to `/v2/cost_provider_accounts`, and returns **`pagination`** (`hasNextPage`, `nextPage`) derived from API `links.next` via the shared `paginationData` helper—matching other paginated list tools. The tool description now steers callers toward **`provider`** / **`account_id`** filters and notes that results are paginated.
> 
> Tests were updated for the new args, default API query params, wrapped success shape, and a case with a next page link.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec106f361a2e290f58fd5d9bdf167752722a3c49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->