### PR TITLE
feat: Add workspace_token to update-dashboard

### DIFF
--- a/src/tools/dashboards/update-dashboard.test.ts
+++ b/src/tools/dashboards/update-dashboard.test.ts
@@ -24,6 +24,7 @@ const undefineds = {
   start_date: undefined,
   end_date: undefined,
   date_interval: undefined,
+  workspace_token: undefined,
 };
 
 const minimalValidInputArguments: InferValidators<Validators> = {

--- a/src/tools/dashboards/update-dashboard.ts
+++ b/src/tools/dashboards/update-dashboard.ts
@@ -29,6 +29,7 @@ export default registerTool({
     start_date: startDateSchema,
     end_date: endDateSchema,
     date_interval: updateDateIntervalSchema,
+    workspace_token: z.string().min(1).optional().describe("Move the dashboard to a different workspace."),
   },
   async execute(args, ctx) {
     const { dashboard_token, ...body } = args;


### PR DESCRIPTION
## Summary
- Add optional `workspace_token` to `update-dashboard` so dashboards can be moved between workspaces
- Update the unit test fixture for the new field

Extracted from `jeremy/van-1646-tool-updates-to-latest-api-spec`.

## Test plan
- [x] `npm test -- --run src/tools/dashboards/update-dashboard.test.ts`
- [x] Confirm schema accepts optional `workspace_token` and passes it through in the PATCH body


Made with [Cursor](https://cursor.com)