### PR TITLE
fix: Pass DEFAULT_LIMIT on list-provider-resources

### DIFF
--- a/src/tools/list-provider-resources.test.ts
+++ b/src/tools/list-provider-resources.test.ts
@@ -1,6 +1,7 @@
 import type { GetReportResourcesResponse } from "@vantage-sh/vantage-client";
 import { expect } from "vitest";
 import tool from "./list-provider-resources";
+import { DEFAULT_LIMIT } from "./structure/constants";
 import {
   type ExecutionTestTableItem,
   type ExtractOutputSchema,
@@ -113,6 +114,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
           filter: undefined,
           workspace_token: undefined,
           include_cost: false,
+          limit: DEFAULT_LIMIT,
         },
         method: "GET",
         result: {
@@ -149,6 +151,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
           filter: "invalid VQL syntax",
           workspace_token: "wt_123",
           include_cost: false,
+          limit: DEFAULT_LIMIT,
         },
         method: "GET",
         result: {

--- a/src/tools/list-provider-resources.ts
+++ b/src/tools/list-provider-resources.ts
@@ -1,4 +1,5 @@
 import z from "zod";
+import { DEFAULT_LIMIT } from "./structure/constants";
 import MCPUserError from "./structure/MCPUserError";
 import registerTool from "./structure/registerTool";
 import paginationData from "./utils/paginationData";
@@ -124,7 +125,7 @@ export default registerTool({
     if (args.filter) {
       args.filter = correctResourceTypes(args.filter);
     }
-    const response = await ctx.callVantageApi("/v2/resources", args, "GET");
+    const response = await ctx.callVantageApi("/v2/resources", { ...args, limit: DEFAULT_LIMIT }, "GET");
     if (!response.ok) {
       throw new MCPUserError({ errors: response.errors });
     }


### PR DESCRIPTION
## Summary
- Send `limit: DEFAULT_LIMIT` (128) on `/v2/resources` requests from `list-provider-resources`
- Previously omitted `limit`, so the core API defaulted to 25/page and agents paginated ~5× more than other list tools

## Context
From Scout MCP analytics investigation ([ENG-2592](https://linear.app/vantage-sh/issue/ENG-2592)): `list-provider-resources` had up to 112 calls in a single conversation. The tool description mentioned pagination but never passed a page size.

## Test plan
- [x] `npm test -- src/tools/list-provider-resources.test.ts`

Made with [Cursor](https://cursor.com)