### PR TITLE
feat: Add count aggregate support to costs MCP tools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
         "@cloudflare/workers-oauth-provider": "^0.0.11",
         "@modelcontextprotocol/sdk": "1.29.0",
         "@sentry/cloudflare": "10.30.0",
-        "@vantage-sh/vantage-client": "2.8.0",
+        "@vantage-sh/vantage-client": "2.10.0",
         "agents": "^0.13.2",
         "axios": "1.13.5",
         "hono": "4.12.12",
@@ -4102,9 +4102,9 @@
       }
     },
     "node_modules/@vantage-sh/vantage-client": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@vantage-sh/vantage-client/-/vantage-client-2.8.0.tgz",
-      "integrity": "sha512-JzHfRaZ81TcoIHXae7hp+jwq8ccbipaUG26/oFZvNriLeAAG5Iki7nN+ldLc5VsZSvrzc/Atc/CkBkhJe3ayqg==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@vantage-sh/vantage-client/-/vantage-client-2.10.0.tgz",
+      "integrity": "sha512-/XmP6tjEjNA7L3RS7sehDJqBtdKiVZ0CNkn1Qn89dDKf0IN/mLSwXRwFe/m8og1An7mntHZE4oWUYc3P21Rikg==",
       "license": "MIT"
     },
     "node_modules/@vercel/oidc": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@cloudflare/workers-oauth-provider": "^0.0.11",
     "@modelcontextprotocol/sdk": "1.29.0",
     "@sentry/cloudflare": "10.30.0",
-    "@vantage-sh/vantage-client": "2.8.0",
+    "@vantage-sh/vantage-client": "2.10.0",
     "agents": "^0.13.2",
     "axios": "1.13.5",
     "hono": "4.12.12",

--- a/src/tools/cost-reports/create-cost-report.test.ts
+++ b/src/tools/cost-reports/create-cost-report.test.ts
@@ -356,6 +356,64 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
     },
   },
   {
+    name: "partial settings with count y-axis omits aggregate_by so API can sync modes",
+    apiCallHandler: requestsInOrder([
+      {
+        endpoint: "/v2/cost_reports",
+        params: {
+          title: "Count Report",
+          end_date: "2025-02-01",
+          previous_period_end_date: "2025-01-31",
+          settings: {
+            include_credits: true,
+            include_refunds: false,
+            include_discounts: true,
+            include_tax: true,
+            amortize: true,
+            unallocated: false,
+            show_previous_period: true,
+            complete_period: false,
+          },
+          chart_settings: {
+            y_axis_dimension: "count",
+          },
+        },
+        method: "POST",
+        result: {
+          ok: true,
+          data: {
+            ...minSuccess,
+            title: "Count Report",
+            chart_settings: {
+              y_axis_dimension: "count" as const,
+              x_axis_dimension: ["date"],
+            },
+          },
+        },
+      },
+    ]),
+    handler: async ({ callExpectingSuccess }) => {
+      const res = await callExpectingSuccess({
+        ...undefineds,
+        title: "Count Report",
+        end_date: "2025-02-01",
+        previous_period_end_date: "2025-01-31",
+        settings: {
+          include_credits: true,
+        },
+        chart_settings: {
+          y_axis_dimension: "count",
+        },
+      });
+      expect(res).toMatchObject({
+        title: "Count Report",
+        chart_settings: {
+          y_axis_dimension: "count",
+        },
+      });
+    },
+  },
+  {
     name: "unsuccessful call",
     apiCallHandler: requestsInOrder([
       {

--- a/src/tools/cost-reports/create-cost-report.test.ts
+++ b/src/tools/cost-reports/create-cost-report.test.ts
@@ -67,7 +67,7 @@ const validInputArguments = {
   date_bin: "day" as const,
   chart_settings: {
     x_axis_dimension: ["date"],
-    y_axis_dimension: "cost",
+    y_axis_dimension: "cost" as const,
   },
 };
 
@@ -168,6 +168,16 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
     },
   },
   {
+    name: "aggregate by count",
+    data: {
+      ...undefineds,
+      title: "Test Report",
+      settings: {
+        aggregate_by: "count",
+      },
+    },
+  },
+  {
     name: "invalid aggregate_by",
     data: {
       ...undefineds,
@@ -176,7 +186,7 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
         aggregate_by: "invalid" as any,
       },
     },
-    expectedIssues: ['Invalid option: expected one of "cost"|"usage"'],
+    expectedIssues: ['Invalid option: expected one of "cost"|"usage"|"count"'],
   },
   {
     name: "business metric with per_thousand scale",
@@ -288,7 +298,7 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
       ...undefineds,
       title: "Test Report",
       chart_settings: {
-        y_axis_dimension: "usage",
+        y_axis_dimension: "usage" as const,
       },
     },
   },
@@ -303,14 +313,14 @@ const minSuccess = {
   title: "Minimal Report",
   business_metric_tokens_with_metadata: [],
   chart_settings: {
-    y_axis_dimension: "cost",
+    y_axis_dimension: "cost" as const,
     x_axis_dimension: ["date"],
   },
-  chart_type: "line",
+  chart_type: "line" as const,
   created_at: "2023-01-01T00:00:00Z",
-  date_bin: "month",
-  date_interval: "this_month",
-  default_forecast: { kind: "baseline" },
+  date_bin: "month" as const,
+  date_interval: "this_month" as const,
+  default_forecast: { kind: "baseline" as const },
   filter: "(costs.provider = 'aws')",
   workspace_token: "wt_123",
 };

--- a/src/tools/cost-reports/list-cost-reports.test.ts
+++ b/src/tools/cost-reports/list-cost-reports.test.ts
@@ -1,5 +1,4 @@
 import { expect } from "vitest";
-import { DEFAULT_LIMIT } from "../structure/constants";
 import {
   type ExecutionTestTableItem,
   type ExtractOutputSchema,
@@ -9,6 +8,7 @@ import {
   type SchemaTestTableItem,
   testTool,
 } from "../../utils/testing";
+import { DEFAULT_LIMIT } from "../structure/constants";
 import tool from "./list-cost-reports";
 
 type Validators = ExtractValidators<typeof tool>;
@@ -41,13 +41,13 @@ const successData = {
       filter: "provider = aws",
       business_metric_tokens_with_metadata: [],
       created_at: "2023-01-15T10:30:00Z",
-      default_forecast: { kind: "baseline" },
+      default_forecast: { kind: "baseline" as const },
       workspace_token: "wrkspc_123",
-      date_interval: "this_month",
-      date_bin: "day",
-      chart_type: "line",
+      date_interval: "this_month" as const,
+      date_bin: "day" as const,
+      chart_type: "line" as const,
       chart_settings: {
-        y_axis_dimension: "cost",
+        y_axis_dimension: "cost" as const,
         x_axis_dimension: ["date"],
       },
     },
@@ -57,13 +57,13 @@ const successData = {
       filter: "provider = azure AND service = EC2",
       business_metric_tokens_with_metadata: [],
       created_at: "2023-01-15T10:30:00Z",
-      default_forecast: { kind: "baseline" },
+      default_forecast: { kind: "baseline" as const },
       workspace_token: "wrkspc_123",
-      date_interval: "this_month",
-      date_bin: "day",
-      chart_type: "line",
+      date_interval: "this_month" as const,
+      date_bin: "day" as const,
+      chart_type: "line" as const,
       chart_settings: {
-        y_axis_dimension: "cost",
+        y_axis_dimension: "cost" as const,
         x_axis_dimension: ["date"],
       },
     },

--- a/src/tools/cost-reports/schemas.ts
+++ b/src/tools/cost-reports/schemas.ts
@@ -55,8 +55,8 @@ export const costReportSettingsForCreate = z.object({
   unallocated: z.boolean().default(false).describe("Report will show unallocated costs."),
   aggregate_by: z
     .enum(["cost", "usage", "count"])
-    .default("cost")
-    .describe("Report will aggregate by cost, usage, or count."),
+    .optional()
+    .describe("Report will aggregate by cost, usage, or count. Defaults to cost when omitted."),
   show_previous_period: z
     .boolean()
     .default(true)

--- a/src/tools/cost-reports/schemas.ts
+++ b/src/tools/cost-reports/schemas.ts
@@ -10,10 +10,10 @@ export const chartSettings = z.object({
       "The dimension used to group or label data along the x-axis (e.g., by date, region, or service). NOTE: Only one value is allowed at this time. Defaults to ['date']."
     ),
   y_axis_dimension: z
-    .string()
+    .enum(["cost", "usage", "count"])
     .optional()
     .describe(
-      "The metric or measure displayed on the chart’s y-axis. Possible values: 'cost', 'usage'. Defaults to 'cost'."
+      "The metric or measure displayed on the chart’s y-axis. Possible values: 'cost', 'usage', 'count'. Defaults to 'cost'."
     ),
 });
 
@@ -53,11 +53,14 @@ export const costReportSettingsForCreate = z.object({
   include_tax: z.boolean().default(true).describe("Report will include tax."),
   amortize: z.boolean().default(true).describe("Report will amortize."),
   unallocated: z.boolean().default(false).describe("Report will show unallocated costs."),
-  aggregate_by: z.enum(["cost", "usage"]).default("cost").describe("Report will aggregate by cost or usage."),
+  aggregate_by: z
+    .enum(["cost", "usage", "count"])
+    .default("cost")
+    .describe("Report will aggregate by cost, usage, or count."),
   show_previous_period: z
     .boolean()
     .default(true)
-    .describe("Report will show previous period costs or usage comparison."),
+    .describe("Report will show previous period cost, usage, or count comparison."),
   complete_period: z.boolean().default(false).describe("Report will restrict date ranges to completed periods only."),
 });
 
@@ -68,6 +71,12 @@ export const costReportSettingsForUpdate = z.object({
   include_tax: z.boolean().optional().describe("Report will include tax."),
   amortize: z.boolean().optional().describe("Report will amortize."),
   unallocated: z.boolean().optional().describe("Report will show unallocated costs."),
-  aggregate_by: z.enum(["cost", "usage"]).optional().describe("Report will aggregate by cost or usage."),
-  show_previous_period: z.boolean().optional().describe("Report will show previous period costs or usage comparison."),
+  aggregate_by: z
+    .enum(["cost", "usage", "count"])
+    .optional()
+    .describe("Report will aggregate by cost, usage, or count."),
+  show_previous_period: z
+    .boolean()
+    .optional()
+    .describe("Report will show previous period cost, usage, or count comparison."),
 });

--- a/src/tools/list-costs.test.ts
+++ b/src/tools/list-costs.test.ts
@@ -1,7 +1,5 @@
 import type { GetCostsResponse } from "@vantage-sh/vantage-client";
 import { expect } from "vitest";
-import tool from "./list-costs";
-import { DEFAULT_LIMIT } from "./structure/constants";
 import {
   dateValidatorPoisoner,
   type ExecutionTestTableItem,
@@ -13,6 +11,8 @@ import {
   type SchemaTestTableItem,
   testTool,
 } from "../utils/testing";
+import tool from "./list-costs";
+import { DEFAULT_LIMIT } from "./structure/constants";
 
 type Validators = ExtractValidators<typeof tool>;
 type OutputSchema = ExtractOutputSchema<typeof tool>;
@@ -77,6 +77,13 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
       date_bin: "week",
     },
   },
+  {
+    name: "aggregate by count",
+    data: {
+      ...validArguments,
+      settings_aggregate_by: "count",
+    },
+  },
   poisonOneValue(validArguments, "start_date", dateValidatorPoisoner),
   poisonOneValue(validArguments, "end_date", dateValidatorPoisoner),
 ];
@@ -104,6 +111,15 @@ const successData: GetCostsResponse = {
   },
   total_usage: {},
   links: {},
+};
+
+const countSuccessData: GetCostsResponse = {
+  ...successData,
+  total_count: 42,
+  counts: [
+    { accrued_at: "2023-01-01", count: 20 },
+    { accrued_at: "2023-02-01", count: 22 },
+  ],
 };
 
 const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
@@ -208,6 +224,41 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
         settings_include_credits: true,
       });
       expect(res.costs).toEqual(successData.costs);
+    },
+  },
+  {
+    name: "aggregate by count returns total_count and counts",
+    apiCallHandler: requestsInOrder([
+      {
+        endpoint: "/v2/costs",
+        params: {
+          ...baseApiParams,
+          "settings[aggregate_by]": "count",
+        },
+        method: "GET",
+        result: {
+          ok: true,
+          data: countSuccessData,
+        },
+      },
+    ]),
+    handler: async ({ callExpectingSuccess }) => {
+      const res = await callExpectingSuccess({
+        ...validArguments,
+        settings_aggregate_by: "count",
+      });
+      expect(res).toEqual({
+        costs: countSuccessData.costs,
+        total_cost: countSuccessData.total_cost,
+        total_count: 42,
+        counts: countSuccessData.counts,
+        notes:
+          "Costs records represent one month, the accrued_at field is the first day of the month. If your date range is less than one month, this record includes only data for that date range, not the full month.",
+        pagination: {
+          hasNextPage: false,
+          nextPage: 0,
+        },
+      });
     },
   },
   {

--- a/src/tools/list-costs.ts
+++ b/src/tools/list-costs.ts
@@ -1,9 +1,9 @@
 import z from "zod";
+import dateValidator from "../utils/dateValidator";
+import paginationData from "../utils/paginationData";
 import { DEFAULT_LIMIT } from "./structure/constants";
 import MCPUserError from "./structure/MCPUserError";
 import registerTool from "./structure/registerTool";
-import dateValidator from "../utils/dateValidator";
-import paginationData from "../utils/paginationData";
 
 const description = `
 List the cost items inside a report. The Token of a Report must be provided. Use the page value of 1 to start.
@@ -17,6 +17,9 @@ records. If omitted, the API uses the cost report's configured date bin, or day 
 
 Cost settings (credits, refunds, discounts, tax, amortization, etc.) default to the report's own settings.
 Only provide these parameters if you need to override the report's defaults.
+
+Use settings_aggregate_by to choose the metric: cost (default), usage, or count.
+When aggregate_by is count, the response includes total_count and counts (date-binned distinct Group By permutation counts for the full requested period). Count is not supported for segment reports.
 `.trim();
 
 const args = {
@@ -55,14 +58,14 @@ const args = {
     .optional()
     .describe("Results will show unallocated costs. If not provided, the report's setting is used."),
   settings_aggregate_by: z
-    .enum(["cost", "usage"])
+    .enum(["cost", "usage", "count"])
     .optional()
-    .describe("Results will aggregate by cost or usage. If not provided, the report's setting is used."),
+    .describe("Results will aggregate by cost, usage, or count. If not provided, the report's setting is used."),
   settings_show_previous_period: z
     .boolean()
     .optional()
     .describe(
-      "Results will show previous period costs or usage comparison. If not provided, the report's setting is used."
+      "Results will show previous period cost, usage, or count comparison. If not provided, the report's setting is used."
     ),
   groupings: z
     .array(z.string())
@@ -133,6 +136,8 @@ export default registerTool({
     return {
       costs: response.data.costs,
       total_cost: response.data.total_cost,
+      ...(response.data.total_count != null ? { total_count: response.data.total_count } : {}),
+      ...(response.data.counts != null ? { counts: response.data.counts } : {}),
       notes,
       pagination: paginationData(response.data),
     };

--- a/src/tools/query-costs.test.ts
+++ b/src/tools/query-costs.test.ts
@@ -1,6 +1,5 @@
 import type { GetCostsResponse } from "@vantage-sh/vantage-client";
 import { expect } from "vitest";
-import tool from "./query-costs";
 import {
   dateValidatorPoisoner,
   type ExecutionTestTableItem,
@@ -11,6 +10,7 @@ import {
   type SchemaTestTableItem,
   testTool,
 } from "../utils/testing";
+import tool from "./query-costs";
 
 type Validators = ExtractValidators<typeof tool>;
 type OutputSchema = ExtractOutputSchema<typeof tool>;
@@ -89,6 +89,13 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
     },
   },
   {
+    name: "aggregate by count",
+    data: {
+      ...validInputArguments,
+      settings_aggregate_by: "count",
+    },
+  },
+  {
     name: "date_bin day",
     data: {
       ...validInputArguments,
@@ -131,6 +138,15 @@ const successData: GetCostsResponse = {
   },
   total_usage: {},
   links: {},
+};
+
+const countSuccessData: GetCostsResponse = {
+  ...successData,
+  total_count: 42,
+  counts: [
+    { accrued_at: "2023-01-01", count: 20 },
+    { accrued_at: "2023-02-01", count: 22 },
+  ],
 };
 
 const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
@@ -297,6 +313,41 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
       });
       expect(res.costs).toEqual([]);
       expect(res.hint).toContain("No cost rows matched");
+    },
+  },
+  {
+    name: "aggregate by count returns total_count and counts",
+    apiCallHandler: requestsInOrder([
+      {
+        endpoint: "/v2/costs",
+        params: {
+          ...baseApiParams,
+          "settings[aggregate_by]": "count",
+        },
+        method: "GET",
+        result: {
+          ok: true,
+          data: countSuccessData,
+        },
+      },
+    ]),
+    handler: async ({ callExpectingSuccess }) => {
+      const res = await callExpectingSuccess({
+        ...validInputArguments,
+        settings_aggregate_by: "count",
+      });
+      expect(res).toEqual({
+        costs: countSuccessData.costs,
+        total_cost: countSuccessData.total_cost,
+        total_count: 42,
+        counts: countSuccessData.counts,
+        notes:
+          "Costs records represent one month, the accrued_at field is the first day of the month. If your date range is less than one month, this record includes only data for that date range, not the full month.",
+        pagination: {
+          hasNextPage: false,
+          nextPage: 0,
+        },
+      });
     },
   },
   {

--- a/src/tools/query-costs.ts
+++ b/src/tools/query-costs.ts
@@ -1,8 +1,8 @@
 import z from "zod";
-import MCPUserError from "./structure/MCPUserError";
-import registerTool from "./structure/registerTool";
 import dateValidator from "../utils/dateValidator";
 import paginationData from "../utils/paginationData";
+import MCPUserError from "./structure/MCPUserError";
+import registerTool from "./structure/registerTool";
 
 const description = `
 Query for costs in a Vantage Account. These are independent of a cost reports.
@@ -44,6 +44,9 @@ records. If omitted, DateBin defaults to day.
 
 Cost settings (credits, refunds, discounts, tax, amortization, etc.) default to the workspace's default report settings.
 Only provide these parameters if you need to override those defaults.
+
+Use settings_aggregate_by to choose the metric: cost (default), usage, or count.
+When aggregate_by is count, the response includes total_count and counts (date-binned distinct Group By permutation counts for the full requested period).
 `.trim();
 
 const args = {
@@ -81,16 +84,16 @@ const args = {
     .optional()
     .describe("Results will show unallocated costs. If not provided, the workspace's default report setting is used."),
   settings_aggregate_by: z
-    .enum(["cost", "usage"])
+    .enum(["cost", "usage", "count"])
     .optional()
     .describe(
-      "Results will aggregate by cost or usage. If not provided, the workspace's default report setting is used."
+      "Results will aggregate by cost, usage, or count. If not provided, the workspace's default report setting is used."
     ),
   settings_show_previous_period: z
     .boolean()
     .optional()
     .describe(
-      "Results will show previous period costs or usage comparison. If not provided, the workspace's default report setting is used."
+      "Results will show previous period cost, usage, or count comparison. If not provided, the workspace's default report setting is used."
     ),
   groupings: z
     .array(z.string())
@@ -166,6 +169,8 @@ export default registerTool({
     return {
       costs,
       total_cost: response.data.total_cost,
+      ...(response.data.total_count != null ? { total_count: response.data.total_count } : {}),
+      ...(response.data.counts != null ? { counts: response.data.counts } : {}),
       notes,
       ...(hint ? { hint } : {}),
       pagination: paginationData(response.data),


### PR DESCRIPTION
## Summary
- Bump `@vantage-sh/vantage-client` to 2.10.0 for cost count API types
- Allow `settings_aggregate_by: "count"` on `list-costs` and `query-costs`, and pass through `total_count` / `counts`
- Allow `aggregate_by` / `y_axis_dimension: "count"` on create/update cost report schemas

## Test plan
- [x] `npx vitest run src/tools/list-costs.test.ts src/tools/query-costs.test.ts src/tools/cost-reports/create-cost-report.test.ts src/tools/cost-reports/update-cost-report.test.ts src/tools/cost-reports/list-cost-reports.test.ts`
- [x] `npm run type-check`


Made with [Cursor](https://cursor.com)