### PR TITLE
fix: Make destructive hints consistent to specs.

### DIFF
--- a/src/tools/billing-rules/create-billing-rule.ts
+++ b/src/tools/billing-rules/create-billing-rule.ts
@@ -17,7 +17,7 @@ export default registerTool({
   title: "Create Billing Rule",
   description,
   annotations: {
-    destructive: true,
+    destructive: false,
     openWorld: false,
     readOnly: false,
   },

--- a/src/tools/budgets/create-budget.ts
+++ b/src/tools/budgets/create-budget.ts
@@ -13,7 +13,7 @@ export default registerTool({
   title: "Create Budget",
   description,
   annotations: {
-    destructive: true,
+    destructive: false,
     openWorld: false,
     readOnly: false,
   },

--- a/src/tools/canvases/update-canvas.ts
+++ b/src/tools/canvases/update-canvas.ts
@@ -12,7 +12,7 @@ export default registerTool({
   title: "Update Canvas",
   description,
   annotations: {
-    destructive: false,
+    destructive: true,
     openWorld: false,
     readOnly: false,
   },

--- a/src/tools/cost-reports/create-cost-report.ts
+++ b/src/tools/cost-reports/create-cost-report.ts
@@ -43,7 +43,7 @@ export default registerTool({
   title: "Create Cost Report",
   description,
   annotations: {
-    destructive: true,
+    destructive: false,
     openWorld: false,
     readOnly: false,
   },

--- a/src/tools/create-folder.ts
+++ b/src/tools/create-folder.ts
@@ -12,7 +12,7 @@ export default registerTool({
   title: "Create Folder",
   description,
   annotations: {
-    destructive: true,
+    destructive: false,
     openWorld: false,
     readOnly: false,
   },

--- a/src/tools/create-report-notification.ts
+++ b/src/tools/create-report-notification.ts
@@ -15,7 +15,7 @@ export default registerTool({
   title: "Create Report Notification",
   description,
   annotations: {
-    destructive: true,
+    destructive: false,
     openWorld: false,
     readOnly: false,
   },

--- a/src/tools/create-virtual-tag-config.ts
+++ b/src/tools/create-virtual-tag-config.ts
@@ -51,7 +51,7 @@ export default registerTool({
     values: z.array(valueSchema).optional(),
   },
   annotations: {
-    destructive: true,
+    destructive: false,
     openWorld: false,
     readOnly: false,
   },

--- a/src/tools/dashboards/create-dashboard.ts
+++ b/src/tools/dashboards/create-dashboard.ts
@@ -43,7 +43,7 @@ export default registerTool({
     date_interval: dateIntervalSchema,
   },
   annotations: {
-    destructive: true,
+    destructive: false,
     openWorld: false,
     readOnly: false,
   },

--- a/src/tools/financial-commitment-reports/create-financial-commitment-report.ts
+++ b/src/tools/financial-commitment-reports/create-financial-commitment-report.ts
@@ -35,7 +35,7 @@ export default registerTool({
   title: "Create Financial Commitment Report",
   description,
   annotations: {
-    destructive: true,
+    destructive: false,
     openWorld: false,
     readOnly: false,
   },

--- a/src/tools/recommendation-views/create-recommendation-view.ts
+++ b/src/tools/recommendation-views/create-recommendation-view.ts
@@ -27,7 +27,7 @@ export default registerTool({
   title: "Create Recommendation View",
   description,
   annotations: {
-    destructive: true,
+    destructive: false,
     openWorld: false,
     readOnly: false,
   },

--- a/src/tools/workspaces/update-workspace.ts
+++ b/src/tools/workspaces/update-workspace.ts
@@ -12,7 +12,7 @@ export default registerTool({
   title: "Update Workspace",
   description,
   annotations: {
-    destructive: false,
+    destructive: true,
     openWorld: false,
     readOnly: false,
   },


### PR DESCRIPTION
Aligns tool annotations with the `writing-mcp-tools` skill, the official MCP spec, and updated vendor (i.e., OpenAI and Anthropic) app submission criteria, by setting all `create-*` tools to `destructive: false` (creates are additive) and `update-canvas`/`update-workspace` to `destructive: true`, fixing 9 create tools that had drifted from the documented convention.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Annotation-only changes with no API or execute logic; risk is limited to how MCP hosts prompt or gate tool calls.
> 
> **Overview**
> Aligns MCP **`destructive`** annotations with the **`writing-mcp-tools`** skill and MCP spec so clients (and vendor app review) classify tools correctly.
> 
> **Nine `create-*` tools** (billing rules, budgets, cost reports, folders, report notifications, virtual tag configs, dashboards, financial commitment reports, recommendation views) are changed from **`destructive: true`** to **`destructive: false`**, treating creates as additive rather than destructive updates.
> 
> **`update-canvas`** and **`update-workspace`** flip from **`destructive: false`** to **`destructive: true`**, matching other **`update-*`** tools that modify existing state (including canvas prompt refresh and workspace currency settings).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3be482e66d5ea9df11383731d410f9a7167956a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->