### PR TITLE
Keep npm and GitHub tags/releases in sync

### DIFF
--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -84,5 +84,10 @@ jobs:
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
             git push origin "v$VERSION"
+          fi
+
+          if gh release view "v$VERSION" >/dev/null 2>&1; then
+            echo "Release v$VERSION already exists"
+          else
             gh release create "v$VERSION" --title "v$VERSION" --generate-notes --latest
           fi

--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -65,6 +65,8 @@ jobs:
         run: npm ci
 
       - name: Get the version and create a tag/publish if it doesn't exist
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           VERSION=$(npm run --silent print-version)
           if git tag -l "v$VERSION" | grep -q .; then
@@ -75,10 +77,12 @@ jobs:
             # Build the package and publish it
             npm run local:dist
             cd local-package && npm publish --provenance
+            cd ..
 
-            # Push the tag to the remote repository
+            # Push the tag and create a GitHub Release so Releases stay in sync with npm
             git tag "v$VERSION"
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
             git push origin "v$VERSION"
+            gh release create "v$VERSION" --title "v$VERSION" --generate-notes --latest
           fi

--- a/README.npmjs.md
+++ b/README.npmjs.md
@@ -1,0 +1,140 @@
+# `vantage-mcp-server`
+
+Self-hosted (local) MCP server that runs the same tools as the [hosted Vantage MCP](https://mcp.vantage.sh/mcp). Use this package when you need API-token auth without OAuth, or when you cannot reach the hosted endpoint.
+
+**Prefer the hosted MCP?** Most clients can connect to `https://mcp.vantage.sh/mcp` with OAuth instead. See the [repo README](https://github.com/vantage-sh/vantage-mcp-server) for those instructions.
+
+## Requirements
+
+- [Node.js 20+](https://nodejs.org/en/download)
+- A [Vantage API token](https://docs.vantage.sh/vantage_account#create-an-api-token)
+
+Set `VANTAGE_TOKEN` to your API token in the client config (examples below).
+
+## Claude Code
+
+```bash
+claude mcp add --transport stdio vantage --env VANTAGE_TOKEN=<your_vantage_api_token> -- npx -y vantage-mcp-server
+```
+
+## Codex
+
+```bash
+codex mcp add vantage --env VANTAGE_TOKEN=<your_vantage_api_token> -- npx -y vantage-mcp-server
+```
+
+## Cursor
+
+Open **Cursor Settings → Tools & MCP → New MCP Server** (or create `.cursor/mcp.json` in your project):
+
+```json
+{
+  "mcpServers": {
+    "Vantage": {
+      "command": "npx",
+      "args": ["-y", "vantage-mcp-server"],
+      "env": {
+        "VANTAGE_TOKEN": "<your_vantage_api_token>"
+      }
+    }
+  }
+}
+```
+
+## Visual Studio Code
+
+```json
+{
+  "mcpServers": {
+    "vantage": {
+      "command": "npx",
+      "args": ["-y", "vantage-mcp-server"],
+      "env": {
+        "VANTAGE_TOKEN": "<your_vantage_api_token>"
+      }
+    }
+  }
+}
+```
+
+Or use the command palette: **MCP: Add Server → Command (stdio)** and enter `npx -y vantage-mcp-server`, then set `VANTAGE_TOKEN` in the server env.
+
+## Windsurf
+
+Under **Cascade → MCP servers → Add custom server**:
+
+```json
+{
+  "mcpServers": {
+    "vantage": {
+      "command": "npx",
+      "args": ["-y", "vantage-mcp-server"],
+      "env": {
+        "VANTAGE_TOKEN": "<your_vantage_api_token>"
+      }
+    }
+  }
+}
+```
+
+## Zed
+
+In Zed settings:
+
+```json
+{
+  "context_servers": {
+    "vantage": {
+      "source": "custom",
+      "command": "npx",
+      "args": ["-y", "vantage-mcp-server"],
+      "env": {
+        "VANTAGE_TOKEN": "<your_vantage_api_token>"
+      }
+    }
+  }
+}
+```
+
+## Goose
+
+1. **Extensions → Add custom extension**
+2. **Type:** STDIO
+3. **Command:** `npx`
+4. **Args:** `-y vantage-mcp-server`
+5. Add environment variable `VANTAGE_TOKEN` with your API token
+
+## Claude Desktop
+
+**Settings → Developer → Edit Config**, then add:
+
+```json
+{
+  "mcpServers": {
+    "Vantage": {
+      "command": "npx",
+      "args": ["-y", "vantage-mcp-server"],
+      "env": {
+        "VANTAGE_TOKEN": "<your_vantage_api_token>"
+      }
+    }
+  }
+}
+```
+
+Restart Claude Desktop after saving.
+
+## Other clients
+
+For any stdio MCP client:
+
+- **Command:** `npx`
+- **Arguments:** `-y vantage-mcp-server`
+- **Env:** `VANTAGE_TOKEN=<your_vantage_api_token>`
+
+See the [MCP clients list](https://modelcontextprotocol.io/clients) and the [Vantage MCP documentation](https://docs.vantage.sh/vantage_mcp) for more clients and prompting examples.
+
+## Docs & source
+
+- [GitHub repository](https://github.com/vantage-sh/vantage-mcp-server)
+- [Vantage MCP docs](https://docs.vantage.sh/vantage_mcp)

--- a/build/npm.ts
+++ b/build/npm.ts
@@ -42,7 +42,7 @@ writeFileSync(
 chmodSync(join(__dirname, "../local-package/index.js"), 0o755);
 
 copyFileSync(
-    join(__dirname, "../README.local.md"),
+    join(__dirname, "../README.npmjs.md"),
     join(__dirname, "../local-package/README.md"),
 );
 

--- a/src/tools/structure/constants.ts
+++ b/src/tools/structure/constants.ts
@@ -1,2 +1,2 @@
 export const DEFAULT_LIMIT = 128;
-export const SERVER_VERSION = "2.15.1";
+export const SERVER_VERSION = "2.16.0";


### PR DESCRIPTION
## What Changed

Adding automatic creation of GitHub releases to our CI so the latest GitHub release matches the latest NPM release

Also fixed an issue I created when I deleted `README.local.md`. I did not realize that was being used for the NPM release. I added the file back at `README.npmjs.md`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI release automation, documentation, and a version constant; no runtime auth or API behavior changes.
> 
> **Overview**
> **Release housekeeping** now creates a matching **GitHub Release** for each published version (via `gh release create` with generated notes), with idempotent checks so existing tags/releases are skipped. The publish step also sets `GH_TOKEN` and returns to the repo root after `npm publish`.
> 
> **npm package docs** are restored by adding `README.npmjs.md` (client setup for `vantage-mcp-server`) and wiring `build/npm.ts` to copy it into `local-package/README.md` instead of the removed `README.local.md`.
> 
> **Version** bumped to `2.16.0` in `SERVER_VERSION`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de40e2b6adbf9163fe601f50605604a9dbbf66d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->