### PR TITLE
feat: Add query-costs retry guidance and empty-result hints

### DIFF
--- a/src/tools/list-cost-services.ts
+++ b/src/tools/list-cost-services.ts
@@ -3,7 +3,8 @@ import MCPUserError from "./structure/MCPUserError";
 import registerTool from "./structure/registerTool";
 
 const description = `
-List of cost services available to query for a given Workspace. Can be used to filter costs down to a specific service in VQL queries.
+List cost service display names for a workspace. These names may NOT match VQL costs.service identifiers used in query-costs filters.
+Do not copy names from this tool directly into VQL. Use vql_info (Scout) or costs.service values from a broad query-costs probe instead.
 `.trim();
 
 const args = {

--- a/src/tools/list-cost-services.ts
+++ b/src/tools/list-cost-services.ts
@@ -4,7 +4,7 @@ import registerTool from "./structure/registerTool";
 
 const description = `
 List cost service display names for a workspace. These names may NOT match VQL costs.service identifiers used in query-costs filters.
-Do not copy names from this tool directly into VQL. Use vql_info (Scout) or costs.service values from a broad query-costs probe instead.
+Do not copy names from this tool directly into VQL. Use vql_info or costs.service values from a broad query-costs probe instead.
 `.trim();
 
 const args = {

--- a/src/tools/query-costs.test.ts
+++ b/src/tools/query-costs.test.ts
@@ -266,6 +266,40 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
     },
   },
   {
+    name: "successful call with empty costs returns hint",
+    apiCallHandler: requestsInOrder([
+      {
+        endpoint: "/v2/costs",
+        params: {
+          ...baseApiParams,
+          filter: "(costs.provider = 'aws' AND costs.service = 'AmazonVPC')",
+          start_date: "2025-04-01",
+          end_date: "2025-05-31",
+        },
+        method: "GET",
+        result: {
+          ok: true,
+          data: {
+            costs: [],
+            total_cost: { amount: "0", currency: "USD" },
+            total_usage: {},
+            links: {},
+          },
+        },
+      },
+    ]),
+    handler: async ({ callExpectingSuccess }) => {
+      const res = await callExpectingSuccess({
+        ...validInputArguments,
+        filter: "(costs.provider = 'aws' AND costs.service = 'AmazonVPC')",
+        start_date: "2025-04-01",
+        end_date: "2025-05-31",
+      });
+      expect(res.costs).toEqual([]);
+      expect(res.hint).toContain("No cost rows matched");
+    },
+  },
+  {
     name: "unsuccessful call",
     apiCallHandler: requestsInOrder([
       {

--- a/src/tools/query-costs.ts
+++ b/src/tools/query-costs.ts
@@ -17,8 +17,11 @@ All costs originate from a Cost Provider (generally a cloud company like AWS, Az
 A cost provider is required on every VQL query.
 VQL is always in parenthesis. Always use single quotes around names that are being queried.
 To query on a cost provider, use this syntax: (costs.provider = '<provider name>'). The provider name must come from the list-cost-providers tool.
-To query on a cost service, use this syntax: (costs.provider = '<provider name>' AND costs.service = '<service name>'). The service name must come from the list-cost-services tool.
-For the AWS provider, always use short names for the services. example: Use 'AmazonEC2' not 'Amazon Elastic Compute Cloud' and 'AmazonRDS' not 'Amazon Relational Database Service'. Again the list-cost-services tool in this MCP can give accurate service names.
+To query on a cost service, use this syntax: (costs.provider = '<provider name>' AND costs.service = '<service name>').
+For AWS, costs.service must be a CUR identifier (e.g. 'AmazonEC2', 'AmazonVPC', 'AWSDirectConnect'). Use vql_info in Scout to resolve aliases — not display names from list-cost-services.
+If a query returns no rows, run one broad probe query first (provider only, date_bin=month, wide date range) to learn available months and service identifiers before retrying with a narrower filter.
+For month-over-month comparisons, span both months in start_date/end_date with date_bin=month and settings_show_previous_period=true instead of separate queries per month.
+Prefer one query-costs call with all needed groupings (e.g. service, account_id, tag:<key>) over multiple calls that only change groupings.
 You can only filter against one cost provider at a time. If you want to query for costs from two providers, you need to use the OR operator. Example: ((costs.provider = 'aws') OR (costs.provider = 'azure'))
 You can otherwise use the IN system to compare against a list of items, like this: (costs.provider = 'aws' AND costs.service IN ('AWSQueueService', 'AWSLambda'))
 To filter within a cost provider, keep the cost provider part and add a AND section, example: (costs.provider = 'aws' AND costs.service = 'AmazonRDS')
@@ -93,7 +96,7 @@ const args = {
     .array(z.string())
     .default(["provider", "service", "region"])
     .describe(
-      "Group the results by specific field(s). Defaults to provider, service, account_id. Valid groupings: account_id, billing_account_id, charge_type, cost_category, cost_subcategory, provider, region, resource_id, service, tagged, tag:<tag_value>. Let Groupings default unless explicitly asked for."
+      "Group the results by specific field(s). Defaults to provider, service, region. Valid groupings: account_id, billing_account_id, charge_type, cost_category, cost_subcategory, provider, region, resource_id, service, tagged, tag:<tag_value>. Include every grouping you need in one call rather than issuing separate calls per grouping."
     ),
 };
 
@@ -154,10 +157,17 @@ export default registerTool({
         break;
     }
 
+    const costs = response.data.costs;
+    const hint =
+      costs.length === 0
+        ? "No cost rows matched this filter and date range. Widen the date range, verify costs.service identifiers (vql_info in Scout or service values from a broad probe query), and avoid retrying with only a different groupings parameter."
+        : undefined;
+
     return {
-      costs: response.data.costs,
+      costs,
       total_cost: response.data.total_cost,
       notes,
+      ...(hint ? { hint } : {}),
       pagination: paginationData(response.data),
     };
   },

--- a/src/tools/query-costs.ts
+++ b/src/tools/query-costs.ts
@@ -18,7 +18,7 @@ A cost provider is required on every VQL query.
 VQL is always in parenthesis. Always use single quotes around names that are being queried.
 To query on a cost provider, use this syntax: (costs.provider = '<provider name>'). The provider name must come from the list-cost-providers tool.
 To query on a cost service, use this syntax: (costs.provider = '<provider name>' AND costs.service = '<service name>').
-For AWS, costs.service must be a CUR identifier (e.g. 'AmazonEC2', 'AmazonVPC', 'AWSDirectConnect'). Use vql_info in Scout to resolve aliases — not display names from list-cost-services.
+For AWS, costs.service must be a CUR identifier (e.g. 'AmazonEC2', 'AmazonVPC', 'AWSDirectConnect'). Use vql_info to resolve aliases — not display names from list-cost-services.
 If a query returns no rows, run one broad probe query first (provider only, date_bin=month, wide date range) to learn available months and service identifiers before retrying with a narrower filter.
 For month-over-month comparisons, span both months in start_date/end_date with date_bin=month and settings_show_previous_period=true instead of separate queries per month.
 Prefer one query-costs call with all needed groupings (e.g. service, account_id, tag:<key>) over multiple calls that only change groupings.
@@ -160,7 +160,7 @@ export default registerTool({
     const costs = response.data.costs;
     const hint =
       costs.length === 0
-        ? "No cost rows matched this filter and date range. Widen the date range, verify costs.service identifiers (vql_info in Scout or service values from a broad probe query), and avoid retrying with only a different groupings parameter."
+        ? "No cost rows matched this filter and date range. Widen the date range, verify costs.service identifiers (vql_info or service values from a broad probe query), and avoid retrying with only a different groupings parameter."
         : undefined;
 
     return {


### PR DESCRIPTION
## Summary
- Clarify in `list-cost-services` and `query-costs` that display names ≠ VQL `costs.service` identifiers; point agents to `vql_info` or probe queries instead.
- Add tool description guidance for probe-before-retry, month-over-month via `settings_show_previous_period`, and combining groupings in one call.
- Return a `hint` field when `query-costs` succeeds but returns zero rows, nudging agents away from blind retries.

Part of ENG-2592 remediation for Scout MCP tool call duplication.

## Test plan
- [x] `pnpm test src/tools/query-costs.test.ts src/tools/list-cost-services.test.ts`
- [ ] Deploy to staging and verify Scout gets `hint` on empty cost queries


Made with [Cursor](https://cursor.com)