### PR TITLE
refactor: Nest get-financial-commitment-report under financial-commitment-reports/

### DIFF
--- a/src/tools/financial-commitment-reports/get-financial-commitment-report.ts
+++ b/src/tools/financial-commitment-reports/get-financial-commitment-report.ts
@@ -1,7 +1,7 @@
 import { pathEncode } from "@vantage-sh/vantage-client";
 import z from "zod";
-import MCPUserError from "./structure/MCPUserError";
-import registerTool from "./structure/registerTool";
+import MCPUserError from "../structure/MCPUserError";
+import registerTool from "../structure/registerTool";
 
 const description = `
 Gets a specific financial commitment report by its token.

--- a/src/tools/financial-commitment-reports/index.ts
+++ b/src/tools/financial-commitment-reports/index.ts
@@ -1,4 +1,5 @@
-import "./list-financial-commitment-reports";
-import "./delete-financial-commitment-report";
-import "./update-financial-commitment-report";
 import "./create-financial-commitment-report";
+import "./delete-financial-commitment-report";
+import "./get-financial-commitment-report";
+import "./list-financial-commitment-reports";
+import "./update-financial-commitment-report";

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -15,7 +15,6 @@ import "./dashboards";
 import "./financial-commitment-reports";
 import "./folders";
 import "./get-cost-provider-accounts";
-import "./get-financial-commitment-report";
 import "./list-cost-integrations";
 import "./list-cost-providers";
 import "./list-cost-services";

--- a/test/tools/financial-commitment-reports/get-financial-commitment-report.test.ts
+++ b/test/tools/financial-commitment-reports/get-financial-commitment-report.test.ts
@@ -1,7 +1,7 @@
 import { type GetFinancialCommitmentReportResponse, pathEncode } from "@vantage-sh/vantage-client";
 import { expect } from "vitest";
-import tool from "../../src/tools/get-financial-commitment-report";
-import { requestsInOrder, testTool } from "../../src/utils/testing";
+import tool from "../../../src/tools/financial-commitment-reports/get-financial-commitment-report";
+import { requestsInOrder, testTool } from "../../../src/utils/testing";
 
 const success: GetFinancialCommitmentReportResponse = {
   token: "fncl_cmnt_rprt_86a93126175f91ed",


### PR DESCRIPTION
## Summary
- Move top-level `financial-commitment-reports` MCP tools into `src/tools/financial-commitment-reports/` (tests under `test/tools/financial-commitment-reports/`).
- Mechanical move only: import path fixes + `npm run generate-tools-index`. No tool behavior changes.

## Test plan
- [x] `npm run type-check`
- [x] `npm test -- --run test/tools/financial-commitment-reports/`
- [ ] CI green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> File moves and import path updates only; no logic or API behavior changes.
> 
> **Overview**
> **Moves** the `get-financial-commitment-report` MCP tool from `src/tools/` into `src/tools/financial-commitment-reports/` so it lives alongside the other financial commitment report tools.
> 
> Import paths are updated (`../structure/...` in the tool module; test imports under `test/tools/financial-commitment-reports/`). The feature barrel `financial-commitment-reports/index.ts` now registers `get-financial-commitment-report`, and the generated `src/tools/index.ts` no longer imports the tool at the top level—only `./financial-commitment-reports`.
> 
> No changes to tool name, API calls, or runtime behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 212acd43fcbd72b0d1f33e910b7f07636a50b2aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->