### PR TITLE
docs: Steer agents away from N+1 get-provider-resource calls

### DIFF
--- a/src/tools/get-provider-resource.ts
+++ b/src/tools/get-provider-resource.ts
@@ -6,6 +6,8 @@ import registerTool from "./structure/registerTool";
 const description = `
 Get detailed information about a specific provider resource using its token or UUID.
 
+Use this for one resource at a time. When you need many resources, prefer list-provider-resources instead—it returns batches and supports include_cost. Do not call this tool repeatedly for every resource from a list.
+
 This returns comprehensive details about the resource including:
 - Resource metadata (instance type, size, configuration, etc.)
 - Account and billing account information


### PR DESCRIPTION
## Summary
- Document that `get-provider-resource` is for single resources
- Direct agents to `list-provider-resources` (with `include_cost` when needed) for bulk lookups

## Context
Scout MCP analytics ([ENG-2592](https://linear.app/vantage-sh/issue/ENG-2592)) showed up to **282** `get-provider-resource` calls in one conversation—classic list-then-fetch-each anti-pattern.

## Test plan
- [x] `npm test -- src/tools/get-provider-resource.test.ts`

Made with [Cursor](https://cursor.com)