### PR TITLE
Add workflow dispatch to housekeeping

### DIFF
--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -1,5 +1,6 @@
 name: Housekeeping
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   generate-version-pr:
     name: Generate Version PR
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-22.04
     permissions:
       contents: write
@@ -44,6 +45,7 @@ jobs:
 
   publish:
     name: Publish Package and Auto Tag
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-22.04
     needs: generate-version-pr
     permissions:


### PR DESCRIPTION
## What Changed

Need to be able to trigger this manually, the last PR bump didn't work

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow trigger and guard changes; no application or publish logic was modified.
> 
> **Overview**
> **Manual runs:** The Housekeeping workflow can now be started from the Actions UI via `workflow_dispatch`, so version PR generation and publish can be retried without waiting for a `main` push.
> 
> **Safety on manual triggers:** Both `generate-version-pr` and `publish` now run only when `github.ref == 'refs/heads/main'`, so a manual run on another branch does not execute those jobs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c21ca41eaa7c598318b227cda8f3a324d768595. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->