### PR TITLE
fix: When add or update a biz metric on a report, set label or calculation_type value

### DIFF
--- a/src/tools/cost-reports/schemas.ts
+++ b/src/tools/cost-reports/schemas.ts
@@ -20,6 +20,7 @@ export const chartSettings = z.object({
 export const dateBins = ["cumulative", "day", "week", "month", "quarter", "hour"] as const;
 
 const businessMetricUnitScale = z.enum(["per_unit", "per_hundred", "per_thousand", "per_million", "per_billion"]);
+const businessMetricCalcuationType = z.enum(["unit_cost", "gross_margin", "usage_unit_cost", "raw_business_metric"])
 
 export const businessMetricTokenForCreate = z.object({
   business_metric_token: z.string().min(1).describe("The token of the BusinessMetric to attach to the CostReport."),
@@ -27,6 +28,8 @@ export const businessMetricTokenForCreate = z.object({
     .default("per_unit")
     .describe("Determines the scale of the BusinessMetric's values within the CostReport."),
   label_filter: z.array(z.string()).optional().describe("Include only values with these labels in the CostReport."),
+  label: z.string().optional().describe("An optional label for this business metric on this report."),
+  calculation_type: businessMetricCalcuationType.optional().describe("Calculation to apply to business metric value. Default: unit_cost")
 });
 
 export const businessMetricTokenForUpdate = z.object({
@@ -35,6 +38,8 @@ export const businessMetricTokenForUpdate = z.object({
     .optional()
     .describe("Determines the scale of the BusinessMetric's values within the CostReport."),
   label_filter: z.array(z.string()).optional().describe("Include only values with these labels in the CostReport."),
+  label: z.string().optional().describe("An optional label for this business metric on this report."),
+  calculation_type: businessMetricCalcuationType.optional().describe("Calculation to apply to business metric value. Default: unit_cost")
 });
 
 export const costReportSettingsForCreate = z.object({

--- a/src/tools/cost-reports/schemas.ts
+++ b/src/tools/cost-reports/schemas.ts
@@ -20,7 +20,7 @@ export const chartSettings = z.object({
 export const dateBins = ["cumulative", "day", "week", "month", "quarter", "hour"] as const;
 
 const businessMetricUnitScale = z.enum(["per_unit", "per_hundred", "per_thousand", "per_million", "per_billion"]);
-const businessMetricCalcuationType = z.enum(["unit_cost", "gross_margin", "usage_unit_cost", "raw_business_metric"])
+const businessMetricCalcuationType = z.enum(["unit_cost", "gross_margin", "usage_unit_cost", "raw_business_metric"]);
 
 export const businessMetricTokenForCreate = z.object({
   business_metric_token: z.string().min(1).describe("The token of the BusinessMetric to attach to the CostReport."),
@@ -29,7 +29,9 @@ export const businessMetricTokenForCreate = z.object({
     .describe("Determines the scale of the BusinessMetric's values within the CostReport."),
   label_filter: z.array(z.string()).optional().describe("Include only values with these labels in the CostReport."),
   label: z.string().optional().describe("An optional label for this business metric on this report."),
-  calculation_type: businessMetricCalcuationType.optional().describe("Calculation to apply to business metric value. Default: unit_cost")
+  calculation_type: businessMetricCalcuationType
+    .optional()
+    .describe("Calculation to apply to business metric value. Default: unit_cost"),
 });
 
 export const businessMetricTokenForUpdate = z.object({
@@ -39,7 +41,9 @@ export const businessMetricTokenForUpdate = z.object({
     .describe("Determines the scale of the BusinessMetric's values within the CostReport."),
   label_filter: z.array(z.string()).optional().describe("Include only values with these labels in the CostReport."),
   label: z.string().optional().describe("An optional label for this business metric on this report."),
-  calculation_type: businessMetricCalcuationType.optional().describe("Calculation to apply to business metric value. Default: unit_cost")
+  calculation_type: businessMetricCalcuationType
+    .optional()
+    .describe("Calculation to apply to business metric value. Default: unit_cost"),
 });
 
 export const costReportSettingsForCreate = z.object({


### PR DESCRIPTION
## Changes

Updates for new API values for the biz metrics new calculation project. 

## Validation

I ran the MCP Inspector to generate a update-cost-report tool call and set a biz metric on a report locally with the "raw" type and a label. It showed up on the report when I viewed in the console.

### Using the Inspector

<img width="732" height="384" alt="Screenshot 2026-07-20 at 4 34 25 PM" src="https://github.com/user-attachments/assets/50cb1384-5dc4-4273-a0b0-f6e023bd014d" />

### Seeing it on the report

<img width="644" height="576" alt="Screenshot 2026-07-20 at 4 37 00 PM" src="https://github.com/user-attachments/assets/523bff38-65a5-4900-862b-c78acf110512" />

### Context in the tools/list result that an LLM can read and understand the tools

<img width="1011" height="763" alt="Screenshot 2026-07-20 at 4 38 59 PM" src="https://github.com/user-attachments/assets/821c4591-7453-4458-b287-f81c9e6c099c" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema-only expansion for MCP cost report tools with optional fields and no auth or data-path changes.
> 
> **Overview**
> Extends cost report **business metric** validation so create/update payloads can pass optional **`label`** and **`calculation_type`** alongside existing token, unit scale, and label filter fields.
> 
> Adds a shared Zod enum for **`calculation_type`** (`unit_cost`, `gross_margin`, `usage_unit_cost`, `raw_business_metric`), documented as defaulting to `unit_cost` when omitted. Both **`businessMetricTokenForCreate`** and **`businessMetricTokenForUpdate`** in `schemas.ts` are updated; consumers like create/update cost report tools pick up the new fields through those schemas.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fa4f6d80a29e3c43421074bc3296b57afd56a7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->