### PR TITLE
Default business metric values to monthly bins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
         "@cloudflare/workers-oauth-provider": "^0.0.11",
         "@modelcontextprotocol/sdk": "1.29.0",
         "@sentry/cloudflare": "10.30.0",
-        "@vantage-sh/vantage-client": "2.6.0",
+        "@vantage-sh/vantage-client": "2.8.0",
         "agents": "^0.13.2",
         "axios": "1.13.5",
         "hono": "4.12.12",
@@ -4127,9 +4127,9 @@
       }
     },
     "node_modules/@vantage-sh/vantage-client": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@vantage-sh/vantage-client/-/vantage-client-2.6.0.tgz",
-      "integrity": "sha512-fttwe3HRqR2hu3u28bgsQ+gjXzJY0Br8Rkqrtnv3ZKj30LJR3EcFPyhj5YYH31PehU9tsAJCyJtxC1hQ+RLRQg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@vantage-sh/vantage-client/-/vantage-client-2.8.0.tgz",
+      "integrity": "sha512-JzHfRaZ81TcoIHXae7hp+jwq8ccbipaUG26/oFZvNriLeAAG5Iki7nN+ldLc5VsZSvrzc/Atc/CkBkhJe3ayqg==",
       "license": "MIT"
     },
     "node_modules/@vercel/oidc": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@cloudflare/workers-oauth-provider": "^0.0.11",
     "@modelcontextprotocol/sdk": "1.29.0",
     "@sentry/cloudflare": "10.30.0",
-    "@vantage-sh/vantage-client": "2.6.0",
+    "@vantage-sh/vantage-client": "2.8.0",
     "agents": "^0.13.2",
     "axios": "1.13.5",
     "hono": "4.12.12",

--- a/src/tools/business-metrics/get-business-metric-values.test.ts
+++ b/src/tools/business-metrics/get-business-metric-values.test.ts
@@ -20,6 +20,7 @@ type OutputSchema = ExtractOutputSchema<typeof tool>;
 
 const validArguments: InferValidators<Validators> = {
   business_metric_token: "bsnss_mtrc_3080a050c04104ff",
+  date_bin: "day",
   label_values: ["Prod", "Staging"],
   page: 1,
   start_date: "2024-01-01",
@@ -30,6 +31,7 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
     name: "default page and start date",
     data: {
       business_metric_token: "bsnss_mtrc_3080a050c04104ff",
+      date_bin: undefined,
       label_values: undefined,
       page: undefined,
       start_date: undefined,
@@ -38,6 +40,14 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
   {
     name: "valid arguments",
     data: validArguments,
+  },
+  {
+    name: "invalid date bin",
+    data: {
+      ...validArguments,
+      date_bin: "week" as any,
+    },
+    expectedIssues: ['Invalid option: expected one of "raw"|"day"|"month"'],
   },
   poisonOneValue<Validators, string>(validArguments, "start_date", dateValidatorPoisoner),
 ];
@@ -56,6 +66,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
       {
         endpoint: `/v2/business_metrics/${pathEncode("bsnss_mtrc_3080a050c04104ff")}/values`,
         params: {
+          date_bin: "day",
           label_values: ["Prod", "Staging"],
           page: 1,
           start_date: "2024-01-01",
@@ -85,6 +96,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
       {
         endpoint: `/v2/business_metrics/${pathEncode("bsnss_mtrc_with/slash")}/values`,
         params: {
+          date_bin: "month",
           label_values: undefined,
           page: 1,
           start_date: undefined,
@@ -100,6 +112,42 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
     handler: async ({ callExpectingSuccess }) => {
       const res = await callExpectingSuccess({
         business_metric_token: "bsnss_mtrc_with/slash",
+        date_bin: undefined,
+        label_values: undefined,
+        page: 1,
+        start_date: undefined,
+      });
+      expect(res).toEqual({
+        values: successData.values,
+        pagination: {
+          hasNextPage: false,
+          nextPage: 0,
+        },
+      });
+    },
+  },
+  {
+    name: "preserves raw timestamps",
+    apiCallHandler: requestsInOrder([
+      {
+        endpoint: `/v2/business_metrics/${pathEncode("bsnss_mtrc_3080a050c04104ff")}/values`,
+        params: {
+          label_values: undefined,
+          page: 1,
+          start_date: undefined,
+          limit: BUSINESS_METRIC_DATA_LIMIT,
+        },
+        method: "GET",
+        result: {
+          ok: true,
+          data: successData,
+        },
+      },
+    ]),
+    handler: async ({ callExpectingSuccess }) => {
+      const res = await callExpectingSuccess({
+        business_metric_token: "bsnss_mtrc_3080a050c04104ff",
+        date_bin: "raw",
         label_values: undefined,
         page: 1,
         start_date: undefined,
@@ -119,6 +167,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
       {
         endpoint: `/v2/business_metrics/${pathEncode("bsnss_mtrc_nonexistent")}/values`,
         params: {
+          date_bin: "day",
           label_values: ["Prod", "Staging"],
           page: 1,
           start_date: "2024-01-01",

--- a/src/tools/business-metrics/get-business-metric-values.ts
+++ b/src/tools/business-metrics/get-business-metric-values.ts
@@ -6,6 +6,7 @@ import { BUSINESS_METRIC_DATA_LIMIT, historicalBusinessMetricValueArgs } from ".
 
 const description = `
 Get historical values for a BusinessMetric.
+Values default to monthly sums grouped by label. Use day for daily sums or raw to preserve original timestamps, including hourly values; binned sums may not suit gauges or percentages.
 Values are returned in descending date order by the Vantage API and can include optional labels.
 When a request depends on labels but exact values are not confirmed, call list-business-metric-labels first and pass the selected values through label_values. Skip label discovery when exact values are already supplied.
 Use start_date to limit results to values on or after a YYYY-MM-DD date.
@@ -24,8 +25,12 @@ export default registerTool({
   },
   args: historicalBusinessMetricValueArgs,
   async execute(args, ctx) {
-    const { business_metric_token, ...params } = args;
-    const requestParams = { ...params, limit: BUSINESS_METRIC_DATA_LIMIT };
+    const { business_metric_token, date_bin, ...params } = args;
+    const requestParams = {
+      ...params,
+      ...(date_bin === "raw" ? {} : { date_bin }),
+      limit: BUSINESS_METRIC_DATA_LIMIT,
+    };
     const response = await ctx.callVantageApi(
       `/v2/business_metrics/${pathEncode(business_metric_token)}/values`,
       requestParams,

--- a/src/tools/business-metrics/schemas.ts
+++ b/src/tools/business-metrics/schemas.ts
@@ -14,6 +14,13 @@ export const businessMetricValueArgs = {
 
 export const historicalBusinessMetricValueArgs = {
   ...businessMetricValueArgs,
+  date_bin: z
+    .enum(["raw", "day", "month"])
+    .optional()
+    .default("month")
+    .describe(
+      "Time aggregation. Defaults to month. Day and month sum amounts by UTC bucket and label; raw preserves original timestamps, including hourly values. Use raw for gauges or percentages when summing is not appropriate."
+    ),
   label_values: z
     .array(z.string())
     .optional()


### PR DESCRIPTION
## Summary
- default `get-business-metric-values` to monthly sums grouped by label
- expose `day` and `raw` overrides, with guidance for hourly values, gauges, and percentages
- update the Vantage client to 2.8.0 for the new API parameter types

## Test plan
- [x] `npm run type-check`
- [x] `npm run lint`
- [x] `npm test -- --run` (812 tests)


Made with [Cursor](https://cursor.com)