### PR TITLE
feat: add business metric label support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
         "@cloudflare/workers-oauth-provider": "^0.0.11",
         "@modelcontextprotocol/sdk": "1.29.0",
         "@sentry/cloudflare": "10.30.0",
-        "@vantage-sh/vantage-client": "2.5.0",
+        "@vantage-sh/vantage-client": "2.6.0",
         "agents": "^0.13.2",
         "axios": "1.13.5",
         "hono": "4.12.12",
@@ -4127,9 +4127,9 @@
       }
     },
     "node_modules/@vantage-sh/vantage-client": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@vantage-sh/vantage-client/-/vantage-client-2.5.0.tgz",
-      "integrity": "sha512-+Ip1Lg6o3UjVXmIywgeJTgNvbd9NzIosHzQDCbAkjk/VxpLVf6M2pEVqcSOClVjPuWIFonsCNtJsxCkIgez3lg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@vantage-sh/vantage-client/-/vantage-client-2.6.0.tgz",
+      "integrity": "sha512-fttwe3HRqR2hu3u28bgsQ+gjXzJY0Br8Rkqrtnv3ZKj30LJR3EcFPyhj5YYH31PehU9tsAJCyJtxC1hQ+RLRQg==",
       "license": "MIT"
     },
     "node_modules/@vercel/oidc": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@cloudflare/workers-oauth-provider": "^0.0.11",
     "@modelcontextprotocol/sdk": "1.29.0",
     "@sentry/cloudflare": "10.30.0",
-    "@vantage-sh/vantage-client": "2.5.0",
+    "@vantage-sh/vantage-client": "2.6.0",
     "agents": "^0.13.2",
     "axios": "1.13.5",
     "hono": "4.12.12",

--- a/src/tools/business-metrics/get-business-metric-values.ts
+++ b/src/tools/business-metrics/get-business-metric-values.ts
@@ -2,11 +2,12 @@ import { pathEncode } from "@vantage-sh/vantage-client";
 import MCPUserError from "../structure/MCPUserError";
 import registerTool from "../structure/registerTool";
 import paginationData from "../utils/paginationData";
-import { BUSINESS_METRICS_LIMIT, businessMetricValueArgs } from "./schemas";
+import { BUSINESS_METRICS_LIMIT, historicalBusinessMetricValueArgs } from "./schemas";
 
 const description = `
 Get historical values for a BusinessMetric.
 Values are returned in descending date order by the Vantage API and can include optional labels.
+When a request depends on labels but exact values are not confirmed, call list-business-metric-labels first and pass the selected values through label_values. Skip label discovery when exact values are already supplied.
 Use start_date to limit results to values on or after a YYYY-MM-DD date.
 This endpoint is paginated. If the user asks for all values, complete data, or values for a date range such as a month, keep calling this tool with pagination.nextPage until pagination.hasNextPage is false before answering.
 The API only supports a start_date lower bound. For bounded ranges, such as a specific month, fetch all pages from the requested start date and then filter the returned values to the requested end date locally.
@@ -21,7 +22,7 @@ export default registerTool({
     openWorld: false,
     readOnly: true,
   },
-  args: businessMetricValueArgs,
+  args: historicalBusinessMetricValueArgs,
   async execute(args, ctx) {
     const { business_metric_token, ...params } = args;
     const requestParams = { ...params, limit: BUSINESS_METRICS_LIMIT };

--- a/src/tools/business-metrics/index.ts
+++ b/src/tools/business-metrics/index.ts
@@ -1,4 +1,5 @@
 import "./get-business-metric";
 import "./get-business-metric-forecasted-values";
 import "./get-business-metric-values";
+import "./list-business-metric-labels";
 import "./list-business-metrics";

--- a/src/tools/business-metrics/list-business-metric-labels.test.ts
+++ b/src/tools/business-metrics/list-business-metric-labels.test.ts
@@ -1,52 +1,63 @@
-import type { GetBusinessMetricValuesResponse } from "@vantage-sh/vantage-client";
-import { pathEncode } from "@vantage-sh/vantage-client";
+import {
+  type GetBusinessMetricLabelsRequest,
+  type GetBusinessMetricLabelsResponse,
+  pathEncode,
+} from "@vantage-sh/vantage-client";
 import { expect } from "vitest";
 import {
-  dateValidatorPoisoner,
   type ExecutionTestTableItem,
   type ExtractOutputSchema,
   type ExtractValidators,
   type InferValidators,
-  poisonOneValue,
   requestsInOrder,
   type SchemaTestTableItem,
   testTool,
 } from "../utils/testing";
-import tool from "./get-business-metric-values";
-import { BUSINESS_METRICS_LIMIT } from "./schemas";
+import tool from "./list-business-metric-labels";
 
 type Validators = ExtractValidators<typeof tool>;
 type OutputSchema = ExtractOutputSchema<typeof tool>;
 
 const validArguments: InferValidators<Validators> = {
   business_metric_token: "bsnss_mtrc_3080a050c04104ff",
-  label_values: ["Prod", "Staging"],
   page: 1,
-  start_date: "2024-01-01",
 };
 
 const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
   {
-    name: "default page and start date",
+    name: "default page",
     data: {
       business_metric_token: "bsnss_mtrc_3080a050c04104ff",
-      label_values: undefined,
       page: undefined,
-      start_date: undefined,
     },
+  },
+  {
+    name: "blank business metric token",
+    data: {
+      business_metric_token: "",
+      page: 1,
+    },
+    expectedIssues: ["Too small: expected string to have >=1 characters"],
+  },
+  {
+    name: "page must be positive",
+    data: {
+      business_metric_token: "bsnss_mtrc_3080a050c04104ff",
+      page: 0,
+    },
+    expectedIssues: ["Too small: expected number to be >=1"],
   },
   {
     name: "valid arguments",
     data: validArguments,
   },
-  poisonOneValue<Validators, string>(validArguments, "start_date", dateValidatorPoisoner),
 ];
 
-const successData: GetBusinessMetricValuesResponse = {
-  values: [
-    { date: "2024-01-03T00:00:00Z", amount: "300.0", label: "Prod" },
-    { date: "2024-01-02T00:00:00Z", amount: "200.0" },
-  ],
+const successData: GetBusinessMetricLabelsResponse = {
+  labels: [{ value: "Enterprise" }, { value: "Prod" }, { value: "Staging" }],
+  links: {
+    next: "https://api.vantage.sh/v2/business_metrics/bsnss_mtrc_3080a050c04104ff/labels?page=2",
+  },
 };
 
 const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
@@ -54,13 +65,11 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
     name: "successful call",
     apiCallHandler: requestsInOrder([
       {
-        endpoint: `/v2/business_metrics/${pathEncode("bsnss_mtrc_3080a050c04104ff")}/values`,
+        endpoint: `/v2/business_metrics/${pathEncode(validArguments.business_metric_token)}/labels`,
         params: {
-          label_values: ["Prod", "Staging"],
           page: 1,
-          start_date: "2024-01-01",
-          limit: BUSINESS_METRICS_LIMIT,
-        },
+          limit: 5000,
+        } as GetBusinessMetricLabelsRequest,
         method: "GET",
         result: {
           ok: true,
@@ -71,10 +80,10 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
     handler: async ({ callExpectingSuccess }) => {
       const res = await callExpectingSuccess(validArguments);
       expect(res).toEqual({
-        values: successData.values,
+        labels: successData.labels,
         pagination: {
-          hasNextPage: false,
-          nextPage: 0,
+          hasNextPage: true,
+          nextPage: 2,
         },
       });
     },
@@ -83,13 +92,11 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
     name: "encodes token in path",
     apiCallHandler: requestsInOrder([
       {
-        endpoint: `/v2/business_metrics/${pathEncode("bsnss_mtrc_with/slash")}/values`,
+        endpoint: `/v2/business_metrics/${pathEncode("bsnss_mtrc_with/slash")}/labels`,
         params: {
-          label_values: undefined,
           page: 1,
-          start_date: undefined,
-          limit: BUSINESS_METRICS_LIMIT,
-        },
+          limit: 5000,
+        } as GetBusinessMetricLabelsRequest,
         method: "GET",
         result: {
           ok: true,
@@ -98,18 +105,9 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
       },
     ]),
     handler: async ({ callExpectingSuccess }) => {
-      const res = await callExpectingSuccess({
+      await callExpectingSuccess({
         business_metric_token: "bsnss_mtrc_with/slash",
-        label_values: undefined,
         page: 1,
-        start_date: undefined,
-      });
-      expect(res).toEqual({
-        values: successData.values,
-        pagination: {
-          hasNextPage: false,
-          nextPage: 0,
-        },
       });
     },
   },
@@ -117,13 +115,11 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
     name: "unsuccessful call",
     apiCallHandler: requestsInOrder([
       {
-        endpoint: `/v2/business_metrics/${pathEncode("bsnss_mtrc_nonexistent")}/values`,
+        endpoint: `/v2/business_metrics/${pathEncode("bsnss_mtrc_nonexistent")}/labels`,
         params: {
-          label_values: ["Prod", "Staging"],
           page: 1,
-          start_date: "2024-01-01",
-          limit: BUSINESS_METRICS_LIMIT,
-        },
+          limit: 5000,
+        } as GetBusinessMetricLabelsRequest,
         method: "GET",
         result: {
           ok: false,
@@ -133,8 +129,8 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
     ]),
     handler: async ({ callExpectingMCPUserError }) => {
       const err = await callExpectingMCPUserError({
-        ...validArguments,
         business_metric_token: "bsnss_mtrc_nonexistent",
+        page: 1,
       });
       expect(err.exception).toEqual({
         errors: [{ message: "Business Metric not found" }],

--- a/src/tools/business-metrics/list-business-metric-labels.ts
+++ b/src/tools/business-metrics/list-business-metric-labels.ts
@@ -1,0 +1,48 @@
+import { type GetBusinessMetricLabelsRequest, pathEncode } from "@vantage-sh/vantage-client";
+import z from "zod";
+import MCPUserError from "../structure/MCPUserError";
+import registerTool from "../structure/registerTool";
+import paginationData from "../utils/paginationData";
+import { BUSINESS_METRIC_LABELS_LIMIT } from "./schemas";
+
+const description = `
+List distinct label values for a BusinessMetric. For multi-label metrics, values are flattened across label keys.
+Use this before get-business-metric-values when a label-dependent request does not provide confirmed exact label values.
+This endpoint is paginated. If the user needs the complete set of labels, keep calling this tool with pagination.nextPage until pagination.hasNextPage is false.
+`.trim();
+
+const args = {
+  business_metric_token: z
+    .string()
+    .min(1)
+    .describe("The BusinessMetric token to list label values for. Use list-business-metrics to discover."),
+  page: z.number().int().min(1).optional().default(1).describe("The page number to return, defaults to 1."),
+};
+
+export default registerTool({
+  name: "list-business-metric-labels",
+  title: "List Business Metric Labels",
+  description,
+  annotations: {
+    destructive: false,
+    openWorld: false,
+    readOnly: true,
+  },
+  args,
+  async execute(args, ctx) {
+    const { business_metric_token, ...params } = args;
+    const requestParams = { ...params, limit: BUSINESS_METRIC_LABELS_LIMIT };
+    const response = await ctx.callVantageApi(
+      `/v2/business_metrics/${pathEncode(business_metric_token)}/labels`,
+      requestParams as GetBusinessMetricLabelsRequest,
+      "GET"
+    );
+    if (!response.ok) {
+      throw new MCPUserError({ errors: response.errors });
+    }
+    return {
+      labels: response.data.labels,
+      pagination: paginationData(response.data),
+    };
+  },
+});

--- a/src/tools/business-metrics/list-business-metrics.ts
+++ b/src/tools/business-metrics/list-business-metrics.ts
@@ -8,7 +8,7 @@ const description = `
 List all BusinessMetrics available to the current Vantage API token.
 Use page 1 when calling this tool for the first time. If the user asks for all BusinessMetrics or needs to search across the full set, keep calling this tool with pagination.nextPage until pagination.hasNextPage is false.
 BusinessMetrics represent business KPIs, such as requests, users, or revenue, that can be attached to Cost Reports for per-unit cost analysis.
-The token of a BusinessMetric can be used with get-business-metric, get-business-metric-values, and get-business-metric-forecasted-values.
+The token of a BusinessMetric can be used with get-business-metric, list-business-metric-labels, get-business-metric-values, and get-business-metric-forecasted-values.
 `.trim();
 
 const args = {

--- a/src/tools/business-metrics/schemas.ts
+++ b/src/tools/business-metrics/schemas.ts
@@ -2,6 +2,7 @@ import z from "zod";
 import dateValidator from "../utils/dateValidator";
 
 export const BUSINESS_METRICS_LIMIT = 1000;
+export const BUSINESS_METRIC_LABELS_LIMIT = 5000;
 
 export const businessMetricValueArgs = {
   business_metric_token: z.string().describe("The BusinessMetric token to retrieve values for."),
@@ -9,4 +10,14 @@ export const businessMetricValueArgs = {
   start_date: dateValidator(
     "Query BusinessMetric values by the first date to filter from. Must be YYYY-MM-DD format."
   ).optional(),
+};
+
+export const historicalBusinessMetricValueArgs = {
+  ...businessMetricValueArgs,
+  label_values: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Return values matching any exact label value. For multi-label metrics, matches values under any label key. If exact values are not confirmed, call list-business-metric-labels first."
+    ),
 };


### PR DESCRIPTION
## Summary
- add `list-business-metric-labels` for discovering exact label values before filtering historical values
- add `label_values` filtering to `get-business-metric-values` without exposing it on forecasted values
- upgrade `@vantage-sh/vantage-client` to 2.6.0

## Testing
- `npm run type-check`
- `npm run lint`
- `npm test -- --run` (810 tests)

## Follow-up
- add the required tool-selection eval after the eval harness in #170 lands

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only MCP tools and optional query parameters; forecasted-values path is untouched and tests cover the new behavior.
> 
> **Overview**
> Adds **business metric label** support so agents can discover valid label strings and filter historical values, backed by `@vantage-sh/vantage-client` **2.6.0**.
> 
> A new read-only MCP tool **`list-business-metric-labels`** calls `GET /v2/business_metrics/{token}/labels` (paginated, limit 5000) and is registered in the business-metrics index. **`get-business-metric-values`** now accepts optional **`label_values`** via `historicalBusinessMetricValueArgs`, forwards them to the values API, and its tool description steers callers to list labels when exact values are unknown. **`get-business-metric-forecasted-values`** is unchanged and still uses the base args without `label_values`. **`list-business-metrics`** docs mention the new tool.
> 
> Tests cover the new tool and updated expectations for `label_values` on historical values requests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a622068736769188d3bbe990a01f1d26a1035f8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->