### PR TITLE
fix: Validate list-provider-resources filter constraints

### DIFF
--- a/src/tools/list-provider-resources.test.ts
+++ b/src/tools/list-provider-resources.test.ts
@@ -16,7 +16,7 @@ type OutputSchema = ExtractOutputSchema<typeof tool>;
 
 const validArguments: InferValidators<Validators> = {
   page: 1,
-  resource_report_token: undefined,
+  resource_report_token: "rr_123",
   filter: undefined,
   workspace_token: undefined,
   include_cost: false,
@@ -102,6 +102,51 @@ const successData: GetReportResourcesResponse = {
 };
 
 const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
+  {
+    name: "throws when filter is provided without workspace_token",
+    handler: async ({ callExpectingMCPUserError }) => {
+      const err = await callExpectingMCPUserError({
+        page: 1,
+        resource_report_token: undefined,
+        filter: "(resources.provider = 'aws')",
+        workspace_token: undefined,
+        include_cost: false,
+      });
+      expect(err.exception).toEqual({
+        errors: [{ message: "workspace_token is required when filter is provided" }],
+      });
+    },
+  },
+  {
+    name: "throws when both resource_report_token and filter are provided",
+    handler: async ({ callExpectingMCPUserError }) => {
+      const err = await callExpectingMCPUserError({
+        page: 1,
+        resource_report_token: "rr_123",
+        filter: "(resources.provider = 'aws')",
+        workspace_token: "wt_123",
+        include_cost: false,
+      });
+      expect(err.exception).toEqual({
+        errors: [{ message: "Provide either resource_report_token or filter, not both" }],
+      });
+    },
+  },
+  {
+    name: "throws when neither resource_report_token nor filter is provided",
+    handler: async ({ callExpectingMCPUserError }) => {
+      const err = await callExpectingMCPUserError({
+        page: 1,
+        resource_report_token: undefined,
+        filter: undefined,
+        workspace_token: undefined,
+        include_cost: false,
+      });
+      expect(err.exception).toEqual({
+        errors: [{ message: "Either resource_report_token or filter is required" }],
+      });
+    },
+  },
   {
     name: "successful call",
     apiCallHandler: requestsInOrder([

--- a/src/tools/list-provider-resources.ts
+++ b/src/tools/list-provider-resources.ts
@@ -9,6 +9,7 @@ Resources can be fetched either from a specific Resource Report or by using VQL 
 
 When using a resource_report_token, you get the pre-filtered resources from that report.
 When using VQL filters with workspace_token, you can dynamically query resources across your infrastructure.
+Provide either resource_report_token or filter (not both). When using filter, workspace_token is required.
 
 VQL for Resource Reports enables filtering using two primary namespaces:
 
@@ -121,6 +122,21 @@ export default registerTool({
       .describe("Include cost information broken down by category for each resource"),
   },
   async execute(args, ctx) {
+    if (!args.resource_report_token && !args.filter) {
+      throw new MCPUserError({
+        errors: [{ message: "Either resource_report_token or filter is required" }],
+      });
+    }
+    if (args.resource_report_token && args.filter) {
+      throw new MCPUserError({
+        errors: [{ message: "Provide either resource_report_token or filter, not both" }],
+      });
+    }
+    if (args.filter && !args.workspace_token) {
+      throw new MCPUserError({
+        errors: [{ message: "workspace_token is required when filter is provided" }],
+      });
+    }
     if (args.filter) {
       args.filter = correctResourceTypes(args.filter);
     }


### PR DESCRIPTION
## Summary
- Require `workspace_token` when `filter` is provided
- Reject providing both `resource_report_token` and `filter`
- Require one of `resource_report_token` or `filter`

## Context
[ENG-2592](https://linear.app/vantage-sh/issue/ENG-2592) — agents called with filter but no workspace_token

## Test plan
- [x] `npm test -- src/tools/list-provider-resources.test.ts`

Made with [Cursor](https://cursor.com)