### PR TITLE
refactor: Nest audit-logs tools under src/tools/audit-logs/

### DIFF
--- a/src/tools/audit-logs/index.ts
+++ b/src/tools/audit-logs/index.ts
@@ -1,0 +1,1 @@
+import "./list-audit-logs";

--- a/src/tools/audit-logs/list-audit-logs.ts
+++ b/src/tools/audit-logs/list-audit-logs.ts
@@ -1,9 +1,9 @@
 import z from "zod";
-import dateValidator from "../utils/dateValidator";
-import paginationData from "../utils/paginationData";
-import { DEFAULT_LIMIT } from "./structure/constants";
-import MCPUserError from "./structure/MCPUserError";
-import registerTool from "./structure/registerTool";
+import dateValidator from "../../utils/dateValidator";
+import paginationData from "../../utils/paginationData";
+import { DEFAULT_LIMIT } from "../structure/constants";
+import MCPUserError from "../structure/MCPUserError";
+import registerTool from "../structure/registerTool";
 
 const AUDIT_LOG_ACTIONS = ["create", "update", "delete"] as const;
 const AUDIT_LOG_SOURCES = ["console", "api", "finops_agent"] as const;

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,6 +1,7 @@
 // This file is auto-generated. Do not edit directly. Run npm run generate-tools-index to update.
 
 import "./anomalies";
+import "./audit-logs";
 import "./billing-rules";
 import "./budgets";
 import "./business-metrics";
@@ -20,7 +21,6 @@ import "./get-financial-commitment-report";
 import "./get-report-notification";
 import "./get-team";
 import "./get-teams";
-import "./list-audit-logs";
 import "./list-cost-integrations";
 import "./list-cost-providers";
 import "./list-cost-services";

--- a/test/tools/audit-logs/list-audit-logs.test.ts
+++ b/test/tools/audit-logs/list-audit-logs.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "vitest";
-import tool from "../../src/tools/list-audit-logs";
-import { DEFAULT_LIMIT } from "../../src/tools/structure/constants";
+import tool from "../../../src/tools/audit-logs/list-audit-logs";
+import { DEFAULT_LIMIT } from "../../../src/tools/structure/constants";
 import {
   type ExecutionTestTableItem,
   type ExtractOutputSchema,
@@ -9,7 +9,7 @@ import {
   requestsInOrder,
   type SchemaTestTableItem,
   testTool,
-} from "../../src/utils/testing";
+} from "../../../src/utils/testing";
 
 type Validators = ExtractValidators<typeof tool>;
 type OutputSchema = ExtractOutputSchema<typeof tool>;


### PR DESCRIPTION
## Summary
- Move top-level `audit-logs` MCP tools into `src/tools/audit-logs/` (tests under `test/tools/audit-logs/`).
- Mechanical move only: import path fixes + `npm run generate-tools-index`. No tool behavior changes.

## Test plan
- [x] `npm run type-check`
- [x] `npm test -- --run test/tools/audit-logs/`
- [ ] CI green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Path-only refactor with no logic or API changes; risk is limited to a broken import if registration is miswired.
> 
> **Overview**
> **Mechanical file move** — `list-audit-logs` now lives under `src/tools/audit-logs/` with a small `index.ts` barrel, matching domains like `anomalies`.
> 
> The auto-generated `src/tools/index.ts` loads `./audit-logs` instead of `./list-audit-logs`. Tool and test imports are updated for the new paths only; **`list-audit-logs` behavior is unchanged**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0d4b90af271ef6a05ecde69edb95cd32ea60fe8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->