### PR TITLE
fix: Align tag MCP tools with core API

### DIFF
--- a/src/tools/list-tag-values.test.ts
+++ b/src/tools/list-tag-values.test.ts
@@ -18,6 +18,8 @@ type OutputSchema = ExtractOutputSchema<typeof tool>;
 const validArguments: InferValidators<Validators> = {
   key: "environment",
   page: 1,
+  search_query: undefined,
+  providers: undefined,
 };
 
 const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [

--- a/src/tools/list-tag-values.test.ts
+++ b/src/tools/list-tag-values.test.ts
@@ -1,4 +1,4 @@
-import { type GetTagValuesResponse, pathEncode } from "@vantage-sh/vantage-client";
+import { type GetTagValuesRequest, type GetTagValuesResponse, pathEncode } from "@vantage-sh/vantage-client";
 import { expect } from "vitest";
 import tool from "./list-tag-values";
 import { DEFAULT_LIMIT } from "./structure/constants";
@@ -28,6 +28,8 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
     data: {
       key: "",
       page: 1,
+      search_query: undefined,
+      providers: undefined,
     },
     expectedIssues: ["Too small: expected string to have >=1 characters"],
   },
@@ -55,7 +57,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
         params: {
           ...validArguments,
           limit: DEFAULT_LIMIT,
-        },
+        } as GetTagValuesRequest,
         method: "GET",
         result: {
           ok: true,
@@ -83,7 +85,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
           ...validArguments,
           page: 1,
           limit: DEFAULT_LIMIT,
-        },
+        } as GetTagValuesRequest,
         method: "GET",
         result: {
           ok: false,

--- a/src/tools/list-tag-values.ts
+++ b/src/tools/list-tag-values.ts
@@ -1,4 +1,4 @@
-import { pathEncode, type GetTagValuesRequest } from "@vantage-sh/vantage-client";
+import { type GetTagValuesRequest, pathEncode } from "@vantage-sh/vantage-client";
 import z from "zod";
 import { DEFAULT_LIMIT } from "./structure/constants";
 import MCPUserError from "./structure/MCPUserError";

--- a/src/tools/list-tag-values.ts
+++ b/src/tools/list-tag-values.ts
@@ -1,4 +1,4 @@
-import { pathEncode } from "@vantage-sh/vantage-client";
+import { pathEncode, type GetTagValuesRequest } from "@vantage-sh/vantage-client";
 import z from "zod";
 import { DEFAULT_LIMIT } from "./structure/constants";
 import MCPUserError from "./structure/MCPUserError";
@@ -33,7 +33,11 @@ export default registerTool({
   args,
   async execute(args, ctx) {
     const requestParams = { ...args, limit: DEFAULT_LIMIT };
-    const response = await ctx.callVantageApi(`/v2/tags/${pathEncode(args.key)}/values`, requestParams, "GET");
+    const response = await ctx.callVantageApi(
+      `/v2/tags/${pathEncode(args.key)}/values`,
+      requestParams as GetTagValuesRequest,
+      "GET"
+    );
     if (!response.ok) {
       throw new MCPUserError({ errors: response.errors });
     }

--- a/src/tools/list-tag-values.ts
+++ b/src/tools/list-tag-values.ts
@@ -6,12 +6,19 @@ import registerTool from "./structure/registerTool";
 import paginationData from "./utils/paginationData";
 
 const description = `
-Tags can have many values. Use this tool to find the values and service providers that are associated with a tag.
+List values for a tag key. The argument is \`key\` (the tag key name); the API response fields use \`tag_value\`.
+
+Requires integration settings permission; callers without it receive 403 from the API.
 `.trim();
 
 const args = {
   page: z.number().optional().default(1).describe("The page number to return, defaults to 1"),
-  key: z.string().min(1).describe("Tag key to list values for"),
+  key: z.string().min(1).describe("Tag key name to list values for (matches API path parameter `key`)"),
+  search_query: z.string().optional().describe("Search query to filter tag values by value name"),
+  providers: z
+    .array(z.string())
+    .optional()
+    .describe("Filter values to those present on the given cost providers (e.g. aws, azure, gcp)"),
 };
 
 export default registerTool({

--- a/src/tools/list-tags.test.ts
+++ b/src/tools/list-tags.test.ts
@@ -17,6 +17,8 @@ type OutputSchema = ExtractOutputSchema<typeof tool>;
 
 const validArguments: InferValidators<Validators> = {
   page: 1,
+  search_query: undefined,
+  providers: undefined,
 };
 
 const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
@@ -49,6 +51,8 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
         endpoint: "/v2/tags",
         params: {
           page: 1,
+          search_query: undefined,
+          providers: undefined,
           limit: DEFAULT_LIMIT,
         },
         method: "GET",
@@ -76,6 +80,8 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
         endpoint: "/v2/tags",
         params: {
           page: 1,
+          search_query: undefined,
+          providers: undefined,
           limit: DEFAULT_LIMIT,
         },
         method: "GET",

--- a/src/tools/list-tags.test.ts
+++ b/src/tools/list-tags.test.ts
@@ -26,6 +26,8 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
     name: "default page",
     data: {
       page: undefined,
+      search_query: undefined,
+      providers: undefined,
     },
   },
   {

--- a/src/tools/list-tags.ts
+++ b/src/tools/list-tags.ts
@@ -8,10 +8,18 @@ const description = `
 List tags that can be used to filter costs and cost reports.
 Tags are associated with one or more Cost Providers.
 Tags can be edited in the Vantage Web UI, or have further details displayed there. Link a user to the tag page like this: https://console.vantage.sh/settings/tags?search_query=<tag>
+
+Requires integration settings permission; callers without it receive 403 from the API.
+Each tag in the response uses the field \`tag_key\` (not \`key\`).
 `.trim();
 
 const args = {
   page: z.number().optional().default(1).describe("The page number to return, defaults to 1"),
+  search_query: z.string().optional().describe("Search query to filter tags by tag key name"),
+  providers: z
+    .array(z.string())
+    .optional()
+    .describe("Filter tags to those present on the given cost providers (e.g. aws, azure, gcp)"),
 };
 
 export default registerTool({

--- a/src/tools/list-tags.ts
+++ b/src/tools/list-tags.ts
@@ -1,5 +1,5 @@
-import z from "zod";
 import type { GetTagsRequest } from "@vantage-sh/vantage-client";
+import z from "zod";
 import { DEFAULT_LIMIT } from "./structure/constants";
 import MCPUserError from "./structure/MCPUserError";
 import registerTool from "./structure/registerTool";

--- a/src/tools/list-tags.ts
+++ b/src/tools/list-tags.ts
@@ -1,4 +1,5 @@
 import z from "zod";
+import type { GetTagsRequest } from "@vantage-sh/vantage-client";
 import { DEFAULT_LIMIT } from "./structure/constants";
 import MCPUserError from "./structure/MCPUserError";
 import registerTool from "./structure/registerTool";
@@ -34,7 +35,7 @@ export default registerTool({
   args,
   async execute(args, ctx) {
     const requestParams = { ...args, limit: DEFAULT_LIMIT };
-    const response = await ctx.callVantageApi("/v2/tags", requestParams, "GET");
+    const response = await ctx.callVantageApi("/v2/tags", requestParams as GetTagsRequest, "GET");
     if (!response.ok) {
       throw new MCPUserError({ errors: response.errors });
     }


### PR DESCRIPTION
## Summary
- Add optional `search_query` and `providers` to `list-tags` and `list-tag-values`
- Document `tag_key` in list response vs `key` argument for values
- Note integration-settings permission requirement (403 without it)

## Context
[ENG-2592](https://linear.app/vantage-sh/issue/ENG-2592) — `list-tags` / `list-tag-values` high failure rates

## Test plan
- [x] `npm test -- src/tools/list-tags.test.ts src/tools/list-tag-values.test.ts`

Made with [Cursor](https://cursor.com)