### PR TITLE
Don't need to send PII to Sentry

### DIFF
--- a/src/cf-worker.ts
+++ b/src/cf-worker.ts
@@ -201,7 +201,7 @@ const fetchHandler = async (request: Request, env: AppEnv, ctx: ExecutionContext
       release: versionId,
       // Adds request headers and IP for users, for more info visit:
       // https://docs.sentry.io/platforms/javascript/guides/cloudflare/configuration/options/#sendDefaultPii
-      sendDefaultPii: true,
+      sendDefaultPii: false,
 
       // Set tracesSampleRate to 1.0 to capture 100% of spans for tracing.
       // Learn more at


### PR DESCRIPTION
## What Changed

Remove sending any PII to Sentry. We only care about code crashes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Sentry config flag change with no auth or business-logic impact; slightly less diagnostic context in Sentry events.
> 
> **Overview**
> **Disables Sentry’s default PII collection** on the Cloudflare worker by setting `sendDefaultPii` to `false` in the `Sentry.withSentry` options in `cf-worker.ts`.
> 
> Crash and trace reporting (`dsn`, `release`, `tracesSampleRate`) is unchanged; Sentry will no longer automatically attach request headers and client IP that `sendDefaultPii: true` would have included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2b59683fcf93dfb012b5d7c1f00d7d3bf7d5b48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->