### PR TITLE
fix: Request full business metric value pages

### DIFF
--- a/src/tools/business-metrics/get-business-metric-forecasted-values.test.ts
+++ b/src/tools/business-metrics/get-business-metric-forecasted-values.test.ts
@@ -13,7 +13,6 @@ import {
   testTool,
 } from "../utils/testing";
 import tool from "./get-business-metric-forecasted-values";
-import { BUSINESS_METRICS_LIMIT } from "./schemas";
 
 type Validators = ExtractValidators<typeof tool>;
 type OutputSchema = ExtractOutputSchema<typeof tool>;
@@ -56,7 +55,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
         params: {
           page: 1,
           start_date: "2025-01-01",
-          limit: BUSINESS_METRICS_LIMIT,
+          limit: 5000,
         },
         method: "GET",
         result: {
@@ -84,7 +83,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
         params: {
           page: 1,
           start_date: undefined,
-          limit: BUSINESS_METRICS_LIMIT,
+          limit: 5000,
         },
         method: "GET",
         result: {
@@ -116,7 +115,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
         params: {
           page: 1,
           start_date: "2025-01-01",
-          limit: BUSINESS_METRICS_LIMIT,
+          limit: 5000,
         },
         method: "GET",
         result: {

--- a/src/tools/business-metrics/get-business-metric-forecasted-values.test.ts
+++ b/src/tools/business-metrics/get-business-metric-forecasted-values.test.ts
@@ -13,6 +13,7 @@ import {
   testTool,
 } from "../utils/testing";
 import tool from "./get-business-metric-forecasted-values";
+import { BUSINESS_METRIC_DATA_LIMIT } from "./schemas";
 
 type Validators = ExtractValidators<typeof tool>;
 type OutputSchema = ExtractOutputSchema<typeof tool>;
@@ -55,7 +56,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
         params: {
           page: 1,
           start_date: "2025-01-01",
-          limit: 5000,
+          limit: BUSINESS_METRIC_DATA_LIMIT,
         },
         method: "GET",
         result: {
@@ -83,7 +84,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
         params: {
           page: 1,
           start_date: undefined,
-          limit: 5000,
+          limit: BUSINESS_METRIC_DATA_LIMIT,
         },
         method: "GET",
         result: {
@@ -115,7 +116,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
         params: {
           page: 1,
           start_date: "2025-01-01",
-          limit: 5000,
+          limit: BUSINESS_METRIC_DATA_LIMIT,
         },
         method: "GET",
         result: {

--- a/src/tools/business-metrics/get-business-metric-forecasted-values.ts
+++ b/src/tools/business-metrics/get-business-metric-forecasted-values.ts
@@ -2,7 +2,7 @@ import { pathEncode } from "@vantage-sh/vantage-client";
 import MCPUserError from "../structure/MCPUserError";
 import registerTool from "../structure/registerTool";
 import paginationData from "../utils/paginationData";
-import { BUSINESS_METRIC_VALUES_LIMIT, businessMetricValueArgs } from "./schemas";
+import { BUSINESS_METRIC_DATA_LIMIT, businessMetricValueArgs } from "./schemas";
 
 const description = `
 Get forecasted values for a BusinessMetric.
@@ -24,7 +24,7 @@ export default registerTool({
   args: businessMetricValueArgs,
   async execute(args, ctx) {
     const { business_metric_token, ...params } = args;
-    const requestParams = { ...params, limit: BUSINESS_METRIC_VALUES_LIMIT };
+    const requestParams = { ...params, limit: BUSINESS_METRIC_DATA_LIMIT };
     const response = await ctx.callVantageApi(
       `/v2/business_metrics/${pathEncode(business_metric_token)}/forecasted_values`,
       requestParams,

--- a/src/tools/business-metrics/get-business-metric-forecasted-values.ts
+++ b/src/tools/business-metrics/get-business-metric-forecasted-values.ts
@@ -2,7 +2,7 @@ import { pathEncode } from "@vantage-sh/vantage-client";
 import MCPUserError from "../structure/MCPUserError";
 import registerTool from "../structure/registerTool";
 import paginationData from "../utils/paginationData";
-import { BUSINESS_METRICS_LIMIT, businessMetricValueArgs } from "./schemas";
+import { BUSINESS_METRIC_VALUES_LIMIT, businessMetricValueArgs } from "./schemas";
 
 const description = `
 Get forecasted values for a BusinessMetric.
@@ -24,7 +24,7 @@ export default registerTool({
   args: businessMetricValueArgs,
   async execute(args, ctx) {
     const { business_metric_token, ...params } = args;
-    const requestParams = { ...params, limit: BUSINESS_METRICS_LIMIT };
+    const requestParams = { ...params, limit: BUSINESS_METRIC_VALUES_LIMIT };
     const response = await ctx.callVantageApi(
       `/v2/business_metrics/${pathEncode(business_metric_token)}/forecasted_values`,
       requestParams,

--- a/src/tools/business-metrics/get-business-metric-values.test.ts
+++ b/src/tools/business-metrics/get-business-metric-values.test.ts
@@ -13,6 +13,7 @@ import {
   testTool,
 } from "../utils/testing";
 import tool from "./get-business-metric-values";
+import { BUSINESS_METRIC_DATA_LIMIT } from "./schemas";
 
 type Validators = ExtractValidators<typeof tool>;
 type OutputSchema = ExtractOutputSchema<typeof tool>;
@@ -58,7 +59,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
           label_values: ["Prod", "Staging"],
           page: 1,
           start_date: "2024-01-01",
-          limit: 5000,
+          limit: BUSINESS_METRIC_DATA_LIMIT,
         },
         method: "GET",
         result: {
@@ -87,7 +88,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
           label_values: undefined,
           page: 1,
           start_date: undefined,
-          limit: 5000,
+          limit: BUSINESS_METRIC_DATA_LIMIT,
         },
         method: "GET",
         result: {
@@ -121,7 +122,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
           label_values: ["Prod", "Staging"],
           page: 1,
           start_date: "2024-01-01",
-          limit: 5000,
+          limit: BUSINESS_METRIC_DATA_LIMIT,
         },
         method: "GET",
         result: {

--- a/src/tools/business-metrics/get-business-metric-values.test.ts
+++ b/src/tools/business-metrics/get-business-metric-values.test.ts
@@ -13,7 +13,6 @@ import {
   testTool,
 } from "../utils/testing";
 import tool from "./get-business-metric-values";
-import { BUSINESS_METRICS_LIMIT } from "./schemas";
 
 type Validators = ExtractValidators<typeof tool>;
 type OutputSchema = ExtractOutputSchema<typeof tool>;
@@ -59,7 +58,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
           label_values: ["Prod", "Staging"],
           page: 1,
           start_date: "2024-01-01",
-          limit: BUSINESS_METRICS_LIMIT,
+          limit: 5000,
         },
         method: "GET",
         result: {
@@ -88,7 +87,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
           label_values: undefined,
           page: 1,
           start_date: undefined,
-          limit: BUSINESS_METRICS_LIMIT,
+          limit: 5000,
         },
         method: "GET",
         result: {
@@ -122,7 +121,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
           label_values: ["Prod", "Staging"],
           page: 1,
           start_date: "2024-01-01",
-          limit: BUSINESS_METRICS_LIMIT,
+          limit: 5000,
         },
         method: "GET",
         result: {

--- a/src/tools/business-metrics/get-business-metric-values.ts
+++ b/src/tools/business-metrics/get-business-metric-values.ts
@@ -2,7 +2,7 @@ import { pathEncode } from "@vantage-sh/vantage-client";
 import MCPUserError from "../structure/MCPUserError";
 import registerTool from "../structure/registerTool";
 import paginationData from "../utils/paginationData";
-import { BUSINESS_METRIC_VALUES_LIMIT, historicalBusinessMetricValueArgs } from "./schemas";
+import { BUSINESS_METRIC_DATA_LIMIT, historicalBusinessMetricValueArgs } from "./schemas";
 
 const description = `
 Get historical values for a BusinessMetric.
@@ -25,7 +25,7 @@ export default registerTool({
   args: historicalBusinessMetricValueArgs,
   async execute(args, ctx) {
     const { business_metric_token, ...params } = args;
-    const requestParams = { ...params, limit: BUSINESS_METRIC_VALUES_LIMIT };
+    const requestParams = { ...params, limit: BUSINESS_METRIC_DATA_LIMIT };
     const response = await ctx.callVantageApi(
       `/v2/business_metrics/${pathEncode(business_metric_token)}/values`,
       requestParams,

--- a/src/tools/business-metrics/get-business-metric-values.ts
+++ b/src/tools/business-metrics/get-business-metric-values.ts
@@ -2,7 +2,7 @@ import { pathEncode } from "@vantage-sh/vantage-client";
 import MCPUserError from "../structure/MCPUserError";
 import registerTool from "../structure/registerTool";
 import paginationData from "../utils/paginationData";
-import { BUSINESS_METRICS_LIMIT, historicalBusinessMetricValueArgs } from "./schemas";
+import { BUSINESS_METRIC_VALUES_LIMIT, historicalBusinessMetricValueArgs } from "./schemas";
 
 const description = `
 Get historical values for a BusinessMetric.
@@ -25,7 +25,7 @@ export default registerTool({
   args: historicalBusinessMetricValueArgs,
   async execute(args, ctx) {
     const { business_metric_token, ...params } = args;
-    const requestParams = { ...params, limit: BUSINESS_METRICS_LIMIT };
+    const requestParams = { ...params, limit: BUSINESS_METRIC_VALUES_LIMIT };
     const response = await ctx.callVantageApi(
       `/v2/business_metrics/${pathEncode(business_metric_token)}/values`,
       requestParams,

--- a/src/tools/business-metrics/list-business-metric-labels.test.ts
+++ b/src/tools/business-metrics/list-business-metric-labels.test.ts
@@ -14,6 +14,7 @@ import {
   testTool,
 } from "../utils/testing";
 import tool from "./list-business-metric-labels";
+import { BUSINESS_METRIC_DATA_LIMIT } from "./schemas";
 
 type Validators = ExtractValidators<typeof tool>;
 type OutputSchema = ExtractOutputSchema<typeof tool>;
@@ -68,7 +69,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
         endpoint: `/v2/business_metrics/${pathEncode(validArguments.business_metric_token)}/labels`,
         params: {
           page: 1,
-          limit: 5000,
+          limit: BUSINESS_METRIC_DATA_LIMIT,
         } as GetBusinessMetricLabelsRequest,
         method: "GET",
         result: {
@@ -95,7 +96,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
         endpoint: `/v2/business_metrics/${pathEncode("bsnss_mtrc_with/slash")}/labels`,
         params: {
           page: 1,
-          limit: 5000,
+          limit: BUSINESS_METRIC_DATA_LIMIT,
         } as GetBusinessMetricLabelsRequest,
         method: "GET",
         result: {
@@ -118,7 +119,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
         endpoint: `/v2/business_metrics/${pathEncode("bsnss_mtrc_nonexistent")}/labels`,
         params: {
           page: 1,
-          limit: 5000,
+          limit: BUSINESS_METRIC_DATA_LIMIT,
         } as GetBusinessMetricLabelsRequest,
         method: "GET",
         result: {

--- a/src/tools/business-metrics/list-business-metric-labels.ts
+++ b/src/tools/business-metrics/list-business-metric-labels.ts
@@ -3,7 +3,7 @@ import z from "zod";
 import MCPUserError from "../structure/MCPUserError";
 import registerTool from "../structure/registerTool";
 import paginationData from "../utils/paginationData";
-import { BUSINESS_METRIC_LABELS_LIMIT } from "./schemas";
+import { BUSINESS_METRIC_DATA_LIMIT } from "./schemas";
 
 const description = `
 List distinct label values for a BusinessMetric. For multi-label metrics, values are flattened across label keys.
@@ -31,7 +31,7 @@ export default registerTool({
   args,
   async execute(args, ctx) {
     const { business_metric_token, ...params } = args;
-    const requestParams = { ...params, limit: BUSINESS_METRIC_LABELS_LIMIT };
+    const requestParams = { ...params, limit: BUSINESS_METRIC_DATA_LIMIT };
     const response = await ctx.callVantageApi(
       `/v2/business_metrics/${pathEncode(business_metric_token)}/labels`,
       requestParams as GetBusinessMetricLabelsRequest,

--- a/src/tools/business-metrics/list-business-metrics.test.ts
+++ b/src/tools/business-metrics/list-business-metrics.test.ts
@@ -10,7 +10,7 @@ import {
   testTool,
 } from "../utils/testing";
 import tool from "./list-business-metrics";
-import { BUSINESS_METRICS_LIMIT } from "./schemas";
+import { BUSINESS_METRICS_LIST_LIMIT } from "./schemas";
 
 type Validators = ExtractValidators<typeof tool>;
 type OutputSchema = ExtractOutputSchema<typeof tool>;
@@ -69,7 +69,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
         endpoint: "/v2/business_metrics",
         params: {
           page: 1,
-          limit: BUSINESS_METRICS_LIMIT,
+          limit: BUSINESS_METRICS_LIST_LIMIT,
         },
         method: "GET",
         result: {
@@ -96,7 +96,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
         endpoint: "/v2/business_metrics",
         params: {
           page: 1,
-          limit: BUSINESS_METRICS_LIMIT,
+          limit: BUSINESS_METRICS_LIST_LIMIT,
         },
         method: "GET",
         result: {

--- a/src/tools/business-metrics/list-business-metrics.ts
+++ b/src/tools/business-metrics/list-business-metrics.ts
@@ -2,7 +2,7 @@ import z from "zod";
 import MCPUserError from "../structure/MCPUserError";
 import registerTool from "../structure/registerTool";
 import paginationData from "../utils/paginationData";
-import { BUSINESS_METRICS_LIMIT } from "./schemas";
+import { BUSINESS_METRICS_LIST_LIMIT } from "./schemas";
 
 const description = `
 List all BusinessMetrics available to the current Vantage API token.
@@ -26,7 +26,7 @@ export default registerTool({
   },
   args,
   async execute(args, ctx) {
-    const requestParams = { ...args, limit: BUSINESS_METRICS_LIMIT };
+    const requestParams = { ...args, limit: BUSINESS_METRICS_LIST_LIMIT };
     const response = await ctx.callVantageApi("/v2/business_metrics", requestParams, "GET");
     if (!response.ok) {
       throw new MCPUserError({ errors: response.errors });

--- a/src/tools/business-metrics/schemas.ts
+++ b/src/tools/business-metrics/schemas.ts
@@ -1,8 +1,9 @@
 import z from "zod";
 import dateValidator from "../utils/dateValidator";
 
-export const BUSINESS_METRICS_LIMIT = 1000;
+export const BUSINESS_METRICS_LIST_LIMIT = 1000;
 export const BUSINESS_METRIC_LABELS_LIMIT = 5000;
+export const BUSINESS_METRIC_VALUES_LIMIT = 5000;
 
 export const businessMetricValueArgs = {
   business_metric_token: z.string().describe("The BusinessMetric token to retrieve values for."),

--- a/src/tools/business-metrics/schemas.ts
+++ b/src/tools/business-metrics/schemas.ts
@@ -2,8 +2,7 @@ import z from "zod";
 import dateValidator from "../utils/dateValidator";
 
 export const BUSINESS_METRICS_LIST_LIMIT = 1000;
-export const BUSINESS_METRIC_LABELS_LIMIT = 5000;
-export const BUSINESS_METRIC_VALUES_LIMIT = 5000;
+export const BUSINESS_METRIC_DATA_LIMIT = 5000;
 
 export const businessMetricValueArgs = {
   business_metric_token: z.string().describe("The BusinessMetric token to retrieve values for."),


### PR DESCRIPTION
## Summary
- request the Vantage API's 5,000-item limit for historical and forecasted Business Metric values
- separate list and value limit constants so listing Business Metrics remains at its existing limit
- assert the explicit 5,000-item request in focused value tool tests

## Test plan
- [x] `npm test -- --run src/tools/business-metrics`
- [x] `npm test -- --run`
- [x] `npm run type-check`
- [x] `npm run lint`

Made with [Cursor](https://cursor.com)