### PR TITLE
Change default `date_bin` from month to day for cost tools to match API defaults

### DIFF
--- a/src/tools/list-costs.ts
+++ b/src/tools/list-costs.ts
@@ -9,11 +9,11 @@ const description = `
 List the cost items inside a report. The Token of a Report must be provided. Use the page value of 1 to start.
 The report token can be used to link the user to the report in the Vantage Web UI. Build the link like this: https://console.vantage.sh/go/<CostReportToken>
 
-The DateBin parameter will let you get the information with fewer returned results.
+The DateBin parameter controls the time granularity of returned results.
 When DateBin=day you get a record for each service spend on that day. For DateBin=week you get one entry per week,
 with the accrued_at field set to the first day of the week, but the spend item represents spend for a full week.
 Same with DateBin=month, each record returned covers a month of data. This lets you get answers with processing fewer
-records. Only use day/week if needed, otherwise DateBin=month is preferred, and month is the value set if you pass no value for DateBin.
+records. If omitted, the API uses the cost report's configured date bin, or day if the report has no override.
 `.trim();
 
 const args = {
@@ -25,7 +25,7 @@ const args = {
     .enum(["day", "week", "month"])
     .optional()
     .describe(
-      "Date binning for returned costs, default to month unless user says otherwise, allowed values: day, week, month"
+      "Date binning for returned costs. If omitted, the API uses the cost report's configured date bin, or day if the report has no override. Allowed values: day, week, month."
     ),
   settings_include_credits: z
     .boolean()
@@ -115,7 +115,8 @@ export default registerTool({
           "Costs records represent one month, the accrued_at field is the first day of the month. If your date range is less than one month, this record includes only data for that date range, not the full month.";
         break;
       default:
-        notes = "Costs records represent one day.";
+        notes =
+          "No date_bin was specified; the API will use the cost report's configured date bin (defaulting to day). Each cost record's time span depends on that setting.";
         break;
     }
 

--- a/src/tools/list-unit-costs.ts
+++ b/src/tools/list-unit-costs.ts
@@ -17,7 +17,7 @@ const args = {
     .enum(["day", "week", "month"])
     .optional()
     .describe(
-      "Date binning for returned costs, default to month unless user says otherwise, allowed values: day, week, month"
+      "Date binning for returned costs. If omitted, the API uses the cost report's configured date bin, or day if the report has no override. Allowed values: day, week, month."
     ),
   order: z.enum(["asc", "desc"]).optional().default("desc").describe("Order of the returned costs, defaults to desc"),
 };

--- a/src/tools/query-costs.test.ts
+++ b/src/tools/query-costs.test.ts
@@ -133,7 +133,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
           start_date: undefined,
           end_date: undefined,
           workspace_token: "wt_123",
-          date_bin: "month",
+          date_bin: undefined,
           groupings: GROUPINGS_API,
           "settings[include_credits]": false,
           "settings[include_refunds]": false,
@@ -173,8 +173,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
       expect(res).toEqual({
         costs: successData.costs,
         total_cost: successData.total_cost,
-        notes:
-          "Costs records represent one month, the accrued_at field is the first day of the month. If your date range is less than one month, this record includes only data for that date range, not the full month.",
+        notes: "Costs records represent one day.",
         pagination: {
           hasNextPage: false,
           nextPage: 0,
@@ -288,7 +287,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
           start_date: undefined,
           end_date: undefined,
           workspace_token: "wt_123",
-          date_bin: "month",
+          date_bin: undefined,
           groupings: GROUPINGS_API,
           "settings[include_credits]": false,
           "settings[include_refunds]": false,

--- a/src/tools/query-costs.ts
+++ b/src/tools/query-costs.ts
@@ -33,11 +33,11 @@ Some cost providers operate in a specific region, you can filter using the costs
 Note that when users want to query a Custom Provider, that has a special case. When doing a VQL query for custom provider, use the 'token' you get back from the 'list-cost-integrations' tool. Here is an example, where the token of the custom provider is "accss_crdntl_07171984": 
   (costs.provider = 'custom_provider:accss_crdntl_07171984')
 
-The DateBin parameter will let you get the information with fewer returned results.
+The DateBin parameter controls the time granularity of returned results.
 When DateBin=day you get a record for each service spend on that day. For DateBin=week you get one entry per week,
 with the accrued_at field set to the first day of the week, but the spend item represents spend for a full week.
 Same with DateBin=month, each record returned covers a month of data. This lets you get answers with processing fewer
-records. Only use day/week if needed, otherwise DateBin=month is preferred, and month is the value set if you pass no value for DateBin.
+records. If omitted, DateBin defaults to day.
 `.trim();
 
 const args = {
@@ -49,9 +49,7 @@ const args = {
   date_bin: z
     .enum(["day", "week", "month"])
     .optional()
-    .describe(
-      "Date binning for returned costs, default to month unless user says otherwise, allowed values: day, week, month"
-    ),
+    .describe("Date binning for returned costs. Defaults to day if omitted. Allowed values: day, week, month."),
   settings_include_credits: z
     .boolean()
     .optional()
@@ -106,8 +104,6 @@ export default registerTool({
     const requestParams: Record<string, unknown> = {
       limit: 1000,
     };
-    if (!args.date_bin) args.date_bin = "month";
-
     // Every arg we get needs to be in requestParams, but under 'settings' if it has that prefix.
     Object.keys(args).forEach((key) => {
       const typedKey = key as keyof typeof args;
@@ -143,7 +139,8 @@ export default registerTool({
           "Costs records represent one month, the accrued_at field is the first day of the month. If your date range is less than one month, this record includes only data for that date range, not the full month.";
         break;
       default:
-        throw new Error("Invalid date bin value");
+        notes = "Costs records represent one day.";
+        break;
     }
 
     return {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Omitted `date_bin` now yields finer-grained (day) data for workspace queries and can change row counts and agent-facing notes versus the previous month default.
> 
> **Overview**
> Stops the MCP layer from overriding Vantage’s **`date_bin`** behavior for cost reads. **`query-costs`** no longer sets **`date_bin`** to **`month`** when omitted; the parameter is left unset so the API defaults to **day**, and tool copy plus response **`notes`** reflect that. **`list-costs`** and **`list-unit-costs`** update descriptions and schema text to say that omitted **`date_bin`** follows the cost report’s configured bin (or **day**), and **`list-costs`** adds **`notes`** for the unspecified case instead of implying daily records only.
> 
> **`query-costs.test.ts`** expects **`date_bin: undefined`** on minimal API calls and daily **`notes`** when **`date_bin`** is omitted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c9e628a60f2bf47be257a97c5840c4a4eda0227. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->