### PR TITLE
fix: Tighten list-audit-logs filters to match core API

### DIFF
--- a/src/tools/list-audit-logs.test.ts
+++ b/src/tools/list-audit-logs.test.ts
@@ -25,8 +25,8 @@ const validArguments: InferValidators<Validators> = {
   object_type: "cost_report" as const,
   token: "audit_123",
   object_token: "obj_123",
-  start_date: "2025-01-01T00:00:00Z",
-  end_date: "2025-01-31T23:59:59Z",
+  start_date: "2025-01-01",
+  end_date: "2025-01-31",
 };
 
 const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
@@ -115,8 +115,8 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
       object_type: undefined,
       token: undefined,
       object_token: undefined,
-      start_date: "2025-01-01T00:00:00Z",
-      end_date: "2025-01-31T23:59:59Z",
+      start_date: "2025-01-01",
+      end_date: "2025-01-31",
     },
   },
   {
@@ -132,7 +132,7 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
       object_type: undefined,
       token: undefined,
       object_token: undefined,
-      start_date: "2025-01-01T00:00:00Z",
+      start_date: "2025-01-01",
       end_date: undefined,
     },
   },
@@ -150,7 +150,7 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
       token: undefined,
       object_token: undefined,
       start_date: undefined,
-      end_date: "2025-01-31T23:59:59Z",
+      end_date: "2025-01-31",
     },
   },
   {
@@ -234,8 +234,8 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
       object_type: undefined,
       token: undefined,
       object_token: undefined,
-      start_date: "2025-01-01T00:00:00Z",
-      end_date: "2025-01-31T23:59:59Z",
+      start_date: "2025-01-01",
+      end_date: "2025-01-31",
     },
   },
   {
@@ -251,8 +251,8 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
       object_type: undefined,
       token: undefined,
       object_token: undefined,
-      start_date: "2025-01-01T00:00:00Z",
-      end_date: "2025-01-31T23:59:59Z",
+      start_date: "2025-01-01",
+      end_date: "2025-01-31",
     },
   },
   {
@@ -390,6 +390,43 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
       start_date: undefined,
       end_date: undefined,
     },
+  },
+  {
+    name: "invalid source developer",
+    data: {
+      ...validArguments,
+      source: "developer" as "api",
+    },
+    expectedIssues: ['Invalid option: expected one of "console"|"api"|"finops_agent"'],
+  },
+  {
+    name: "invalid object_type dashboard",
+    data: {
+      ...validArguments,
+      object_type: "dashboard" as "cost_report",
+    },
+    expectedIssues: [
+      'Invalid option: expected one of "virtual_tag"|"cost_report"|"recommendation_commitment"|"segment"',
+    ],
+  },
+  {
+    name: "invalid action",
+    data: {
+      ...validArguments,
+      action: "destroy" as "create",
+    },
+    expectedIssues: ['Invalid option: expected one of "create"|"update"|"delete"'],
+  },
+  {
+    name: "invalid start_date format",
+    data: {
+      ...validArguments,
+      start_date: "01-01-2025",
+      end_date: "2025-01-31",
+    },
+    expectedIssues: [
+      "Invalid date input, must be YYYY-MM-DD format and a reasonable date.",
+    ],
   },
 ];
 
@@ -602,8 +639,8 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
         endpoint: "/v2/audit_logs",
         params: {
           page: 1,
-          start_date: "2025-01-01T00:00:00Z",
-          end_date: "2025-01-31T23:59:59Z",
+          start_date: "2025-01-01",
+          end_date: "2025-01-31",
           limit: DEFAULT_LIMIT,
         },
         method: "GET",
@@ -625,8 +662,8 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
         object_type: undefined,
         token: undefined,
         object_token: undefined,
-        start_date: "2025-01-01T00:00:00Z",
-        end_date: "2025-01-31T23:59:59Z",
+        start_date: "2025-01-01",
+        end_date: "2025-01-31",
       });
       expect(res).toEqual({
         audit_logs: successData.audit_logs,
@@ -644,7 +681,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
         endpoint: "/v2/audit_logs",
         params: {
           page: 1,
-          start_date: "2025-01-01T00:00:00Z",
+          start_date: "2025-01-01",
           limit: DEFAULT_LIMIT,
         },
         method: "GET",
@@ -666,7 +703,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
         object_type: undefined,
         token: undefined,
         object_token: undefined,
-        start_date: "2025-01-01T00:00:00Z",
+        start_date: "2025-01-01",
         end_date: undefined,
       });
       expect(res).toEqual({
@@ -685,7 +722,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
         endpoint: "/v2/audit_logs",
         params: {
           page: 1,
-          end_date: "2025-01-31T23:59:59Z",
+          end_date: "2025-01-31",
           limit: DEFAULT_LIMIT,
         },
         method: "GET",
@@ -708,7 +745,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
         token: undefined,
         object_token: undefined,
         start_date: undefined,
-        end_date: "2025-01-31T23:59:59Z",
+        end_date: "2025-01-31",
       });
       expect(res).toEqual({
         audit_logs: successData.audit_logs,
@@ -851,8 +888,8 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
         params: {
           page: 1,
           user: 123,
-          start_date: "2025-01-01T00:00:00Z",
-          end_date: "2025-01-31T23:59:59Z",
+          start_date: "2025-01-01",
+          end_date: "2025-01-31",
           limit: DEFAULT_LIMIT,
         },
         method: "GET",
@@ -874,8 +911,8 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
         object_type: undefined,
         token: undefined,
         object_token: undefined,
-        start_date: "2025-01-01T00:00:00Z",
-        end_date: "2025-01-31T23:59:59Z",
+        start_date: "2025-01-01",
+        end_date: "2025-01-31",
       });
       expect(res).toEqual({
         audit_logs: successData.audit_logs,
@@ -894,8 +931,8 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
         params: {
           page: 1,
           action: "update",
-          start_date: "2025-01-01T00:00:00Z",
-          end_date: "2025-01-31T23:59:59Z",
+          start_date: "2025-01-01",
+          end_date: "2025-01-31",
           limit: DEFAULT_LIMIT,
         },
         method: "GET",
@@ -917,8 +954,8 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
         object_type: undefined,
         token: undefined,
         object_token: undefined,
-        start_date: "2025-01-01T00:00:00Z",
-        end_date: "2025-01-31T23:59:59Z",
+        start_date: "2025-01-01",
+        end_date: "2025-01-31",
       });
       expect(res).toEqual({
         audit_logs: successData.audit_logs,

--- a/src/tools/list-audit-logs.test.ts
+++ b/src/tools/list-audit-logs.test.ts
@@ -424,9 +424,7 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
       start_date: "01-01-2025",
       end_date: "2025-01-31",
     },
-    expectedIssues: [
-      "Invalid date input, must be YYYY-MM-DD format and a reasonable date.",
-    ],
+    expectedIssues: ["Invalid date input, must be YYYY-MM-DD format and a reasonable date."],
   },
 ];
 

--- a/src/tools/list-audit-logs.ts
+++ b/src/tools/list-audit-logs.ts
@@ -3,6 +3,16 @@ import { DEFAULT_LIMIT } from "./structure/constants";
 import MCPUserError from "./structure/MCPUserError";
 import registerTool from "./structure/registerTool";
 import paginationData from "./utils/paginationData";
+import dateValidator from "./utils/dateValidator";
+
+const AUDIT_LOG_ACTIONS = ["create", "update", "delete"] as const;
+const AUDIT_LOG_SOURCES = ["console", "api", "finops_agent"] as const;
+const AUDIT_LOG_OBJECT_TYPES = [
+  "virtual_tag",
+  "cost_report",
+  "recommendation_commitment",
+  "segment",
+] as const;
 
 const description = `
 List audit logs visible to the authenticated Vantage access token. Audit logs provide a chronological history of supported changes to user-facing resources in Vantage, such as cost reports, virtual tags, segments, recommendation commitments, and other workspace-related objects.
@@ -36,7 +46,7 @@ Audit logs can be filtered by:
 - \`object_name\`: exact object title
 - \`object_token\`: audited object token
 - \`source\`: \`console\`, \`api\`, or \`finops_agent\`
-- \`start_date\` and \`end_date\`: ISO 8601 dates such as \`2024-06-01\`
+- \`start_date\` and \`end_date\`: YYYY-MM-DD dates such as \`2024-06-01\`
 - \`token\`: audit log token
 
 Use cases for audit logs include:
@@ -59,24 +69,31 @@ const args = {
     .number()
     .int()
     .optional()
-    .describe("Filter by personal or service API token that performed the action (user ID)"),
+    .describe(
+      "Filter by numeric user ID (the user's database id). Do not pass email addresses or user tokens."
+    ),
   workspace_token: z.string().optional().describe("Filter by workspace token"),
-  action: z.string().optional().describe("Filter by action type (e.g., create, update, delete)"),
+  action: z
+    .enum(AUDIT_LOG_ACTIONS)
+    .optional()
+    .describe("Filter by action type: create, update, or delete."),
   object_name: z.string().optional().describe("Filter by object name"),
   source: z
-    .string()
+    .enum(AUDIT_LOG_SOURCES)
     .optional()
     .describe(
-      "Filter by source (e.g., console, api, developer, finops_agent). Use 'finops_agent' to filter for actions specifically taken by the Finops Agent."
+      "Filter by source: console, api, or finops_agent. Use finops_agent for actions taken by the FinOps Agent."
     ),
   object_type: z
-    .string()
+    .enum(AUDIT_LOG_OBJECT_TYPES)
     .optional()
-    .describe("Filter by object type (e.g., virtual_tag, cost_report, recommendation_commitment)."),
+    .describe(
+      "Filter by object type: cost_report, virtual_tag, recommendation_commitment, or segment. Other types (e.g. dashboard, budget) are not supported."
+    ),
   token: z.string().optional().describe("Filter by audit log token"),
   object_token: z.string().optional().describe("Filter by object token (auditable_token)"),
-  start_date: z.string().optional().describe("Filter by start date (ISO 8601 format) for the time period"),
-  end_date: z.string().optional().describe("Filter by end date (ISO 8601 format) for the time period"),
+  start_date: dateValidator("Filter by start date (YYYY-MM-DD, inclusive).").optional(),
+  end_date: dateValidator("Filter by end date (YYYY-MM-DD, inclusive).").optional(),
 };
 
 export default registerTool({

--- a/src/tools/list-audit-logs.ts
+++ b/src/tools/list-audit-logs.ts
@@ -2,17 +2,12 @@ import z from "zod";
 import { DEFAULT_LIMIT } from "./structure/constants";
 import MCPUserError from "./structure/MCPUserError";
 import registerTool from "./structure/registerTool";
-import paginationData from "./utils/paginationData";
 import dateValidator from "./utils/dateValidator";
+import paginationData from "./utils/paginationData";
 
 const AUDIT_LOG_ACTIONS = ["create", "update", "delete"] as const;
 const AUDIT_LOG_SOURCES = ["console", "api", "finops_agent"] as const;
-const AUDIT_LOG_OBJECT_TYPES = [
-  "virtual_tag",
-  "cost_report",
-  "recommendation_commitment",
-  "segment",
-] as const;
+const AUDIT_LOG_OBJECT_TYPES = ["virtual_tag", "cost_report", "recommendation_commitment", "segment"] as const;
 
 const description = `
 List audit logs visible to the authenticated Vantage access token. Audit logs provide a chronological history of supported changes to user-facing resources in Vantage, such as cost reports, virtual tags, segments, recommendation commitments, and other workspace-related objects.
@@ -69,14 +64,9 @@ const args = {
     .number()
     .int()
     .optional()
-    .describe(
-      "Filter by numeric user ID (the user's database id). Do not pass email addresses or user tokens."
-    ),
+    .describe("Filter by numeric user ID (the user's database id). Do not pass email addresses or user tokens."),
   workspace_token: z.string().optional().describe("Filter by workspace token"),
-  action: z
-    .enum(AUDIT_LOG_ACTIONS)
-    .optional()
-    .describe("Filter by action type: create, update, or delete."),
+  action: z.enum(AUDIT_LOG_ACTIONS).optional().describe("Filter by action type: create, update, or delete."),
   object_name: z.string().optional().describe("Filter by object name"),
   source: z
     .enum(AUDIT_LOG_SOURCES)


### PR DESCRIPTION
## Summary
- Enum `action`, `source`, and `object_type` to match `/v2/audit_logs` API
- Use shared `dateValidator` for `start_date` / `end_date` (YYYY-MM-DD)
- Fix `user` description (numeric user ID, not API token); remove invalid `developer` source

## Context
[ENG-2592](https://linear.app/vantage-sh/issue/ENG-2592) — `list-audit-logs` had 11%+ failure rate from schema/doc mismatches

## Test plan
- [x] `npm test -- src/tools/list-audit-logs.test.ts`

Made with [Cursor](https://cursor.com)