### PR TITLE
Use report's default amatorization settings when non provider as param (`query-costs`)

### DIFF
--- a/src/tools/query-costs.test.ts
+++ b/src/tools/query-costs.test.ts
@@ -18,6 +18,18 @@ type OutputSchema = ExtractOutputSchema<typeof tool>;
 // groupings is pre-joined to a CSV string for /v2/costs (coerce_with: CSV::parse_line)
 const GROUPINGS_API = "provider,service,region" as unknown as string[];
 
+// Non-settings fields expected in every /v2/costs request via query-costs.
+const baseApiParams = {
+  page: 1,
+  filter: "(costs.provider = 'aws')",
+  workspace_token: "wt_123",
+  start_date: "2023-01-01",
+  end_date: "2023-01-31",
+  date_bin: "month" as const,
+  groupings: GROUPINGS_API,
+  limit: 1000,
+};
+
 const validInputArguments = {
   page: 1,
   filter: "(costs.provider = 'aws')",
@@ -25,14 +37,14 @@ const validInputArguments = {
   end_date: "2023-01-31",
   workspace_token: "wt_123",
   date_bin: "month",
-  settings_include_credits: false,
-  settings_include_refunds: false,
-  settings_include_discounts: true,
-  settings_include_tax: true,
-  settings_amortize: true,
-  settings_unallocated: false,
-  settings_aggregate_by: "cost",
-  settings_show_previous_period: true,
+  settings_include_credits: undefined,
+  settings_include_refunds: undefined,
+  settings_include_discounts: undefined,
+  settings_include_tax: undefined,
+  settings_amortize: undefined,
+  settings_unallocated: undefined,
+  settings_aggregate_by: undefined,
+  settings_show_previous_period: undefined,
   groupings: ["provider", "service", "region"] as string[],
 } as const;
 
@@ -46,14 +58,14 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
       end_date: undefined,
       workspace_token: "wt_123",
       date_bin: undefined,
-      settings_include_credits: false,
-      settings_include_refunds: false,
-      settings_include_discounts: true,
-      settings_include_tax: true,
-      settings_amortize: true,
-      settings_unallocated: false,
-      settings_aggregate_by: "cost",
-      settings_show_previous_period: true,
+      settings_include_credits: undefined,
+      settings_include_refunds: undefined,
+      settings_include_discounts: undefined,
+      settings_include_tax: undefined,
+      settings_amortize: undefined,
+      settings_unallocated: undefined,
+      settings_aggregate_by: undefined,
+      settings_show_previous_period: undefined,
       groupings: ["provider", "service", "region"],
     },
   },
@@ -123,27 +135,15 @@ const successData: GetCostsResponse = {
 
 const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
   {
-    name: "successful call with minimal arguments",
+    name: "successful call omits settings so API uses workspace defaults",
     apiCallHandler: requestsInOrder([
       {
         endpoint: "/v2/costs",
         params: {
-          page: 1,
-          filter: "(costs.provider = 'aws')",
+          ...baseApiParams,
           start_date: undefined,
           end_date: undefined,
-          workspace_token: "wt_123",
           date_bin: undefined,
-          groupings: GROUPINGS_API,
-          "settings[include_credits]": false,
-          "settings[include_refunds]": false,
-          "settings[include_discounts]": true,
-          "settings[include_tax]": true,
-          "settings[amortize]": true,
-          "settings[unallocated]": false,
-          "settings[aggregate_by]": "cost",
-          "settings[show_previous_period]": true,
-          limit: 1000,
         },
         method: "GET",
         result: {
@@ -160,14 +160,14 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
         end_date: undefined,
         workspace_token: "wt_123",
         date_bin: undefined,
-        settings_include_credits: false,
-        settings_include_refunds: false,
-        settings_include_discounts: true,
-        settings_include_tax: true,
-        settings_amortize: true,
-        settings_unallocated: false,
-        settings_aggregate_by: "cost",
-        settings_show_previous_period: true,
+        settings_include_credits: undefined,
+        settings_include_refunds: undefined,
+        settings_include_discounts: undefined,
+        settings_include_tax: undefined,
+        settings_amortize: undefined,
+        settings_unallocated: undefined,
+        settings_aggregate_by: undefined,
+        settings_show_previous_period: undefined,
         groupings: ["provider", "service", "region"],
       });
       expect(res).toEqual({
@@ -182,18 +182,12 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
     },
   },
   {
-    name: "successful call with all arguments",
+    name: "successful call with all arguments and explicit settings",
     apiCallHandler: requestsInOrder([
       {
         endpoint: "/v2/costs",
         params: {
-          page: 1,
-          filter: "(costs.provider = 'aws')",
-          start_date: "2023-01-01",
-          end_date: "2023-01-31",
-          workspace_token: "wt_123",
-          date_bin: "month",
-          groupings: GROUPINGS_API,
+          ...baseApiParams,
           "settings[include_credits]": false,
           "settings[include_refunds]": false,
           "settings[include_discounts]": true,
@@ -202,7 +196,6 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
           "settings[unallocated]": false,
           "settings[aggregate_by]": "cost",
           "settings[show_previous_period]": true,
-          limit: 1000,
         },
         method: "GET",
         result: {
@@ -217,7 +210,17 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
       },
     ]),
     handler: async ({ callExpectingSuccess }) => {
-      const res = await callExpectingSuccess(validInputArguments);
+      const res = await callExpectingSuccess({
+        ...validInputArguments,
+        settings_include_credits: false,
+        settings_include_refunds: false,
+        settings_include_discounts: true,
+        settings_include_tax: true,
+        settings_amortize: true,
+        settings_unallocated: false,
+        settings_aggregate_by: "cost",
+        settings_show_previous_period: true,
+      });
       expect(res).toEqual({
         costs: successData.costs,
         total_cost: successData.total_cost,
@@ -236,22 +239,8 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
       {
         endpoint: "/v2/costs",
         params: {
-          page: 1,
-          filter: "(costs.provider = 'aws')",
-          start_date: "2023-01-01",
-          end_date: "2023-01-31",
-          workspace_token: "wt_123",
+          ...baseApiParams,
           date_bin: "day",
-          groupings: GROUPINGS_API,
-          "settings[include_credits]": false,
-          "settings[include_refunds]": false,
-          "settings[include_discounts]": true,
-          "settings[include_tax]": true,
-          "settings[amortize]": true,
-          "settings[unallocated]": false,
-          "settings[aggregate_by]": "cost",
-          "settings[show_previous_period]": true,
-          limit: 1000,
         },
         method: "GET",
         result: {
@@ -282,22 +271,10 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
       {
         endpoint: "/v2/costs",
         params: {
-          page: 1,
-          filter: "(costs.provider = 'aws')",
+          ...baseApiParams,
           start_date: undefined,
           end_date: undefined,
-          workspace_token: "wt_123",
           date_bin: undefined,
-          groupings: GROUPINGS_API,
-          "settings[include_credits]": false,
-          "settings[include_refunds]": false,
-          "settings[include_discounts]": true,
-          "settings[include_tax]": true,
-          "settings[amortize]": true,
-          "settings[unallocated]": false,
-          "settings[aggregate_by]": "cost",
-          "settings[show_previous_period]": true,
-          limit: 1000,
         },
         method: "GET",
         result: {
@@ -314,14 +291,14 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
         end_date: undefined,
         workspace_token: "wt_123",
         date_bin: undefined,
-        settings_include_credits: false,
-        settings_include_refunds: false,
-        settings_include_discounts: true,
-        settings_include_tax: true,
-        settings_amortize: true,
-        settings_unallocated: false,
-        settings_aggregate_by: "cost",
-        settings_show_previous_period: true,
+        settings_include_credits: undefined,
+        settings_include_refunds: undefined,
+        settings_include_discounts: undefined,
+        settings_include_tax: undefined,
+        settings_amortize: undefined,
+        settings_unallocated: undefined,
+        settings_aggregate_by: undefined,
+        settings_show_previous_period: undefined,
         groupings: ["provider", "service", "region"],
       });
       expect(err.exception).toEqual({

--- a/src/tools/query-costs.ts
+++ b/src/tools/query-costs.ts
@@ -38,6 +38,9 @@ When DateBin=day you get a record for each service spend on that day. For DateBi
 with the accrued_at field set to the first day of the week, but the spend item represents spend for a full week.
 Same with DateBin=month, each record returned covers a month of data. This lets you get answers with processing fewer
 records. If omitted, DateBin defaults to day.
+
+Cost settings (credits, refunds, discounts, tax, amortization, etc.) default to the workspace's default report settings.
+Only provide these parameters if you need to override those defaults.
 `.trim();
 
 const args = {
@@ -53,35 +56,39 @@ const args = {
   settings_include_credits: z
     .boolean()
     .optional()
-    .default(false)
-    .describe("Results will include credits, defaults to false"),
+    .describe("Results will include credits. If not provided, the workspace's default report setting is used."),
   settings_include_refunds: z
     .boolean()
     .optional()
-    .default(false)
-    .describe("Results will include refunds, defaults to false"),
+    .describe("Results will include refunds. If not provided, the workspace's default report setting is used."),
   settings_include_discounts: z
     .boolean()
     .optional()
-    .default(true)
-    .describe("Results will include discounts, defaults to true"),
-  settings_include_tax: z.boolean().optional().default(true).describe("Results will include tax, defaults to true"),
-  settings_amortize: z.boolean().optional().default(true).describe("Results will amortize, defaults to true"),
+    .describe("Results will include discounts. If not provided, the workspace's default report setting is used."),
+  settings_include_tax: z
+    .boolean()
+    .optional()
+    .describe("Results will include tax. If not provided, the workspace's default report setting is used."),
+  settings_amortize: z
+    .boolean()
+    .optional()
+    .describe("Results will amortize. If not provided, the workspace's default report setting is used."),
   settings_unallocated: z
     .boolean()
     .optional()
-    .default(false)
-    .describe("Results will show unallocated costs, defaults to false"),
+    .describe("Results will show unallocated costs. If not provided, the workspace's default report setting is used."),
   settings_aggregate_by: z
     .enum(["cost", "usage"])
     .optional()
-    .default("cost")
-    .describe("Results will aggregate by cost or usage, defaults to cost"),
+    .describe(
+      "Results will aggregate by cost or usage. If not provided, the workspace's default report setting is used."
+    ),
   settings_show_previous_period: z
     .boolean()
     .optional()
-    .default(true)
-    .describe("Results will show previous period costs or usage comparison, defaults to true"),
+    .describe(
+      "Results will show previous period costs or usage comparison. If not provided, the workspace's default report setting is used."
+    ),
   groupings: z
     .array(z.string())
     .default(["provider", "service", "region"])
@@ -101,19 +108,23 @@ export default registerTool({
   },
   args,
   async execute(args, ctx) {
+    // Build request params. Settings that are not explicitly provided are left out
+    // so the API uses the workspace's default report settings.
     const requestParams: Record<string, unknown> = {
       limit: 1000,
     };
-    // Every arg we get needs to be in requestParams, but under 'settings' if it has that prefix.
-    Object.keys(args).forEach((key) => {
+    for (const key of Object.keys(args)) {
       const typedKey = key as keyof typeof args;
       if (key.startsWith("settings_")) {
-        const keyWithoutPrefix = key.slice("settings_".length);
-        requestParams[`settings[${keyWithoutPrefix}]`] = args[typedKey];
+        const value = args[typedKey];
+        if (value !== undefined) {
+          const keyWithoutPrefix = key.slice("settings_".length);
+          requestParams[`settings[${keyWithoutPrefix}]`] = value;
+        }
       } else {
         requestParams[key] = args[typedKey];
       }
-    });
+    }
     // /v2/costs expects groupings as a comma-joined string (coerce_with: CSV::parse_line),
     // not the bracket-suffix array format used by other endpoints.
     if (Array.isArray(requestParams.groupings)) {


### PR DESCRIPTION
same fix as https://github.com/vantage-sh/vantage-mcp-server/pull/199

https://vantagesh.slack.com/archives/C07JTMG9WKX/p1782254846246769?thread_ts=1780443163.680589&cid=C07JTMG9WKX

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how cost totals are computed when agents omit settings; behavior should match the product UI but differs from the previous always-sent defaults.
> 
> **Overview**
> **`query-costs` no longer hard-codes report settings** (credits, refunds, discounts, tax, amortize, unallocated, aggregate_by, show_previous_period). Zod `.default()` values were removed so omitted tool arguments stay `undefined`, and the `/v2/costs` request builder **only adds `settings[...]` query params when the caller explicitly sets a value**. Unset settings are left off the request so the API applies the workspace’s default report settings.
> 
> Tool docs and parameter descriptions now state that behavior. Tests were updated with shared `baseApiParams`, expectations that minimal calls send **no** settings keys, and a separate case that still verifies explicit overrides are forwarded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62919e9d766a308aedccfd81ba0dca43cf96c66e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->