### PR TITLE
docs: Fix query-costs groupings default description

### DIFF
--- a/src/tools/query-costs.ts
+++ b/src/tools/query-costs.ts
@@ -86,7 +86,7 @@ const args = {
     .array(z.string())
     .default(["provider", "service", "region"])
     .describe(
-      "Group the results by specific field(s). Defaults to provider, service, account_id. Valid groupings: account_id, billing_account_id, charge_type, cost_category, cost_subcategory, provider, region, resource_id, service, tagged, tag:<tag_value>. Let Groupings default unless explicitly asked for."
+      "Group the results by specific field(s). Defaults to provider, service, region. Valid groupings: account_id, billing_account_id, charge_type, cost_category, cost_subcategory, provider, region, resource_id, service, tagged, tag:<tag_value>. Let Groupings default unless explicitly asked for."
     ),
 };
 


### PR DESCRIPTION
## Summary
- Correct `groupings` description to match schema default: `provider`, `service`, `region`

## Context
[ENG-2592](https://linear.app/vantage-sh/issue/ENG-2592) — docs said `account_id` but default array uses `region`

## Test plan
- [x] `npm test -- src/tools/query-costs.test.ts`

Made with [Cursor](https://cursor.com)