### PR TITLE
refactor: Nest integrations tools under src/tools/integrations/

### DIFF
--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -15,7 +15,7 @@ import "./current-user";
 import "./dashboards";
 import "./financial-commitment-reports";
 import "./folders";
-import "./list-cost-integrations";
+import "./integrations";
 import "./network-flow-reports";
 import "./provider-resources";
 import "./recommendation-views";

--- a/src/tools/integrations/index.ts
+++ b/src/tools/integrations/index.ts
@@ -1,0 +1,1 @@
+import "./list-cost-integrations";

--- a/src/tools/integrations/list-cost-integrations.ts
+++ b/src/tools/integrations/list-cost-integrations.ts
@@ -1,8 +1,8 @@
 import z from "zod";
-import paginationData from "../utils/paginationData";
-import { DEFAULT_LIMIT } from "./structure/constants";
-import MCPUserError from "./structure/MCPUserError";
-import registerTool from "./structure/registerTool";
+import paginationData from "../../utils/paginationData";
+import { DEFAULT_LIMIT } from "../structure/constants";
+import MCPUserError from "../structure/MCPUserError";
+import registerTool from "../structure/registerTool";
 
 const description = `
 List all cost provider integrations available to provide costs data from and their associated accounts.

--- a/test/tools/integrations/list-cost-integrations.test.ts
+++ b/test/tools/integrations/list-cost-integrations.test.ts
@@ -1,7 +1,7 @@
 import type { GetIntegrationsResponse } from "@vantage-sh/vantage-client";
 import { expect } from "vitest";
-import tool from "../../src/tools/list-cost-integrations";
-import { DEFAULT_LIMIT } from "../../src/tools/structure/constants";
+import tool from "../../../src/tools/integrations/list-cost-integrations";
+import { DEFAULT_LIMIT } from "../../../src/tools/structure/constants";
 import {
   type ExecutionTestTableItem,
   type ExtractOutputSchema,
@@ -10,7 +10,7 @@ import {
   requestsInOrder,
   type SchemaTestTableItem,
   testTool,
-} from "../../src/utils/testing";
+} from "../../../src/utils/testing";
 
 type Validators = ExtractValidators<typeof tool>;
 type OutputSchema = ExtractOutputSchema<typeof tool>;


### PR DESCRIPTION
## Summary
- Move top-level `integrations` MCP tools into `src/tools/integrations/` (tests under `test/tools/integrations/`).
- Mechanical move only: import path fixes + `npm run generate-tools-index`. No tool behavior changes.

## Test plan
- [x] `npm run type-check`
- [x] `npm test -- --run test/tools/integrations/`
- [ ] CI green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical file move and import path updates with no logic or API behavior changes.
> 
> **Overview**
> Moves the **`list-cost-integrations`** MCP tool from the top-level `src/tools/` tree into **`src/tools/integrations/`**, with tests under **`test/tools/integrations/`**, matching how other tool domains (e.g. `folders`) are organized.
> 
> The root **`src/tools/index.ts`** now imports **`./integrations`** instead of **`./list-cost-integrations`** (via a new barrel **`integrations/index.ts`**). Only relative import paths in the tool and its test were updated; tool name, API calls, and behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 360d6ce39cf47535b0ee5c9c1299e37a36f89eff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->