### PR TITLE
refactor: Nest anomalies tools under src/tools/anomalies/

### DIFF
--- a/src/tools/anomalies/get-anomaly.ts
+++ b/src/tools/anomalies/get-anomaly.ts
@@ -1,7 +1,7 @@
 import { pathEncode } from "@vantage-sh/vantage-client";
 import z from "zod";
-import MCPUserError from "./structure/MCPUserError";
-import registerTool from "./structure/registerTool";
+import MCPUserError from "../structure/MCPUserError";
+import registerTool from "../structure/registerTool";
 
 const description = `
 Gets a specific anomaly alert by its token.

--- a/src/tools/anomalies/index.ts
+++ b/src/tools/anomalies/index.ts
@@ -1,0 +1,3 @@
+import "./get-anomaly";
+import "./list-anomalies";
+import "./update-anomaly";

--- a/src/tools/anomalies/list-anomalies.ts
+++ b/src/tools/anomalies/list-anomalies.ts
@@ -1,9 +1,9 @@
 import z from "zod";
-import dateValidator from "../utils/dateValidator";
-import paginationData from "../utils/paginationData";
-import { DEFAULT_LIMIT } from "./structure/constants";
-import MCPUserError from "./structure/MCPUserError";
-import registerTool from "./structure/registerTool";
+import dateValidator from "../../utils/dateValidator";
+import paginationData from "../../utils/paginationData";
+import { DEFAULT_LIMIT } from "../structure/constants";
+import MCPUserError from "../structure/MCPUserError";
+import registerTool from "../structure/registerTool";
 
 const description = `
 Given a token of a Cost Report, look for anomalies in the report. You may optionally pass a Provider, like AWS to filter on. If you do pass a Provider, you can futher filter on a Service, like EC2 or S3.

--- a/src/tools/anomalies/update-anomaly.ts
+++ b/src/tools/anomalies/update-anomaly.ts
@@ -1,7 +1,7 @@
 import { pathEncode } from "@vantage-sh/vantage-client";
 import z from "zod";
-import MCPUserError from "./structure/MCPUserError";
-import registerTool from "./structure/registerTool";
+import MCPUserError from "../structure/MCPUserError";
+import registerTool from "../structure/registerTool";
 
 const description = `
 Updates an existing anomaly alert by its token. Use this to change the status of an anomaly alert (e.g. to archive or ignore it) and optionally provide feedback.

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,5 +1,6 @@
 // This file is auto-generated. Do not edit directly. Run npm run generate-tools-index to update.
 
+import "./anomalies";
 import "./billing-rules";
 import "./budgets";
 import "./business-metrics";
@@ -15,7 +16,6 @@ import "./dashboards";
 import "./delete-folder";
 import "./delete-report-notification";
 import "./financial-commitment-reports";
-import "./get-anomaly";
 import "./get-cost-provider-accounts";
 import "./get-financial-commitment-report";
 import "./get-folder";
@@ -23,7 +23,6 @@ import "./get-provider-resource";
 import "./get-report-notification";
 import "./get-team";
 import "./get-teams";
-import "./list-anomalies";
 import "./list-audit-logs";
 import "./list-cost-integrations";
 import "./list-cost-providers";
@@ -37,7 +36,6 @@ import "./recommendations";
 import "./resource-reports";
 import "./submit-user-feedback";
 import "./tags";
-import "./update-anomaly";
 import "./update-folder";
 import "./update-report-notification";
 import "./users";

--- a/test/tools/anomalies/get-anomaly.test.ts
+++ b/test/tools/anomalies/get-anomaly.test.ts
@@ -1,7 +1,7 @@
 import { type GetAnomalyAlertResponse, pathEncode } from "@vantage-sh/vantage-client";
 import { expect } from "vitest";
-import tool from "../../src/tools/get-anomaly";
-import { requestsInOrder, testTool } from "../../src/utils/testing";
+import tool from "../../../src/tools/anomalies/get-anomaly";
+import { requestsInOrder, testTool } from "../../../src/utils/testing";
 
 const success: GetAnomalyAlertResponse = {
   token: "anmly_alrt_123",

--- a/test/tools/anomalies/list-anomalies.test.ts
+++ b/test/tools/anomalies/list-anomalies.test.ts
@@ -1,7 +1,7 @@
 import type { GetAnomalyAlertsResponse } from "@vantage-sh/vantage-client";
 import { expect } from "vitest";
-import tool from "../../src/tools/list-anomalies";
-import { DEFAULT_LIMIT } from "../../src/tools/structure/constants";
+import tool from "../../../src/tools/anomalies/list-anomalies";
+import { DEFAULT_LIMIT } from "../../../src/tools/structure/constants";
 import {
   dateValidatorPoisoner,
   type ExecutionTestTableItem,
@@ -12,7 +12,7 @@ import {
   requestsInOrder,
   type SchemaTestTableItem,
   testTool,
-} from "../../src/utils/testing";
+} from "../../../src/utils/testing";
 
 type Validators = ExtractValidators<typeof tool>;
 type OutputSchema = ExtractOutputSchema<typeof tool>;

--- a/test/tools/anomalies/update-anomaly.test.ts
+++ b/test/tools/anomalies/update-anomaly.test.ts
@@ -1,6 +1,6 @@
 import { pathEncode, type UpdateAnomalyAlertResponse } from "@vantage-sh/vantage-client";
 import { expect } from "vitest";
-import tool from "../../src/tools/update-anomaly";
+import tool from "../../../src/tools/anomalies/update-anomaly";
 import {
   type ExecutionTestTableItem,
   type ExtractOutputSchema,
@@ -9,7 +9,7 @@ import {
   requestsInOrder,
   type SchemaTestTableItem,
   testTool,
-} from "../../src/utils/testing";
+} from "../../../src/utils/testing";
 
 type Validators = ExtractValidators<typeof tool>;
 type OutputSchema = ExtractOutputSchema<typeof tool>;

--- a/test/tools/tags/list-tag-values.test.ts
+++ b/test/tools/tags/list-tag-values.test.ts
@@ -1,7 +1,7 @@
 import { type GetTagValuesRequest, type GetTagValuesResponse, pathEncode } from "@vantage-sh/vantage-client";
 import { expect } from "vitest";
-import tool from "../../../src/tools/tags/list-tag-values";
 import { DEFAULT_LIMIT } from "../../../src/tools/structure/constants";
+import tool from "../../../src/tools/tags/list-tag-values";
 import {
   type ExecutionTestTableItem,
   type ExtractOutputSchema,

--- a/test/tools/tags/list-tags.test.ts
+++ b/test/tools/tags/list-tags.test.ts
@@ -1,7 +1,7 @@
 import type { GetTagsResponse } from "@vantage-sh/vantage-client";
 import { expect } from "vitest";
-import tool from "../../../src/tools/tags/list-tags";
 import { DEFAULT_LIMIT } from "../../../src/tools/structure/constants";
+import tool from "../../../src/tools/tags/list-tags";
 import {
   type ExecutionTestTableItem,
   type ExtractOutputSchema,


### PR DESCRIPTION
## Summary
- Move top-level `anomalies` MCP tools into `src/tools/anomalies/` (tests under `test/tools/anomalies/`).
- Mechanical move only: import path fixes + `npm run generate-tools-index`. No tool behavior changes.

## Test plan
- [x] `npm run type-check`
- [x] `npm test -- --run test/tools/anomalies/`
- [ ] CI green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Path-only refactor with no API or tool behavior changes; risk is limited to registration/import wiring if paths are wrong.
> 
> **Overview**
> **Groups anomaly MCP tools** (`get-anomaly`, `list-anomalies`, `update-anomaly`) under `src/tools/anomalies/`, matching other domain folders (e.g. `tags/`, `cost-reports/`).
> 
> Adds `src/tools/anomalies/index.ts` to side-effect–register those tools and updates the auto-generated `src/tools/index.ts` to import `./anomalies` instead of three top-level tool files. Tool implementations are unchanged aside from **import path fixes** for `registerTool`, `MCPUserError`, and shared utils.
> 
> Anomaly tests live under `test/tools/anomalies/` with updated module paths. Tag test files only reorder imports (`DEFAULT_LIMIT` before the tool import).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8be15ee60adb49d284fe7ab8ff7f866f43b83973. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->