### PR TITLE
Use report defaults for amortization settings (`list-costs` tool)

### DIFF
--- a/src/tools/list-costs.test.ts
+++ b/src/tools/list-costs.test.ts
@@ -18,15 +18,16 @@ type Validators = ExtractValidators<typeof tool>;
 type OutputSchema = ExtractOutputSchema<typeof tool>;
 
 const DEFAULT_GROUPINGS = "provider,service,account_id" as unknown as string[];
-const DEFAULT_SETTINGS_API = {
-  "settings[aggregate_by]": "cost",
-  "settings[amortize]": true,
-  "settings[include_credits]": false,
-  "settings[include_discounts]": true,
-  "settings[include_refunds]": false,
-  "settings[include_tax]": true,
-  "settings[show_previous_period]": true,
-  "settings[unallocated]": false,
+
+// Non-settings fields expected in every /v2/costs request.
+const baseApiParams = {
+  page: 1,
+  cost_report_token: "crt_123",
+  start_date: "2023-01-01",
+  end_date: "2023-01-31",
+  date_bin: "month" as const,
+  groupings: DEFAULT_GROUPINGS,
+  limit: DEFAULT_LIMIT,
 };
 
 const validArguments: InferValidators<Validators> = {
@@ -107,20 +108,11 @@ const successData: GetCostsResponse = {
 
 const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
   {
-    name: "successful call with month date_bin",
+    name: "successful call with month date_bin omits settings so API uses report defaults",
     apiCallHandler: requestsInOrder([
       {
         endpoint: "/v2/costs",
-        params: {
-          ...DEFAULT_SETTINGS_API,
-          cost_report_token: "crt_123",
-          start_date: "2023-01-01",
-          end_date: "2023-01-31",
-          date_bin: "month",
-          groupings: DEFAULT_GROUPINGS,
-          page: 1,
-          limit: DEFAULT_LIMIT,
-        },
+        params: baseApiParams,
         method: "GET",
         result: {
           ok: true,
@@ -148,11 +140,8 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
       {
         endpoint: "/v2/costs",
         params: {
-          ...validArguments,
-          ...DEFAULT_SETTINGS_API,
-          groupings: DEFAULT_GROUPINGS,
+          ...baseApiParams,
           date_bin: "day",
-          limit: DEFAULT_LIMIT,
         },
         method: "GET",
         result: {
@@ -175,11 +164,8 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
       {
         endpoint: "/v2/costs",
         params: {
-          ...validArguments,
-          ...DEFAULT_SETTINGS_API,
-          groupings: DEFAULT_GROUPINGS,
+          ...baseApiParams,
           date_bin: "week",
-          limit: DEFAULT_LIMIT,
         },
         method: "GET",
         result: {
@@ -199,19 +185,41 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
     },
   },
   {
+    name: "user-provided settings are sent to the API",
+    apiCallHandler: requestsInOrder([
+      {
+        endpoint: "/v2/costs",
+        params: {
+          ...baseApiParams,
+          "settings[amortize]": false,
+          "settings[include_credits]": true,
+        },
+        method: "GET",
+        result: {
+          ok: true,
+          data: successData,
+        },
+      },
+    ]),
+    handler: async ({ callExpectingSuccess }) => {
+      const res = await callExpectingSuccess({
+        ...validArguments,
+        settings_amortize: false,
+        settings_include_credits: true,
+      });
+      expect(res.costs).toEqual(successData.costs);
+    },
+  },
+  {
     name: "unsuccessful call",
     apiCallHandler: requestsInOrder([
       {
         endpoint: "/v2/costs",
         params: {
-          page: 1,
-          cost_report_token: "crt_123",
+          ...baseApiParams,
           start_date: undefined,
           end_date: undefined,
           date_bin: undefined,
-          limit: DEFAULT_LIMIT,
-          groupings: DEFAULT_GROUPINGS,
-          ...DEFAULT_SETTINGS_API,
         },
         method: "GET",
         result: {

--- a/src/tools/list-costs.ts
+++ b/src/tools/list-costs.ts
@@ -14,6 +14,9 @@ When DateBin=day you get a record for each service spend on that day. For DateBi
 with the accrued_at field set to the first day of the week, but the spend item represents spend for a full week.
 Same with DateBin=month, each record returned covers a month of data. This lets you get answers with processing fewer
 records. If omitted, the API uses the cost report's configured date bin, or day if the report has no override.
+
+Cost settings (credits, refunds, discounts, tax, amortization, etc.) default to the report's own settings.
+Only provide these parameters if you need to override the report's defaults.
 `.trim();
 
 const args = {
@@ -30,35 +33,37 @@ const args = {
   settings_include_credits: z
     .boolean()
     .optional()
-    .default(false)
-    .describe("Results will include credits, defaults to false"),
+    .describe("Results will include credits. If not provided, the report's setting is used."),
   settings_include_refunds: z
     .boolean()
     .optional()
-    .default(false)
-    .describe("Results will include refunds, defaults to false"),
+    .describe("Results will include refunds. If not provided, the report's setting is used."),
   settings_include_discounts: z
     .boolean()
     .optional()
-    .default(true)
-    .describe("Results will include discounts, defaults to true"),
-  settings_include_tax: z.boolean().optional().default(true).describe("Results will include tax, defaults to true"),
-  settings_amortize: z.boolean().optional().default(true).describe("Results will amortize, defaults to true"),
+    .describe("Results will include discounts. If not provided, the report's setting is used."),
+  settings_include_tax: z
+    .boolean()
+    .optional()
+    .describe("Results will include tax. If not provided, the report's setting is used."),
+  settings_amortize: z
+    .boolean()
+    .optional()
+    .describe("Results will amortize. If not provided, the report's setting is used."),
   settings_unallocated: z
     .boolean()
     .optional()
-    .default(false)
-    .describe("Results will show unallocated costs, defaults to false"),
+    .describe("Results will show unallocated costs. If not provided, the report's setting is used."),
   settings_aggregate_by: z
     .enum(["cost", "usage"])
     .optional()
-    .default("cost")
-    .describe("Results will aggregate by cost or usage, defaults to cost"),
+    .describe("Results will aggregate by cost or usage. If not provided, the report's setting is used."),
   settings_show_previous_period: z
     .boolean()
     .optional()
-    .default(true)
-    .describe("Results will show previous period costs or usage comparison, defaults to true"),
+    .describe(
+      "Results will show previous period costs or usage comparison. If not provided, the report's setting is used."
+    ),
   groupings: z
     .array(z.string())
     .default(["provider", "service", "account_id"])
@@ -78,19 +83,24 @@ export default registerTool({
   },
   args,
   async execute(args, ctx) {
-    // Every arg we get needs to be in requestParams, but under 'settings' if it has that prefix.
+    // Build request params. Settings that are not explicitly provided are left out
+    // so the API uses the cost report's own configured settings.
     const requestParams: Record<string, any> = {
       limit: DEFAULT_LIMIT,
     };
-    Object.keys(args).forEach((key) => {
+    for (const key of Object.keys(args)) {
       const typedKey = key as keyof typeof args;
       if (key.startsWith("settings_")) {
-        const keyWithoutPrefix = key.slice("settings_".length);
-        requestParams[`settings[${keyWithoutPrefix}]`] = args[typedKey];
+        const value = args[typedKey];
+        if (value !== undefined) {
+          const keyWithoutPrefix = key.slice("settings_".length);
+          requestParams[`settings[${keyWithoutPrefix}]`] = value;
+        }
       } else {
         requestParams[key] = args[typedKey];
       }
-    });
+    }
+
     // /v2/costs expects groupings as a comma-joined string (coerce_with: CSV::parse_line),
     // not the bracket-suffix array format used by other endpoints.
     if (Array.isArray(requestParams.groupings)) {


### PR DESCRIPTION
Previously, list-costs hardcoded default settings (e.g. amortize=true) regardless of the report's own configuration. Now the tool fetches the cost report first and uses its settings as defaults, only overriding when the caller explicitly provides a value. This ensures customers who disable amortization (or other settings) on their reports see consistent results from the agent.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default cost semantics for agent calls that previously always sent fixed settings, which can alter totals versus the UI unless callers explicitly override.
> 
> **Overview**
> **`list-costs` no longer injects hardcoded cost settings** (amortize, credits, tax, etc.) into `/v2/costs` requests. Those `settings_*` tool args are now truly optional: **only explicit caller values** are sent as `settings[...]` query params, so the API can apply the **cost report’s configured defaults**.
> 
> Tool docs and Zod schemas were updated to remove `.default(...)` on settings fields and to state that omitted settings follow the report. Tests were refactored to expect **no settings** on typical calls and to assert that **user-provided** settings (e.g. `settings_amortize: false`) are forwarded to the API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8d27468317a7d645cfb92d28d1975a971ea8e37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->