### PR TITLE
docs: Note account owner requirement on get-users

### DIFF
--- a/src/tools/get-users.ts
+++ b/src/tools/get-users.ts
@@ -6,6 +6,8 @@ import paginationData from "./utils/paginationData";
 
 const description = `
 Return all Users that the user can see in the workspace.
+
+Requires account owner permissions; non-owners receive 403 from the API.
 `.trim();
 
 const args = {


### PR DESCRIPTION
## Summary
- Document that `get-users` requires account owner permissions (403 otherwise)

## Context
[ENG-2592](https://linear.app/vantage-sh/issue/ENG-2592) — agents call `get-users` without understanding RBAC

## Test plan
- [x] `npm test -- src/tools/get-users.test.ts`

Made with [Cursor](https://cursor.com)