### PR TITLE
feat: Add virtual tag config management tools.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
         "@cloudflare/workers-oauth-provider": "^0.0.11",
         "@modelcontextprotocol/sdk": "1.29.0",
         "@sentry/cloudflare": "10.30.0",
-        "@vantage-sh/vantage-client": "2.11.0",
+        "@vantage-sh/vantage-client": "2.13.0",
         "agents": "^0.13.2",
         "axios": "1.13.5",
         "hono": "4.12.12",
@@ -4102,9 +4102,9 @@
       }
     },
     "node_modules/@vantage-sh/vantage-client": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@vantage-sh/vantage-client/-/vantage-client-2.11.0.tgz",
-      "integrity": "sha512-7KA1pJYZ8S5Wig/IZy1dv2xspR9rsRBqUaZ39h5szdzAVEkSpqssYFrywBalzGhEYLGuZSmbGTjvNvC4kCK6FA==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/@vantage-sh/vantage-client/-/vantage-client-2.13.0.tgz",
+      "integrity": "sha512-hHh/x+A4SVTQOUjzGZJa/Bs1aKD7Ze5cAXTWgVdObE/eLsuTL2VFMM/98d8vsptNTCi3jQUUP4Qnt6+e7DK4pw==",
       "license": "MIT"
     },
     "node_modules/@vercel/oidc": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@cloudflare/workers-oauth-provider": "^0.0.11",
     "@modelcontextprotocol/sdk": "1.29.0",
     "@sentry/cloudflare": "10.30.0",
-    "@vantage-sh/vantage-client": "2.11.0",
+    "@vantage-sh/vantage-client": "2.13.0",
     "agents": "^0.13.2",
     "axios": "1.13.5",
     "hono": "4.12.12",

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -28,5 +28,6 @@ import "./tags";
 import "./teams";
 import "./user-feedback";
 import "./users";
+import "./virtual-tag-config-values";
 import "./virtual-tag-configs";
 import "./workspaces";

--- a/src/tools/virtual-tag-config-values/create-virtual-tag-config-value.ts
+++ b/src/tools/virtual-tag-config-values/create-virtual-tag-config-value.ts
@@ -1,0 +1,52 @@
+import { type CreateVirtualTagConfigValueRequest, pathEncode } from "@vantage-sh/vantage-client";
+import MCPUserError from "../structure/MCPUserError";
+import registerTool from "../structure/registerTool";
+import {
+  countDefinedFields,
+  valueTypeFields,
+  virtualTagConfigToken,
+  virtualTagConfigValueFilter,
+  virtualTagConfigValueOptionalArgs,
+} from "./schemas";
+
+const description = `
+Creates an individual value within a Virtual Tag Config without replacing its full values list. New values append after existing values.
+`.trim();
+
+export default registerTool({
+  name: "create-virtual-tag-config-value",
+  title: "Create Virtual Tag Config Value",
+  description,
+  annotations: {
+    destructive: false,
+    openWorld: false,
+    readOnly: false,
+  },
+  args: {
+    virtual_tag_config_token: virtualTagConfigToken,
+    filter: virtualTagConfigValueFilter,
+    ...virtualTagConfigValueOptionalArgs,
+  },
+  async execute(args, ctx) {
+    if (countDefinedFields(args, valueTypeFields) !== 1) {
+      throw new MCPUserError({
+        errors: [
+          {
+            message: "Exactly one of name, business_metric_token, cost_metric, or percentages must be provided.",
+          },
+        ],
+      });
+    }
+
+    const { virtual_tag_config_token, ...body } = args;
+    const response = await ctx.callVantageApi(
+      `/v2/virtual_tag_configs/${pathEncode(virtual_tag_config_token)}/values`,
+      body as CreateVirtualTagConfigValueRequest,
+      "POST"
+    );
+    if (!response.ok) {
+      throw new MCPUserError({ errors: response.errors });
+    }
+    return response.data;
+  },
+});

--- a/src/tools/virtual-tag-config-values/create-virtual-tag-config-value.ts
+++ b/src/tools/virtual-tag-config-values/create-virtual-tag-config-value.ts
@@ -2,8 +2,7 @@ import { type CreateVirtualTagConfigValueRequest, pathEncode } from "@vantage-sh
 import MCPUserError from "../structure/MCPUserError";
 import registerTool from "../structure/registerTool";
 import {
-  countDefinedFields,
-  valueTypeFields,
+  countProvidedValueTypes,
   virtualTagConfigToken,
   virtualTagConfigValueFilter,
   virtualTagConfigValueOptionalArgs,
@@ -28,7 +27,7 @@ export default registerTool({
     ...virtualTagConfigValueOptionalArgs,
   },
   async execute(args, ctx) {
-    if (countDefinedFields(args, valueTypeFields) !== 1) {
+    if (countProvidedValueTypes(args) !== 1) {
       throw new MCPUserError({
         errors: [
           {

--- a/src/tools/virtual-tag-config-values/create-virtual-tag-config-value.ts
+++ b/src/tools/virtual-tag-config-values/create-virtual-tag-config-value.ts
@@ -10,7 +10,7 @@ import {
 } from "./schemas";
 
 const description = `
-Creates an individual value within a Virtual Tag Config without replacing its full values list. New values append after existing values.
+Adds a value to an existing Virtual Tag Config. Use this when editing a Virtual Tag by adding a value without replacing its full values list; new values append after existing values.
 `.trim();
 
 export default registerTool({

--- a/src/tools/virtual-tag-config-values/create-virtual-tag-config-value.ts
+++ b/src/tools/virtual-tag-config-values/create-virtual-tag-config-value.ts
@@ -4,8 +4,8 @@ import registerTool from "../structure/registerTool";
 import {
   countProvidedValueTypes,
   virtualTagConfigToken,
+  virtualTagConfigValueCreateOptionalArgs,
   virtualTagConfigValueFilter,
-  virtualTagConfigValueOptionalArgs,
 } from "./schemas";
 
 const description = `
@@ -24,7 +24,7 @@ export default registerTool({
   args: {
     virtual_tag_config_token: virtualTagConfigToken,
     filter: virtualTagConfigValueFilter,
-    ...virtualTagConfigValueOptionalArgs,
+    ...virtualTagConfigValueCreateOptionalArgs,
   },
   async execute(args, ctx) {
     if (countProvidedValueTypes(args) !== 1) {

--- a/src/tools/virtual-tag-config-values/create-virtual-tag-config-value.ts
+++ b/src/tools/virtual-tag-config-values/create-virtual-tag-config-value.ts
@@ -9,7 +9,7 @@ import {
 } from "./schemas";
 
 const description = `
-Adds a value to an existing Virtual Tag Config. Use this when editing a Virtual Tag by adding a value without replacing its full values list; new values append after existing values.
+Adds a new mapping/value to an existing Virtual Tag Config without replacing its other values. Use this to append a mapping while editing a Virtual Tag; new values are added after existing values.
 `.trim();
 
 export default registerTool({

--- a/src/tools/virtual-tag-config-values/delete-virtual-tag-config-value.ts
+++ b/src/tools/virtual-tag-config-values/delete-virtual-tag-config-value.ts
@@ -1,0 +1,36 @@
+import { pathEncode } from "@vantage-sh/vantage-client";
+import MCPUserError from "../structure/MCPUserError";
+import registerTool from "../structure/registerTool";
+import { virtualTagConfigToken, virtualTagConfigValueToken } from "./schemas";
+
+const description = `
+Deletes one value from a Virtual Tag Config without replacing or reordering the remaining values.
+`.trim();
+
+export default registerTool({
+  name: "delete-virtual-tag-config-value",
+  title: "Delete Virtual Tag Config Value",
+  description,
+  annotations: {
+    destructive: true,
+    openWorld: false,
+    readOnly: false,
+  },
+  args: {
+    virtual_tag_config_token: virtualTagConfigToken,
+    virtual_tag_config_value_token: virtualTagConfigValueToken,
+  },
+  async execute(args, ctx) {
+    const response = await ctx.callVantageApi(
+      `/v2/virtual_tag_configs/${pathEncode(args.virtual_tag_config_token)}/values/${pathEncode(
+        args.virtual_tag_config_value_token
+      )}`,
+      {},
+      "DELETE"
+    );
+    if (!response.ok) {
+      throw new MCPUserError({ errors: response.errors });
+    }
+    return { token: args.virtual_tag_config_value_token };
+  },
+});

--- a/src/tools/virtual-tag-config-values/delete-virtual-tag-config-value.ts
+++ b/src/tools/virtual-tag-config-values/delete-virtual-tag-config-value.ts
@@ -4,7 +4,7 @@ import registerTool from "../structure/registerTool";
 import { virtualTagConfigToken, virtualTagConfigValueToken } from "./schemas";
 
 const description = `
-Removes one value from an existing Virtual Tag Config. Use this when editing a Virtual Tag by deleting a value without replacing or reordering the remaining values.
+Deletes exactly one mapping/value from an existing Virtual Tag Config, not the containing tag. Remaining values are preserved without replacement or reordering.
 `.trim();
 
 export default registerTool({

--- a/src/tools/virtual-tag-config-values/delete-virtual-tag-config-value.ts
+++ b/src/tools/virtual-tag-config-values/delete-virtual-tag-config-value.ts
@@ -4,7 +4,7 @@ import registerTool from "../structure/registerTool";
 import { virtualTagConfigToken, virtualTagConfigValueToken } from "./schemas";
 
 const description = `
-Deletes one value from a Virtual Tag Config without replacing or reordering the remaining values.
+Removes one value from an existing Virtual Tag Config. Use this when editing a Virtual Tag by deleting a value without replacing or reordering the remaining values.
 `.trim();
 
 export default registerTool({

--- a/src/tools/virtual-tag-config-values/get-virtual-tag-config-value.ts
+++ b/src/tools/virtual-tag-config-values/get-virtual-tag-config-value.ts
@@ -4,7 +4,7 @@ import registerTool from "../structure/registerTool";
 import { virtualTagConfigToken, virtualTagConfigValueToken } from "./schemas";
 
 const description = `
-Returns one value from a Virtual Tag Config, including its filter and allocation settings.
+Returns one value from an existing Virtual Tag Config, including its filter and allocation settings. Use this to inspect a value before editing it.
 `.trim();
 
 export default registerTool({

--- a/src/tools/virtual-tag-config-values/get-virtual-tag-config-value.ts
+++ b/src/tools/virtual-tag-config-values/get-virtual-tag-config-value.ts
@@ -4,7 +4,7 @@ import registerTool from "../structure/registerTool";
 import { virtualTagConfigToken, virtualTagConfigValueToken } from "./schemas";
 
 const description = `
-Returns one value from an existing Virtual Tag Config, including its filter and allocation settings. Use this to inspect a value before editing it.
+Returns one mapping/value from an existing Virtual Tag Config, including its filter and allocation settings. Use this to inspect one mapping before editing it.
 `.trim();
 
 export default registerTool({

--- a/src/tools/virtual-tag-config-values/get-virtual-tag-config-value.ts
+++ b/src/tools/virtual-tag-config-values/get-virtual-tag-config-value.ts
@@ -1,0 +1,36 @@
+import { pathEncode } from "@vantage-sh/vantage-client";
+import MCPUserError from "../structure/MCPUserError";
+import registerTool from "../structure/registerTool";
+import { virtualTagConfigToken, virtualTagConfigValueToken } from "./schemas";
+
+const description = `
+Returns one value from a Virtual Tag Config, including its filter and allocation settings.
+`.trim();
+
+export default registerTool({
+  name: "get-virtual-tag-config-value",
+  title: "Get Virtual Tag Config Value",
+  description,
+  annotations: {
+    destructive: false,
+    openWorld: false,
+    readOnly: true,
+  },
+  args: {
+    virtual_tag_config_token: virtualTagConfigToken,
+    virtual_tag_config_value_token: virtualTagConfigValueToken,
+  },
+  async execute(args, ctx) {
+    const response = await ctx.callVantageApi(
+      `/v2/virtual_tag_configs/${pathEncode(args.virtual_tag_config_token)}/values/${pathEncode(
+        args.virtual_tag_config_value_token
+      )}`,
+      {},
+      "GET"
+    );
+    if (!response.ok) {
+      throw new MCPUserError({ errors: response.errors });
+    }
+    return response.data;
+  },
+});

--- a/src/tools/virtual-tag-config-values/index.ts
+++ b/src/tools/virtual-tag-config-values/index.ts
@@ -1,0 +1,4 @@
+import "./create-virtual-tag-config-value";
+import "./delete-virtual-tag-config-value";
+import "./get-virtual-tag-config-value";
+import "./update-virtual-tag-config-value";

--- a/src/tools/virtual-tag-config-values/schemas.ts
+++ b/src/tools/virtual-tag-config-values/schemas.ts
@@ -1,0 +1,73 @@
+import z from "zod";
+import dateValidator from "../../utils/dateValidator";
+import { nonempty, vantageToken } from "../../utils/zod";
+
+export const virtualTagConfigToken = vantageToken("virtual_tag_config", {
+  description: "Parent Virtual Tag Config.",
+});
+
+export const virtualTagConfigValueToken = vantageToken("virtual_tag_config_value");
+
+export const virtualTagConfigValueFilter = nonempty().describe(
+  "VQL filter that determines which costs match this Virtual Tag Config Value."
+);
+
+const labelTransform = z.object({
+  type: z.enum(["split", "format"]).describe("Label transform operation."),
+  delimiter: nonempty().nullable().optional().describe("Delimiter used by a split transform."),
+  index: z.number().int().nullable().optional().describe("Zero-based index used by a split transform."),
+  template: nonempty().nullable().optional().describe("Template used by a format transform."),
+});
+
+const costMetric = z.object({
+  filter: nonempty().describe("VQL filter for the cost metric used to allocate matching costs."),
+  aggregation: z.object({
+    tag: nonempty().describe("Tag key used to aggregate the cost metric."),
+  }),
+});
+
+const percentage = z.object({
+  value: nonempty().describe("Virtual tag value receiving this percentage of matched costs."),
+  pct: z.number().describe("Percentage of matched costs allocated to the value."),
+});
+
+const dateRange = z.object({
+  start_date: dateValidator("Inclusive start date, YYYY-MM-DD, or null for no lower bound.").nullable().optional(),
+  end_date: dateValidator("Inclusive end date, YYYY-MM-DD, or null for no upper bound.").nullable().optional(),
+});
+
+export const virtualTagConfigValueOptionalArgs = {
+  name: nonempty().optional().describe("Name for a simple Virtual Tag Config Value."),
+  business_metric_token: vantageToken("business_metric", {
+    description: "Associates this value with a Business Metric.",
+  }).optional(),
+  label_key: nonempty().optional().describe("Business Metric label key used by this value."),
+  label_values: z
+    .array(z.string())
+    .optional()
+    .describe("Business Metric label values. An empty array includes every value for the label key."),
+  display_name: nonempty()
+    .nullable()
+    .optional()
+    .describe("Display name for a cost metric or percentage allocation value. Use null to clear it."),
+  label_transforms: z.array(labelTransform).optional().describe("Transforms applied to Business Metric labels."),
+  cost_metric: costMetric.optional().describe("Cost metric used for dynamic allocation."),
+  percentages: z.array(percentage).optional().describe("Fixed percentage allocations for matching costs."),
+  date_ranges: z.array(dateRange).optional().describe("Date ranges that restrict when this value applies."),
+};
+
+export const valueTypeFields = ["name", "business_metric_token", "cost_metric", "percentages"] as const;
+
+export const valueUpdateFields = [
+  "filter",
+  ...valueTypeFields,
+  "label_key",
+  "label_values",
+  "display_name",
+  "label_transforms",
+  "date_ranges",
+] as const;
+
+export function countDefinedFields(args: Record<string, unknown>, fields: readonly string[]): number {
+  return fields.filter((field) => args[field] !== undefined).length;
+}

--- a/src/tools/virtual-tag-config-values/schemas.ts
+++ b/src/tools/virtual-tag-config-values/schemas.ts
@@ -71,3 +71,10 @@ export const valueUpdateFields = [
 export function countDefinedFields(args: Record<string, unknown>, fields: readonly string[]): number {
   return fields.filter((field) => args[field] !== undefined).length;
 }
+
+export function countProvidedValueTypes(args: Record<string, unknown>): number {
+  return valueTypeFields.filter((field) => {
+    const value = args[field];
+    return field === "percentages" ? Array.isArray(value) && value.length > 0 : value !== undefined;
+  }).length;
+}

--- a/src/tools/virtual-tag-config-values/schemas.ts
+++ b/src/tools/virtual-tag-config-values/schemas.ts
@@ -36,7 +36,7 @@ const dateRange = z.object({
   end_date: dateValidator("Inclusive end date, YYYY-MM-DD, or null for no upper bound.").nullable().optional(),
 });
 
-export const virtualTagConfigValueOptionalArgs = {
+export const virtualTagConfigValueCreateOptionalArgs = {
   name: nonempty().optional().describe("Name for a simple Virtual Tag Config Value."),
   business_metric_token: vantageToken("business_metric", {
     description: "Associates this value with a Business Metric.",
@@ -46,14 +46,19 @@ export const virtualTagConfigValueOptionalArgs = {
     .array(z.string())
     .optional()
     .describe("Business Metric label values. An empty array includes every value for the label key."),
-  display_name: nonempty()
-    .nullable()
-    .optional()
-    .describe("Display name for a cost metric or percentage allocation value. Use null to clear it."),
+  display_name: nonempty().optional().describe("Display name for a cost metric or percentage allocation value."),
   label_transforms: z.array(labelTransform).optional().describe("Transforms applied to Business Metric labels."),
   cost_metric: costMetric.optional().describe("Cost metric used for dynamic allocation."),
   percentages: z.array(percentage).optional().describe("Fixed percentage allocations for matching costs."),
   date_ranges: z.array(dateRange).optional().describe("Date ranges that restrict when this value applies."),
+};
+
+export const virtualTagConfigValueUpdateOptionalArgs = {
+  ...virtualTagConfigValueCreateOptionalArgs,
+  display_name: nonempty()
+    .nullable()
+    .optional()
+    .describe("Display name for a cost metric or percentage allocation value. Use null to clear it."),
 };
 
 export const valueTypeFields = ["name", "business_metric_token", "cost_metric", "percentages"] as const;

--- a/src/tools/virtual-tag-config-values/update-virtual-tag-config-value.ts
+++ b/src/tools/virtual-tag-config-values/update-virtual-tag-config-value.ts
@@ -7,8 +7,8 @@ import {
   valueUpdateFields,
   virtualTagConfigToken,
   virtualTagConfigValueFilter,
-  virtualTagConfigValueOptionalArgs,
   virtualTagConfigValueToken,
+  virtualTagConfigValueUpdateOptionalArgs,
 } from "./schemas";
 
 const description = `
@@ -28,7 +28,7 @@ export default registerTool({
     virtual_tag_config_token: virtualTagConfigToken,
     virtual_tag_config_value_token: virtualTagConfigValueToken,
     filter: virtualTagConfigValueFilter.optional(),
-    ...virtualTagConfigValueOptionalArgs,
+    ...virtualTagConfigValueUpdateOptionalArgs,
   },
   async execute(args, ctx) {
     if (countDefinedFields(args, valueUpdateFields) === 0) {

--- a/src/tools/virtual-tag-config-values/update-virtual-tag-config-value.ts
+++ b/src/tools/virtual-tag-config-values/update-virtual-tag-config-value.ts
@@ -12,7 +12,7 @@ import {
 } from "./schemas";
 
 const description = `
-Partially updates one Virtual Tag Config value while preserving omitted fields and its existing order.
+Edits one value in an existing Virtual Tag Config. Only supplied fields are changed; omitted fields and the value's order are preserved.
 `.trim();
 
 export default registerTool({

--- a/src/tools/virtual-tag-config-values/update-virtual-tag-config-value.ts
+++ b/src/tools/virtual-tag-config-values/update-virtual-tag-config-value.ts
@@ -12,7 +12,7 @@ import {
 } from "./schemas";
 
 const description = `
-Edits one value in an existing Virtual Tag Config. Only supplied fields are changed; omitted fields and the value's order are preserved.
+Partially edits one mapping/value in an existing Virtual Tag Config. Omitted fields remain unchanged, display_name set to null clears it, and this tool cannot reorder values.
 `.trim();
 
 export default registerTool({

--- a/src/tools/virtual-tag-config-values/update-virtual-tag-config-value.ts
+++ b/src/tools/virtual-tag-config-values/update-virtual-tag-config-value.ts
@@ -3,7 +3,7 @@ import MCPUserError from "../structure/MCPUserError";
 import registerTool from "../structure/registerTool";
 import {
   countDefinedFields,
-  valueTypeFields,
+  countProvidedValueTypes,
   valueUpdateFields,
   virtualTagConfigToken,
   virtualTagConfigValueFilter,
@@ -36,7 +36,7 @@ export default registerTool({
         errors: [{ message: "At least one Virtual Tag Config Value field must be provided." }],
       });
     }
-    if (countDefinedFields(args, valueTypeFields) > 1) {
+    if (countProvidedValueTypes(args) > 1) {
       throw new MCPUserError({
         errors: [
           {

--- a/src/tools/virtual-tag-config-values/update-virtual-tag-config-value.ts
+++ b/src/tools/virtual-tag-config-values/update-virtual-tag-config-value.ts
@@ -1,0 +1,62 @@
+import { pathEncode, type UpdateVirtualTagConfigValueRequest } from "@vantage-sh/vantage-client";
+import MCPUserError from "../structure/MCPUserError";
+import registerTool from "../structure/registerTool";
+import {
+  countDefinedFields,
+  valueTypeFields,
+  valueUpdateFields,
+  virtualTagConfigToken,
+  virtualTagConfigValueFilter,
+  virtualTagConfigValueOptionalArgs,
+  virtualTagConfigValueToken,
+} from "./schemas";
+
+const description = `
+Partially updates one Virtual Tag Config value while preserving omitted fields and its existing order.
+`.trim();
+
+export default registerTool({
+  name: "update-virtual-tag-config-value",
+  title: "Update Virtual Tag Config Value",
+  description,
+  annotations: {
+    destructive: true,
+    openWorld: false,
+    readOnly: false,
+  },
+  args: {
+    virtual_tag_config_token: virtualTagConfigToken,
+    virtual_tag_config_value_token: virtualTagConfigValueToken,
+    filter: virtualTagConfigValueFilter.optional(),
+    ...virtualTagConfigValueOptionalArgs,
+  },
+  async execute(args, ctx) {
+    if (countDefinedFields(args, valueUpdateFields) === 0) {
+      throw new MCPUserError({
+        errors: [{ message: "At least one Virtual Tag Config Value field must be provided." }],
+      });
+    }
+    if (countDefinedFields(args, valueTypeFields) > 1) {
+      throw new MCPUserError({
+        errors: [
+          {
+            message: "Only one of name, business_metric_token, cost_metric, or percentages may be provided.",
+          },
+        ],
+      });
+    }
+
+    const { virtual_tag_config_token, virtual_tag_config_value_token, ...body } = args;
+    const response = await ctx.callVantageApi(
+      `/v2/virtual_tag_configs/${pathEncode(virtual_tag_config_token)}/values/${pathEncode(
+        virtual_tag_config_value_token
+      )}`,
+      body as UpdateVirtualTagConfigValueRequest,
+      "PATCH"
+    );
+    if (!response.ok) {
+      throw new MCPUserError({ errors: response.errors });
+    }
+    return response.data;
+  },
+});

--- a/src/tools/virtual-tag-configs/create-virtual-tag-config.ts
+++ b/src/tools/virtual-tag-configs/create-virtual-tag-config.ts
@@ -6,6 +6,7 @@ import registerTool from "../structure/registerTool";
 
 const description = `
 Create a Virtual Tag Config in Vantage.
+Do not use this to edit an existing Virtual Tag Config; use the Virtual Tag Config Value tools to add, inspect, edit, or remove individual values.
 
 Virtual Tag Configs define a derived (virtual) tag key and a set of values determined by VQL filters.
 This is useful for normalizing cost attribution (e.g., mapping multiple provider tag formats into a

--- a/src/tools/virtual-tag-configs/create-virtual-tag-config.ts
+++ b/src/tools/virtual-tag-configs/create-virtual-tag-config.ts
@@ -1,12 +1,13 @@
 import z from "zod";
 import dateValidator from "../../utils/dateValidator";
-import { vantageToken } from "../../utils/zod";
+import { nonempty } from "../../utils/zod";
 import MCPUserError from "../structure/MCPUserError";
 import registerTool from "../structure/registerTool";
+import { collapsedTagKeySchema, virtualTagConfigValueSchema } from "./schemas";
 
 const description = `
 Create a Virtual Tag Config in Vantage.
-Do not use this to edit an existing Virtual Tag Config; use the Virtual Tag Config Value tools to add, inspect, edit, or remove individual values.
+Do not use this to edit an existing Virtual Tag Config; use update-virtual-tag-config for config settings or value order, and the Virtual Tag Config Value tools for individual values.
 
 Virtual Tag Configs define a derived (virtual) tag key and a set of values determined by VQL filters.
 This is useful for normalizing cost attribution (e.g., mapping multiple provider tag formats into a
@@ -18,39 +19,26 @@ You can optionally:
 - values: define named values via VQL filters, optionally linked to Business Metrics and/or cost metrics
 `.trim();
 
-const collapsedTagKeySchema = z.object({
-  key: z.string().describe("The tag key to collapse values for."),
-  providers: z.array(z.string()).describe("The providers this collapsed tag key applies to.").optional(),
-});
-
-const valueSchema = z.object({
-  filter: z.string().describe("The filter VQL for the Value."),
-  name: z.string().describe("The name of the Value.").optional(),
-  business_metric_token: vantageToken("business_metric").optional(),
-  cost_metric: z
-    .object({
-      filter: z.string().describe("The filter VQL for the cost metric."),
-      aggregation: z.object({
-        tag: z.string().describe("The tag to aggregate on."),
-      }),
-    })
-    .optional(),
-});
-
 export default registerTool({
   name: "create-virtual-tag-config",
   title: "Create Virtual Tag Config",
   description,
   args: {
-    key: z.string().min(1).describe("The key of the VirtualTagConfig"),
+    key: nonempty().describe("The key of the VirtualTagConfig"),
     overridable: z
       .boolean()
       .describe("Whether the VirtualTagConfig can override a provider-supplied tag on a matching Cost."),
     backfill_until: dateValidator(
       "The earliest month the VirtualTagConfig should be backfilled to. ISO 8601 Formatted."
     ).optional(),
-    collapsed_tag_keys: z.array(collapsedTagKeySchema).optional(),
-    values: z.array(valueSchema).optional(),
+    collapsed_tag_keys: z
+      .array(collapsedTagKeySchema)
+      .optional()
+      .describe("Tag keys whose values should be collapsed."),
+    values: z
+      .array(virtualTagConfigValueSchema)
+      .optional()
+      .describe("Ordered values to create for the Virtual Tag Config."),
   },
   annotations: {
     destructive: false,

--- a/src/tools/virtual-tag-configs/create-virtual-tag-config.ts
+++ b/src/tools/virtual-tag-configs/create-virtual-tag-config.ts
@@ -6,7 +6,7 @@ import registerTool from "../structure/registerTool";
 import { collapsedTagKeySchema, virtualTagConfigValueSchema } from "./schemas";
 
 const description = `
-Create a Virtual Tag Config in Vantage.
+Creates a new Virtual Tag (Virtual Tag Config) in Vantage.
 Do not use this to edit an existing Virtual Tag Config; use update-virtual-tag-config for config settings or value order, and the Virtual Tag Config Value tools for individual values.
 
 Virtual Tag Configs define a derived (virtual) tag key and a set of values determined by VQL filters.

--- a/src/tools/virtual-tag-configs/create-virtual-tag-config.ts
+++ b/src/tools/virtual-tag-configs/create-virtual-tag-config.ts
@@ -1,3 +1,4 @@
+import type { CreateVirtualTagConfigRequest } from "@vantage-sh/vantage-client";
 import z from "zod";
 import dateValidator from "../../utils/dateValidator";
 import { nonempty } from "../../utils/zod";
@@ -46,7 +47,11 @@ export default registerTool({
     readOnly: false,
   },
   async execute(args, ctx) {
-    const response = await ctx.callVantageApi("/v2/virtual_tag_configs", args, "POST");
+    const response = await ctx.callVantageApi(
+      "/v2/virtual_tag_configs",
+      args as unknown as CreateVirtualTagConfigRequest,
+      "POST"
+    );
     if (!response.ok) {
       throw new MCPUserError({ errors: response.errors });
     }

--- a/src/tools/virtual-tag-configs/delete-virtual-tag-config.ts
+++ b/src/tools/virtual-tag-configs/delete-virtual-tag-config.ts
@@ -1,0 +1,33 @@
+import { pathEncode } from "@vantage-sh/vantage-client";
+import { vantageToken } from "../../utils/zod";
+import MCPUserError from "../structure/MCPUserError";
+import registerTool from "../structure/registerTool";
+
+const description = `
+Deletes an entire Virtual Tag Config and all of its values. To remove only one value, use delete-virtual-tag-config-value instead.
+`.trim();
+
+export default registerTool({
+  name: "delete-virtual-tag-config",
+  title: "Delete Virtual Tag Config",
+  description,
+  annotations: {
+    destructive: true,
+    openWorld: false,
+    readOnly: false,
+  },
+  args: {
+    virtual_tag_config_token: vantageToken("virtual_tag_config"),
+  },
+  async execute(args, ctx) {
+    const response = await ctx.callVantageApi(
+      `/v2/virtual_tag_configs/${pathEncode(args.virtual_tag_config_token)}`,
+      {},
+      "DELETE"
+    );
+    if (!response.ok) {
+      throw new MCPUserError({ errors: response.errors });
+    }
+    return { token: args.virtual_tag_config_token };
+  },
+});

--- a/src/tools/virtual-tag-configs/delete-virtual-tag-config.ts
+++ b/src/tools/virtual-tag-configs/delete-virtual-tag-config.ts
@@ -4,7 +4,7 @@ import MCPUserError from "../structure/MCPUserError";
 import registerTool from "../structure/registerTool";
 
 const description = `
-Deletes an entire Virtual Tag Config and all of its values. To remove only one value, use delete-virtual-tag-config-value instead.
+Deletes an entire Virtual Tag Config and all of its mappings/values. To remove only one mapping, use delete-virtual-tag-config-value instead.
 `.trim();
 
 export default registerTool({

--- a/src/tools/virtual-tag-configs/get-virtual-tag-config.ts
+++ b/src/tools/virtual-tag-configs/get-virtual-tag-config.ts
@@ -1,0 +1,33 @@
+import { pathEncode } from "@vantage-sh/vantage-client";
+import { vantageToken } from "../../utils/zod";
+import MCPUserError from "../structure/MCPUserError";
+import registerTool from "../structure/registerTool";
+
+const description = `
+Returns an existing Virtual Tag Config with all of its values. Use this to inspect the tag and discover value tokens before adding, editing, or removing individual values.
+`.trim();
+
+export default registerTool({
+  name: "get-virtual-tag-config",
+  title: "Get Virtual Tag Config",
+  description,
+  annotations: {
+    destructive: false,
+    openWorld: false,
+    readOnly: true,
+  },
+  args: {
+    virtual_tag_config_token: vantageToken("virtual_tag_config"),
+  },
+  async execute(args, ctx) {
+    const response = await ctx.callVantageApi(
+      `/v2/virtual_tag_configs/${pathEncode(args.virtual_tag_config_token)}`,
+      {},
+      "GET"
+    );
+    if (!response.ok) {
+      throw new MCPUserError({ errors: response.errors });
+    }
+    return response.data;
+  },
+});

--- a/src/tools/virtual-tag-configs/get-virtual-tag-config.ts
+++ b/src/tools/virtual-tag-configs/get-virtual-tag-config.ts
@@ -4,7 +4,7 @@ import MCPUserError from "../structure/MCPUserError";
 import registerTool from "../structure/registerTool";
 
 const description = `
-Returns an existing Virtual Tag Config with all of its values. Use this to inspect the tag and discover value tokens before adding, editing, or removing individual values.
+Returns one existing Virtual Tag (Virtual Tag Config) with its complete ordered mappings/values. Use this to show all values on a tag and discover value tokens before editing or reordering.
 `.trim();
 
 export default registerTool({

--- a/src/tools/virtual-tag-configs/index.ts
+++ b/src/tools/virtual-tag-configs/index.ts
@@ -1,1 +1,2 @@
 import "./create-virtual-tag-config";
+import "./get-virtual-tag-config";

--- a/src/tools/virtual-tag-configs/index.ts
+++ b/src/tools/virtual-tag-configs/index.ts
@@ -1,2 +1,5 @@
 import "./create-virtual-tag-config";
+import "./delete-virtual-tag-config";
 import "./get-virtual-tag-config";
+import "./list-virtual-tag-configs";
+import "./update-virtual-tag-config";

--- a/src/tools/virtual-tag-configs/list-virtual-tag-configs.ts
+++ b/src/tools/virtual-tag-configs/list-virtual-tag-configs.ts
@@ -3,7 +3,7 @@ import MCPUserError from "../structure/MCPUserError";
 import registerTool from "../structure/registerTool";
 
 const description = `
-Returns all Virtual Tag Configs the current API token can access, including their values. Use this to discover config and value tokens; optionally search by tag key.
+Lists or searches the Virtual Tags (Virtual Tag Configs) the current API token can access, including every mapping/value. Use this to discover config and value tokens or find a tag by key.
 `.trim();
 
 export default registerTool({

--- a/src/tools/virtual-tag-configs/list-virtual-tag-configs.ts
+++ b/src/tools/virtual-tag-configs/list-virtual-tag-configs.ts
@@ -1,0 +1,28 @@
+import { nonempty } from "../../utils/zod";
+import MCPUserError from "../structure/MCPUserError";
+import registerTool from "../structure/registerTool";
+
+const description = `
+Returns all Virtual Tag Configs the current API token can access, including their values. Use this to discover config and value tokens; optionally search by tag key.
+`.trim();
+
+export default registerTool({
+  name: "list-virtual-tag-configs",
+  title: "List Virtual Tag Configs",
+  description,
+  annotations: {
+    destructive: false,
+    openWorld: false,
+    readOnly: true,
+  },
+  args: {
+    q: nonempty().optional().describe("Search query that filters Virtual Tag Configs by key."),
+  },
+  async execute(args, ctx) {
+    const response = await ctx.callVantageApi("/v2/virtual_tag_configs", args, "GET");
+    if (!response.ok) {
+      throw new MCPUserError({ errors: response.errors });
+    }
+    return response.data;
+  },
+});

--- a/src/tools/virtual-tag-configs/schemas.ts
+++ b/src/tools/virtual-tag-configs/schemas.ts
@@ -1,0 +1,56 @@
+import z from "zod";
+import dateValidator from "../../utils/dateValidator";
+import { nonempty, vantageToken } from "../../utils/zod";
+
+export const collapsedTagKeySchema = z.object({
+  key: nonempty().describe("Tag key whose values should be collapsed."),
+  providers: z
+    .array(nonempty())
+    .optional()
+    .describe("Providers this collapsed tag key applies to. Do not combine with filter."),
+  filter: nonempty()
+    .optional()
+    .describe("VQL filter limiting where this collapsed tag key applies. Do not combine with providers."),
+});
+
+const labelTransformSchema = z.object({
+  type: z.enum(["split", "format"]).describe("Label transform operation."),
+  delimiter: nonempty().nullable().optional().describe("Delimiter used by a split transform."),
+  index: z.number().int().nullable().optional().describe("Zero-based index used by a split transform."),
+  template: nonempty().nullable().optional().describe("Template used by a format transform."),
+});
+
+const costMetricSchema = z.object({
+  filter: nonempty().describe("VQL filter for the cost metric used to allocate matching costs."),
+  aggregation: z.object({
+    tag: nonempty().describe("Tag key used to aggregate the cost metric."),
+  }),
+});
+
+const percentageSchema = z.object({
+  value: nonempty().describe("Virtual tag value receiving this percentage of matched costs."),
+  pct: z.number().describe("Percentage of matched costs allocated to the value."),
+});
+
+const dateRangeSchema = z.object({
+  start_date: dateValidator("Inclusive start date, YYYY-MM-DD.").optional(),
+  end_date: dateValidator("Inclusive end date, YYYY-MM-DD.").optional(),
+});
+
+export const virtualTagConfigValueSchema = z.object({
+  filter: nonempty().describe("VQL filter that determines which costs match this value."),
+  name: nonempty().optional().describe("Name for a simple value."),
+  business_metric_token: vantageToken("business_metric", {
+    description: "Associates this value with a Business Metric.",
+  }).optional(),
+  label_key: nonempty().optional().describe("Business Metric label key used by this value."),
+  label_values: z
+    .array(z.string())
+    .optional()
+    .describe("Business Metric label values. An empty array includes every value for the label key."),
+  display_name: nonempty().optional().describe("Display name for a cost metric or percentage allocation value."),
+  label_transforms: z.array(labelTransformSchema).optional().describe("Transforms applied to Business Metric labels."),
+  cost_metric: costMetricSchema.optional().describe("Cost metric used for dynamic allocation."),
+  percentages: z.array(percentageSchema).optional().describe("Fixed percentage allocations for matching costs."),
+  date_ranges: z.array(dateRangeSchema).optional().describe("Date ranges that restrict when this value applies."),
+});

--- a/src/tools/virtual-tag-configs/schemas.ts
+++ b/src/tools/virtual-tag-configs/schemas.ts
@@ -33,8 +33,8 @@ const percentageSchema = z.object({
 });
 
 const dateRangeSchema = z.object({
-  start_date: dateValidator("Inclusive start date, YYYY-MM-DD.").optional(),
-  end_date: dateValidator("Inclusive end date, YYYY-MM-DD.").optional(),
+  start_date: dateValidator("Inclusive start date, YYYY-MM-DD, or null for no lower bound.").nullable().optional(),
+  end_date: dateValidator("Inclusive end date, YYYY-MM-DD, or null for no upper bound.").nullable().optional(),
 });
 
 export const virtualTagConfigValueSchema = z.object({

--- a/src/tools/virtual-tag-configs/update-virtual-tag-config.ts
+++ b/src/tools/virtual-tag-configs/update-virtual-tag-config.ts
@@ -24,11 +24,7 @@ export default registerTool({
   args: {
     virtual_tag_config_token: vantageToken("virtual_tag_config"),
     key: nonempty().optional().describe("New key for the Virtual Tag Config."),
-    overridable: z
-      .boolean()
-      .nullable()
-      .optional()
-      .describe("Whether the config can override a matching provider-supplied tag."),
+    overridable: z.boolean().optional().describe("Whether the config can override a matching provider-supplied tag."),
     backfill_until: dateValidator("Earliest backfill month, YYYY-MM-DD. Use null to clear.").nullable().optional(),
     collapsed_tag_keys: z
       .array(collapsedTagKeySchema)

--- a/src/tools/virtual-tag-configs/update-virtual-tag-config.ts
+++ b/src/tools/virtual-tag-configs/update-virtual-tag-config.ts
@@ -1,0 +1,62 @@
+import { pathEncode, type UpdateVirtualTagConfigRequest } from "@vantage-sh/vantage-client";
+import z from "zod";
+import dateValidator from "../../utils/dateValidator";
+import { nonempty, vantageToken } from "../../utils/zod";
+import MCPUserError from "../structure/MCPUserError";
+import registerTool from "../structure/registerTool";
+import { collapsedTagKeySchema, virtualTagConfigValueSchema } from "./schemas";
+
+const description = `
+Updates an existing Virtual Tag Config's key, settings, collapsed tags, or complete ordered values list. Use the individual Virtual Tag Config Value tools for single-value edits; supplying values here replaces the full list and determines its order.
+`.trim();
+
+const mutableFields = ["key", "overridable", "backfill_until", "collapsed_tag_keys", "values"] as const;
+
+export default registerTool({
+  name: "update-virtual-tag-config",
+  title: "Update Virtual Tag Config",
+  description,
+  annotations: {
+    destructive: true,
+    openWorld: false,
+    readOnly: false,
+  },
+  args: {
+    virtual_tag_config_token: vantageToken("virtual_tag_config"),
+    key: nonempty().optional().describe("New key for the Virtual Tag Config."),
+    overridable: z
+      .boolean()
+      .nullable()
+      .optional()
+      .describe("Whether the config can override a matching provider-supplied tag."),
+    backfill_until: dateValidator("Earliest backfill month, YYYY-MM-DD. Use null to clear.").nullable().optional(),
+    collapsed_tag_keys: z
+      .array(collapsedTagKeySchema)
+      .optional()
+      .describe("Complete replacement list of tag keys whose values should be collapsed."),
+    values: z
+      .array(virtualTagConfigValueSchema)
+      .optional()
+      .describe(
+        "Complete ordered replacement list of values. Use get-virtual-tag-config first and include every value that should remain."
+      ),
+  },
+  async execute(args, ctx) {
+    if (!mutableFields.some((field) => args[field] !== undefined)) {
+      throw new MCPUserError({
+        errors: [{ message: "At least one Virtual Tag Config field must be provided." }],
+      });
+    }
+
+    const { virtual_tag_config_token, ...body } = args;
+    const response = await ctx.callVantageApi(
+      `/v2/virtual_tag_configs/${pathEncode(virtual_tag_config_token)}`,
+      body as UpdateVirtualTagConfigRequest,
+      "PUT"
+    );
+    if (!response.ok) {
+      throw new MCPUserError({ errors: response.errors });
+    }
+    return response.data;
+  },
+});

--- a/src/tools/virtual-tag-configs/update-virtual-tag-config.ts
+++ b/src/tools/virtual-tag-configs/update-virtual-tag-config.ts
@@ -7,7 +7,7 @@ import registerTool from "../structure/registerTool";
 import { collapsedTagKeySchema, virtualTagConfigValueSchema } from "./schemas";
 
 const description = `
-Updates an existing Virtual Tag Config's key, settings, collapsed tags, or complete ordered values list. Use the individual Virtual Tag Config Value tools for single-value edits; supplying values here replaces the full list and determines its order.
+Updates an existing Virtual Tag's config-level settings or complete ordered mappings/values. Supplying values replaces the entire list in that order, and an empty array clears it; use the value-level tools to append, partially edit, or delete one mapping.
 `.trim();
 
 const mutableFields = ["key", "overridable", "backfill_until", "collapsed_tag_keys", "values"] as const;
@@ -38,7 +38,7 @@ export default registerTool({
       .array(virtualTagConfigValueSchema)
       .optional()
       .describe(
-        "Complete ordered replacement list of values. Use get-virtual-tag-config first and include every value that should remain."
+        "Complete ordered replacement list of values. Use get-virtual-tag-config first and include every value that should remain; an empty array clears all values."
       ),
   },
   async execute(args, ctx) {

--- a/src/utils/zod/token-kinds.ts
+++ b/src/utils/zod/token-kinds.ts
@@ -146,6 +146,10 @@ export const TOKEN_KINDS = {
     prefix: "vtag",
     label: "Virtual Tag Config",
   },
+  virtual_tag_config_value: {
+    prefix: "vtag_val",
+    label: "Virtual Tag Config Value",
+  },
   workspace: {
     prefix: "wrkspc",
     label: "Workspace",

--- a/test/tools/virtual-tag-config-values/create-virtual-tag-config-value.test.ts
+++ b/test/tools/virtual-tag-config-values/create-virtual-tag-config-value.test.ts
@@ -118,13 +118,14 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
     },
   },
   {
-    name: "requires exactly one value type field",
+    name: "requires a non-empty value type field",
     apiCallHandler: requestsInOrder([]),
     handler: async ({ callExpectingMCPUserError }) => {
       const error = await callExpectingMCPUserError({
         ...undefineds,
         virtual_tag_config_token: "vtag_123",
         filter: "costs.provider = 'aws'",
+        percentages: [],
       });
       expect(error.exception).toEqual({
         errors: [

--- a/test/tools/virtual-tag-config-values/create-virtual-tag-config-value.test.ts
+++ b/test/tools/virtual-tag-config-values/create-virtual-tag-config-value.test.ts
@@ -69,6 +69,20 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
     },
   },
   {
+    name: "rejects a null display name",
+    data: {
+      ...undefineds,
+      virtual_tag_config_token: "vtag_123",
+      filter: "costs.provider = 'aws'",
+      cost_metric: {
+        filter: "costs.provider = 'aws'",
+        aggregation: { tag: "team" },
+      },
+      display_name: null as never,
+    },
+    expectedIssues: ["Invalid input: expected string, received null"],
+  },
+  {
     name: "valid percentage value",
     data: {
       ...undefineds,

--- a/test/tools/virtual-tag-config-values/create-virtual-tag-config-value.test.ts
+++ b/test/tools/virtual-tag-config-values/create-virtual-tag-config-value.test.ts
@@ -1,0 +1,175 @@
+import { type CreateVirtualTagConfigValueResponse, pathEncode } from "@vantage-sh/vantage-client";
+import { expect } from "vitest";
+import tool from "../../../src/tools/virtual-tag-config-values/create-virtual-tag-config-value";
+import {
+  type ExecutionTestTableItem,
+  type ExtractOutputSchema,
+  type ExtractValidators,
+  type InferValidators,
+  requestsInOrder,
+  type SchemaTestTableItem,
+  testTool,
+} from "../../../src/utils/testing";
+
+type Validators = ExtractValidators<typeof tool>;
+type OutputSchema = ExtractOutputSchema<typeof tool>;
+
+const undefineds = {
+  name: undefined,
+  business_metric_token: undefined,
+  label_key: undefined,
+  label_values: undefined,
+  display_name: undefined,
+  label_transforms: undefined,
+  cost_metric: undefined,
+  percentages: undefined,
+  date_ranges: undefined,
+};
+
+const validArguments: InferValidators<Validators> = {
+  ...undefineds,
+  virtual_tag_config_token: "vtag_123",
+  filter: "costs.provider = 'aws'",
+  business_metric_token: "bsnss_mtrc_123",
+  label_key: "team",
+  label_values: ["platform"],
+  label_transforms: [{ type: "split", delimiter: "-", index: 0 }],
+  date_ranges: [{ start_date: "2026-01-01", end_date: null }],
+};
+
+const requestBody = {
+  filter: validArguments.filter,
+  name: validArguments.name,
+  business_metric_token: validArguments.business_metric_token,
+  label_key: validArguments.label_key,
+  label_values: validArguments.label_values,
+  display_name: validArguments.display_name,
+  label_transforms: validArguments.label_transforms,
+  cost_metric: validArguments.cost_metric,
+  percentages: validArguments.percentages,
+  date_ranges: validArguments.date_ranges,
+};
+
+const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
+  {
+    name: "valid business metric value",
+    data: validArguments,
+  },
+  {
+    name: "valid cost metric value",
+    data: {
+      ...undefineds,
+      virtual_tag_config_token: "vtag_123",
+      filter: "costs.provider = 'aws'",
+      display_name: "Allocated Team",
+      cost_metric: {
+        filter: "costs.provider = 'aws'",
+        aggregation: { tag: "team" },
+      },
+    },
+  },
+  {
+    name: "valid percentage value",
+    data: {
+      ...undefineds,
+      virtual_tag_config_token: "vtag_123",
+      filter: "costs.provider = 'aws'",
+      percentages: [
+        { value: "platform", pct: 60 },
+        { value: "product", pct: 40 },
+      ],
+    },
+  },
+  {
+    name: "invalid date range",
+    data: {
+      ...validArguments,
+      date_ranges: [{ start_date: "not-a-date" }],
+    },
+    expectedIssues: ["Invalid date input, must be YYYY-MM-DD format and a reasonable date."],
+  },
+];
+
+const successData: CreateVirtualTagConfigValueResponse = {
+  token: "vtag_val_123",
+  filter: "costs.provider = 'aws'",
+  business_metric_token: "bsnss_mtrc_123",
+  label_key: "team",
+  label_values: ["platform"],
+  label_transforms: [{ type: "split", delimiter: "-", index: 0 }],
+  percentages: [],
+  date_ranges: [{ start_date: "2026-01-01", end_date: null }],
+};
+
+const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
+  {
+    name: "successful call",
+    apiCallHandler: requestsInOrder([
+      {
+        endpoint: `/v2/virtual_tag_configs/${pathEncode("vtag_123")}/values`,
+        params: requestBody,
+        method: "POST",
+        result: { ok: true, data: successData },
+      },
+    ]),
+    handler: async ({ callExpectingSuccess }) => {
+      const result = await callExpectingSuccess(validArguments);
+      expect(result).toEqual(successData);
+    },
+  },
+  {
+    name: "requires exactly one value type field",
+    apiCallHandler: requestsInOrder([]),
+    handler: async ({ callExpectingMCPUserError }) => {
+      const error = await callExpectingMCPUserError({
+        ...undefineds,
+        virtual_tag_config_token: "vtag_123",
+        filter: "costs.provider = 'aws'",
+      });
+      expect(error.exception).toEqual({
+        errors: [
+          {
+            message: "Exactly one of name, business_metric_token, cost_metric, or percentages must be provided.",
+          },
+        ],
+      });
+    },
+  },
+  {
+    name: "rejects multiple value type fields",
+    apiCallHandler: requestsInOrder([]),
+    handler: async ({ callExpectingMCPUserError }) => {
+      const error = await callExpectingMCPUserError({
+        ...undefineds,
+        virtual_tag_config_token: "vtag_123",
+        filter: "costs.provider = 'aws'",
+        name: "Platform",
+        percentages: [{ value: "platform", pct: 100 }],
+      });
+      expect(error.exception).toEqual({
+        errors: [
+          {
+            message: "Exactly one of name, business_metric_token, cost_metric, or percentages must be provided.",
+          },
+        ],
+      });
+    },
+  },
+  {
+    name: "unsuccessful call",
+    apiCallHandler: requestsInOrder([
+      {
+        endpoint: `/v2/virtual_tag_configs/${pathEncode("vtag_123")}/values`,
+        params: requestBody,
+        method: "POST",
+        result: { ok: false, errors: [{ message: "Invalid VQL" }] },
+      },
+    ]),
+    handler: async ({ callExpectingMCPUserError }) => {
+      const error = await callExpectingMCPUserError(validArguments);
+      expect(error.exception).toEqual({ errors: [{ message: "Invalid VQL" }] });
+    },
+  },
+];
+
+testTool(tool, argumentSchemaTests, executionTests);

--- a/test/tools/virtual-tag-config-values/delete-virtual-tag-config-value.test.ts
+++ b/test/tools/virtual-tag-config-values/delete-virtual-tag-config-value.test.ts
@@ -1,0 +1,48 @@
+import { pathEncode } from "@vantage-sh/vantage-client";
+import { expect } from "vitest";
+import tool from "../../../src/tools/virtual-tag-config-values/delete-virtual-tag-config-value";
+import { requestsInOrder, testTool } from "../../../src/utils/testing";
+
+const validArguments = {
+  virtual_tag_config_token: "vtag_123",
+  virtual_tag_config_value_token: "vtag_val_456",
+};
+
+testTool(
+  tool,
+  [{ name: "valid tokens", data: validArguments }],
+  [
+    {
+      name: "successful call",
+      apiCallHandler: requestsInOrder([
+        {
+          endpoint: `/v2/virtual_tag_configs/${pathEncode("vtag_123")}/values/${pathEncode("vtag_val_456")}`,
+          params: {},
+          method: "DELETE",
+          result: { ok: true, data: undefined },
+        },
+      ]),
+      handler: async ({ callExpectingSuccess }) => {
+        const result = await callExpectingSuccess(validArguments);
+        expect(result).toEqual({ token: "vtag_val_456" });
+      },
+    },
+    {
+      name: "unsuccessful call",
+      apiCallHandler: requestsInOrder([
+        {
+          endpoint: `/v2/virtual_tag_configs/${pathEncode("vtag_123")}/values/${pathEncode("vtag_val_456")}`,
+          params: {},
+          method: "DELETE",
+          result: { ok: false, errors: [{ message: "VirtualTagConfigValue not found" }] },
+        },
+      ]),
+      handler: async ({ callExpectingMCPUserError }) => {
+        const error = await callExpectingMCPUserError(validArguments);
+        expect(error.exception).toEqual({
+          errors: [{ message: "VirtualTagConfigValue not found" }],
+        });
+      },
+    },
+  ]
+);

--- a/test/tools/virtual-tag-config-values/get-virtual-tag-config-value.test.ts
+++ b/test/tools/virtual-tag-config-values/get-virtual-tag-config-value.test.ts
@@ -1,0 +1,57 @@
+import { type GetVirtualTagConfigValueResponse, pathEncode } from "@vantage-sh/vantage-client";
+import { expect } from "vitest";
+import tool from "../../../src/tools/virtual-tag-config-values/get-virtual-tag-config-value";
+import { requestsInOrder, testTool } from "../../../src/utils/testing";
+
+const validArguments = {
+  virtual_tag_config_token: "vtag_123",
+  virtual_tag_config_value_token: "vtag_val_456",
+};
+
+const successData: GetVirtualTagConfigValueResponse = {
+  token: "vtag_val_456",
+  filter: "costs.provider = 'aws'",
+  name: "AWS",
+  label_transforms: [],
+  percentages: [],
+  date_ranges: [],
+};
+
+testTool(
+  tool,
+  [{ name: "valid tokens", data: validArguments }],
+  [
+    {
+      name: "successful call",
+      apiCallHandler: requestsInOrder([
+        {
+          endpoint: `/v2/virtual_tag_configs/${pathEncode("vtag_123")}/values/${pathEncode("vtag_val_456")}`,
+          params: {},
+          method: "GET",
+          result: { ok: true, data: successData },
+        },
+      ]),
+      handler: async ({ callExpectingSuccess }) => {
+        const result = await callExpectingSuccess(validArguments);
+        expect(result).toEqual(successData);
+      },
+    },
+    {
+      name: "unsuccessful call",
+      apiCallHandler: requestsInOrder([
+        {
+          endpoint: `/v2/virtual_tag_configs/${pathEncode("vtag_123")}/values/${pathEncode("vtag_val_456")}`,
+          params: {},
+          method: "GET",
+          result: { ok: false, errors: [{ message: "VirtualTagConfigValue not found" }] },
+        },
+      ]),
+      handler: async ({ callExpectingMCPUserError }) => {
+        const error = await callExpectingMCPUserError(validArguments);
+        expect(error.exception).toEqual({
+          errors: [{ message: "VirtualTagConfigValue not found" }],
+        });
+      },
+    },
+  ]
+);

--- a/test/tools/virtual-tag-config-values/update-virtual-tag-config-value.test.ts
+++ b/test/tools/virtual-tag-config-values/update-virtual-tag-config-value.test.ts
@@ -1,0 +1,145 @@
+import { pathEncode, type UpdateVirtualTagConfigValueResponse } from "@vantage-sh/vantage-client";
+import { expect } from "vitest";
+import tool from "../../../src/tools/virtual-tag-config-values/update-virtual-tag-config-value";
+import {
+  type ExecutionTestTableItem,
+  type ExtractOutputSchema,
+  type ExtractValidators,
+  type InferValidators,
+  requestsInOrder,
+  type SchemaTestTableItem,
+  testTool,
+} from "../../../src/utils/testing";
+
+type Validators = ExtractValidators<typeof tool>;
+type OutputSchema = ExtractOutputSchema<typeof tool>;
+
+const undefineds = {
+  filter: undefined,
+  name: undefined,
+  business_metric_token: undefined,
+  label_key: undefined,
+  label_values: undefined,
+  display_name: undefined,
+  label_transforms: undefined,
+  cost_metric: undefined,
+  percentages: undefined,
+  date_ranges: undefined,
+};
+
+const validArguments: InferValidators<Validators> = {
+  ...undefineds,
+  virtual_tag_config_token: "vtag_123",
+  virtual_tag_config_value_token: "vtag_val_456",
+  filter: "costs.provider = 'gcp'",
+};
+
+const requestBody = {
+  filter: validArguments.filter,
+  name: validArguments.name,
+  business_metric_token: validArguments.business_metric_token,
+  label_key: validArguments.label_key,
+  label_values: validArguments.label_values,
+  display_name: validArguments.display_name,
+  label_transforms: validArguments.label_transforms,
+  cost_metric: validArguments.cost_metric,
+  percentages: validArguments.percentages,
+  date_ranges: validArguments.date_ranges,
+};
+
+const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
+  {
+    name: "valid partial update",
+    data: validArguments,
+  },
+  {
+    name: "clears optional fields",
+    data: {
+      ...undefineds,
+      virtual_tag_config_token: "vtag_123",
+      virtual_tag_config_value_token: "vtag_val_456",
+      display_name: null,
+      label_values: [],
+      label_transforms: [],
+      date_ranges: [],
+    },
+  },
+];
+
+const successData: UpdateVirtualTagConfigValueResponse = {
+  token: "vtag_val_456",
+  filter: "costs.provider = 'gcp'",
+  name: "Cloud",
+  label_transforms: [],
+  percentages: [],
+  date_ranges: [],
+};
+
+const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
+  {
+    name: "successful partial update",
+    apiCallHandler: requestsInOrder([
+      {
+        endpoint: `/v2/virtual_tag_configs/${pathEncode("vtag_123")}/values/${pathEncode("vtag_val_456")}`,
+        params: requestBody,
+        method: "PATCH",
+        result: { ok: true, data: successData },
+      },
+    ]),
+    handler: async ({ callExpectingSuccess }) => {
+      const result = await callExpectingSuccess(validArguments);
+      expect(result).toEqual(successData);
+    },
+  },
+  {
+    name: "requires a field to update",
+    apiCallHandler: requestsInOrder([]),
+    handler: async ({ callExpectingMCPUserError }) => {
+      const error = await callExpectingMCPUserError({
+        ...undefineds,
+        virtual_tag_config_token: "vtag_123",
+        virtual_tag_config_value_token: "vtag_val_456",
+      });
+      expect(error.exception).toEqual({
+        errors: [{ message: "At least one Virtual Tag Config Value field must be provided." }],
+      });
+    },
+  },
+  {
+    name: "rejects multiple value type fields",
+    apiCallHandler: requestsInOrder([]),
+    handler: async ({ callExpectingMCPUserError }) => {
+      const error = await callExpectingMCPUserError({
+        ...undefineds,
+        virtual_tag_config_token: "vtag_123",
+        virtual_tag_config_value_token: "vtag_val_456",
+        name: "Platform",
+        business_metric_token: "bsnss_mtrc_123",
+      });
+      expect(error.exception).toEqual({
+        errors: [
+          {
+            message: "Only one of name, business_metric_token, cost_metric, or percentages may be provided.",
+          },
+        ],
+      });
+    },
+  },
+  {
+    name: "unsuccessful call",
+    apiCallHandler: requestsInOrder([
+      {
+        endpoint: `/v2/virtual_tag_configs/${pathEncode("vtag_123")}/values/${pathEncode("vtag_val_456")}`,
+        params: requestBody,
+        method: "PATCH",
+        result: { ok: false, errors: [{ message: "Invalid VQL" }] },
+      },
+    ]),
+    handler: async ({ callExpectingMCPUserError }) => {
+      const error = await callExpectingMCPUserError(validArguments);
+      expect(error.exception).toEqual({ errors: [{ message: "Invalid VQL" }] });
+    },
+  },
+];
+
+testTool(tool, argumentSchemaTests, executionTests);

--- a/test/tools/virtual-tag-config-values/update-virtual-tag-config-value.test.ts
+++ b/test/tools/virtual-tag-config-values/update-virtual-tag-config-value.test.ts
@@ -32,6 +32,8 @@ const validArguments: InferValidators<Validators> = {
   virtual_tag_config_token: "vtag_123",
   virtual_tag_config_value_token: "vtag_val_456",
   filter: "costs.provider = 'gcp'",
+  name: "Cloud",
+  percentages: [],
 };
 
 const requestBody = {

--- a/test/tools/virtual-tag-configs/create-virtual-tag-config.test.ts
+++ b/test/tools/virtual-tag-configs/create-virtual-tag-config.test.ts
@@ -1,3 +1,4 @@
+import type { CreateVirtualTagConfigRequest } from "@vantage-sh/vantage-client";
 import { expect } from "vitest";
 import tool from "../../../src/tools/virtual-tag-configs/create-virtual-tag-config";
 import {
@@ -96,7 +97,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
     apiCallHandler: requestsInOrder([
       {
         endpoint: "/v2/virtual_tag_configs",
-        params: validInputArguments,
+        params: validInputArguments as unknown as CreateVirtualTagConfigRequest,
         method: "POST",
         result: {
           ok: true,
@@ -114,7 +115,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
     apiCallHandler: requestsInOrder([
       {
         endpoint: "/v2/virtual_tag_configs",
-        params: minimalValidInputArguments,
+        params: minimalValidInputArguments as unknown as CreateVirtualTagConfigRequest,
         method: "POST",
         result: {
           ok: false,

--- a/test/tools/virtual-tag-configs/delete-virtual-tag-config.test.ts
+++ b/test/tools/virtual-tag-configs/delete-virtual-tag-config.test.ts
@@ -1,0 +1,47 @@
+import { pathEncode } from "@vantage-sh/vantage-client";
+import { expect } from "vitest";
+import tool from "../../../src/tools/virtual-tag-configs/delete-virtual-tag-config";
+import { requestsInOrder, testTool } from "../../../src/utils/testing";
+
+const validArguments = {
+  virtual_tag_config_token: "vtag_123",
+};
+
+testTool(
+  tool,
+  [{ name: "valid token", data: validArguments }],
+  [
+    {
+      name: "successful call",
+      apiCallHandler: requestsInOrder([
+        {
+          endpoint: `/v2/virtual_tag_configs/${pathEncode("vtag_123")}`,
+          params: {},
+          method: "DELETE",
+          result: { ok: true, data: undefined },
+        },
+      ]),
+      handler: async ({ callExpectingSuccess }) => {
+        const result = await callExpectingSuccess(validArguments);
+        expect(result).toEqual({ token: "vtag_123" });
+      },
+    },
+    {
+      name: "unsuccessful call",
+      apiCallHandler: requestsInOrder([
+        {
+          endpoint: `/v2/virtual_tag_configs/${pathEncode("vtag_123")}`,
+          params: {},
+          method: "DELETE",
+          result: { ok: false, errors: [{ message: "VirtualTagConfig not found" }] },
+        },
+      ]),
+      handler: async ({ callExpectingMCPUserError }) => {
+        const error = await callExpectingMCPUserError(validArguments);
+        expect(error.exception).toEqual({
+          errors: [{ message: "VirtualTagConfig not found" }],
+        });
+      },
+    },
+  ]
+);

--- a/test/tools/virtual-tag-configs/get-virtual-tag-config.test.ts
+++ b/test/tools/virtual-tag-configs/get-virtual-tag-config.test.ts
@@ -1,0 +1,74 @@
+import { type GetVirtualTagConfigResponse, pathEncode } from "@vantage-sh/vantage-client";
+import { expect } from "vitest";
+import tool from "../../../src/tools/virtual-tag-configs/get-virtual-tag-config";
+import { requestsInOrder, testTool } from "../../../src/utils/testing";
+
+const validArguments = {
+  virtual_tag_config_token: "vtag_123",
+};
+
+const successData: GetVirtualTagConfigResponse = {
+  token: "vtag_123",
+  created_by_token: null,
+  key: "team",
+  overridable: true,
+  backfill_until: "2026-01-01",
+  collapsed_tag_keys: [],
+  values: [
+    {
+      token: "vtag_val_456",
+      filter: "costs.provider = 'aws'",
+      name: "Platform",
+      label_transforms: [],
+      percentages: [],
+      date_ranges: [],
+    },
+    {
+      token: "vtag_val_789",
+      filter: "costs.provider = 'gcp'",
+      name: "Product",
+      label_transforms: [],
+      percentages: [],
+      date_ranges: [],
+    },
+  ],
+};
+
+testTool(
+  tool,
+  [{ name: "valid token", data: validArguments }],
+  [
+    {
+      name: "returns the config with all values",
+      apiCallHandler: requestsInOrder([
+        {
+          endpoint: `/v2/virtual_tag_configs/${pathEncode("vtag_123")}`,
+          params: {},
+          method: "GET",
+          result: { ok: true, data: successData },
+        },
+      ]),
+      handler: async ({ callExpectingSuccess }) => {
+        const result = await callExpectingSuccess(validArguments);
+        expect(result).toEqual(successData);
+      },
+    },
+    {
+      name: "unsuccessful call",
+      apiCallHandler: requestsInOrder([
+        {
+          endpoint: `/v2/virtual_tag_configs/${pathEncode("vtag_123")}`,
+          params: {},
+          method: "GET",
+          result: { ok: false, errors: [{ message: "VirtualTagConfig not found" }] },
+        },
+      ]),
+      handler: async ({ callExpectingMCPUserError }) => {
+        const error = await callExpectingMCPUserError(validArguments);
+        expect(error.exception).toEqual({
+          errors: [{ message: "VirtualTagConfig not found" }],
+        });
+      },
+    },
+  ]
+);

--- a/test/tools/virtual-tag-configs/list-virtual-tag-configs.test.ts
+++ b/test/tools/virtual-tag-configs/list-virtual-tag-configs.test.ts
@@ -1,0 +1,71 @@
+import type { GetVirtualTagConfigsResponse } from "@vantage-sh/vantage-client";
+import { expect } from "vitest";
+import tool from "../../../src/tools/virtual-tag-configs/list-virtual-tag-configs";
+import { requestsInOrder, testTool } from "../../../src/utils/testing";
+
+const validArguments = {
+  q: "team",
+};
+
+const successData: GetVirtualTagConfigsResponse = {
+  virtual_tag_configs: [
+    {
+      token: "vtag_123",
+      created_by_token: null,
+      key: "team",
+      overridable: true,
+      backfill_until: "2026-01-01",
+      collapsed_tag_keys: [],
+      values: [
+        {
+          token: "vtag_val_456",
+          filter: "costs.provider = 'aws'",
+          name: "Platform",
+          label_transforms: [],
+          percentages: [],
+          date_ranges: [],
+        },
+      ],
+    },
+  ],
+};
+
+testTool(
+  tool,
+  [
+    { name: "lists all configs", data: { q: undefined } },
+    { name: "searches configs by key", data: validArguments },
+  ],
+  [
+    {
+      name: "successful call",
+      apiCallHandler: requestsInOrder([
+        {
+          endpoint: "/v2/virtual_tag_configs",
+          params: validArguments,
+          method: "GET",
+          result: { ok: true, data: successData },
+        },
+      ]),
+      handler: async ({ callExpectingSuccess }) => {
+        const result = await callExpectingSuccess(validArguments);
+        expect(result).toEqual(successData);
+      },
+    },
+    {
+      name: "unsuccessful call",
+      apiCallHandler: requestsInOrder([
+        {
+          endpoint: "/v2/virtual_tag_configs",
+          params: validArguments,
+          method: "GET",
+          result: { ok: false, errors: [{ message: "Access denied" }] },
+        },
+      ]),
+      handler: async ({ callExpectingMCPUserError }) => {
+        const error = await callExpectingMCPUserError(validArguments);
+        expect(error.exception).toEqual({ errors: [{ message: "Access denied" }] });
+      },
+    },
+  ]
+);

--- a/test/tools/virtual-tag-configs/update-virtual-tag-config.test.ts
+++ b/test/tools/virtual-tag-configs/update-virtual-tag-config.test.ts
@@ -1,0 +1,154 @@
+import { pathEncode, type UpdateVirtualTagConfigResponse } from "@vantage-sh/vantage-client";
+import { expect } from "vitest";
+import tool from "../../../src/tools/virtual-tag-configs/update-virtual-tag-config";
+import {
+  type ExecutionTestTableItem,
+  type ExtractOutputSchema,
+  type ExtractValidators,
+  type InferValidators,
+  requestsInOrder,
+  type SchemaTestTableItem,
+  testTool,
+} from "../../../src/utils/testing";
+
+type Validators = ExtractValidators<typeof tool>;
+type OutputSchema = ExtractOutputSchema<typeof tool>;
+
+const undefineds = {
+  key: undefined,
+  overridable: undefined,
+  backfill_until: undefined,
+  collapsed_tag_keys: undefined,
+  values: undefined,
+};
+
+const validArguments: InferValidators<Validators> = {
+  ...undefineds,
+  virtual_tag_config_token: "vtag_123",
+  key: "team",
+  values: [
+    {
+      filter: "costs.provider = 'gcp'",
+      name: "Product",
+    },
+    {
+      filter: "costs.provider = 'aws'",
+      name: "Platform",
+    },
+  ],
+};
+
+const requestBody = {
+  key: validArguments.key,
+  overridable: validArguments.overridable,
+  backfill_until: validArguments.backfill_until,
+  collapsed_tag_keys: validArguments.collapsed_tag_keys,
+  values: validArguments.values,
+};
+
+const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
+  {
+    name: "updates config metadata",
+    data: {
+      ...undefineds,
+      virtual_tag_config_token: "vtag_123",
+      overridable: false,
+      backfill_until: null,
+      collapsed_tag_keys: [{ key: "environment", filter: "costs.provider = 'aws'" }],
+    },
+  },
+  {
+    name: "replaces values in the supplied order",
+    data: validArguments,
+  },
+  {
+    name: "rejects an invalid nested date",
+    data: {
+      ...undefineds,
+      virtual_tag_config_token: "vtag_123",
+      values: [
+        {
+          filter: "costs.provider = 'aws'",
+          name: "Platform",
+          date_ranges: [{ start_date: "not-a-date" }],
+        },
+      ],
+    },
+    expectedIssues: ["Invalid date input, must be YYYY-MM-DD format and a reasonable date."],
+  },
+];
+
+const successData: UpdateVirtualTagConfigResponse = {
+  token: "vtag_123",
+  created_by_token: null,
+  key: "team",
+  overridable: true,
+  backfill_until: "2026-01-01",
+  collapsed_tag_keys: [],
+  values: [
+    {
+      token: "vtag_val_789",
+      filter: "costs.provider = 'gcp'",
+      name: "Product",
+      label_transforms: [],
+      percentages: [],
+      date_ranges: [],
+    },
+    {
+      token: "vtag_val_456",
+      filter: "costs.provider = 'aws'",
+      name: "Platform",
+      label_transforms: [],
+      percentages: [],
+      date_ranges: [],
+    },
+  ],
+};
+
+const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
+  {
+    name: "successful call with ordered values",
+    apiCallHandler: requestsInOrder([
+      {
+        endpoint: `/v2/virtual_tag_configs/${pathEncode("vtag_123")}`,
+        params: requestBody,
+        method: "PUT",
+        result: { ok: true, data: successData },
+      },
+    ]),
+    handler: async ({ callExpectingSuccess }) => {
+      const result = await callExpectingSuccess(validArguments);
+      expect(result).toEqual(successData);
+    },
+  },
+  {
+    name: "requires a field to update",
+    apiCallHandler: requestsInOrder([]),
+    handler: async ({ callExpectingMCPUserError }) => {
+      const error = await callExpectingMCPUserError({
+        ...undefineds,
+        virtual_tag_config_token: "vtag_123",
+      });
+      expect(error.exception).toEqual({
+        errors: [{ message: "At least one Virtual Tag Config field must be provided." }],
+      });
+    },
+  },
+  {
+    name: "unsuccessful call",
+    apiCallHandler: requestsInOrder([
+      {
+        endpoint: `/v2/virtual_tag_configs/${pathEncode("vtag_123")}`,
+        params: requestBody,
+        method: "PUT",
+        result: { ok: false, errors: [{ message: "Invalid VQL" }] },
+      },
+    ]),
+    handler: async ({ callExpectingMCPUserError }) => {
+      const error = await callExpectingMCPUserError(validArguments);
+      expect(error.exception).toEqual({ errors: [{ message: "Invalid VQL" }] });
+    },
+  },
+];
+
+testTool(tool, argumentSchemaTests, executionTests);

--- a/test/tools/virtual-tag-configs/update-virtual-tag-config.test.ts
+++ b/test/tools/virtual-tag-configs/update-virtual-tag-config.test.ts
@@ -1,4 +1,8 @@
-import { pathEncode, type UpdateVirtualTagConfigResponse } from "@vantage-sh/vantage-client";
+import {
+  pathEncode,
+  type UpdateVirtualTagConfigRequest,
+  type UpdateVirtualTagConfigResponse,
+} from "@vantage-sh/vantage-client";
 import { expect } from "vitest";
 import tool from "../../../src/tools/virtual-tag-configs/update-virtual-tag-config";
 import {
@@ -44,7 +48,7 @@ const requestBody = {
   backfill_until: validArguments.backfill_until,
   collapsed_tag_keys: validArguments.collapsed_tag_keys,
   values: validArguments.values,
-};
+} as unknown as UpdateVirtualTagConfigRequest;
 
 const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
   {
@@ -60,6 +64,20 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
   {
     name: "replaces values in the supplied order",
     data: validArguments,
+  },
+  {
+    name: "accepts open-ended value date ranges from get responses",
+    data: {
+      ...undefineds,
+      virtual_tag_config_token: "vtag_123",
+      values: [
+        {
+          filter: "costs.provider = 'aws'",
+          name: "Platform",
+          date_ranges: [{ start_date: null, end_date: "2026-12-31" }],
+        },
+      ],
+    },
   },
   {
     name: "rejects an invalid nested date",

--- a/test/tools/virtual-tag-configs/update-virtual-tag-config.test.ts
+++ b/test/tools/virtual-tag-configs/update-virtual-tag-config.test.ts
@@ -62,6 +62,15 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
     },
   },
   {
+    name: "rejects null overridable",
+    data: {
+      ...undefineds,
+      virtual_tag_config_token: "vtag_123",
+      overridable: null as never,
+    },
+    expectedIssues: ["Invalid input: expected boolean, received null"],
+  },
+  {
     name: "replaces values in the supplied order",
     data: validArguments,
   },

--- a/test/utils/zod/token-kinds.test.ts
+++ b/test/utils/zod/token-kinds.test.ts
@@ -12,6 +12,7 @@ test("prefixes match public API token examples", () => {
   expect(TOKEN_KINDS.canvas.prefix).toBe("cnvs");
   expect(TOKEN_KINDS.anomaly_alert.prefix).toBe("anmly_alrt");
   expect(TOKEN_KINDS.virtual_tag_config.prefix).toBe("vtag");
+  expect(TOKEN_KINDS.virtual_tag_config_value.prefix).toBe("vtag_val");
   expect(TOKEN_KINDS.cost_report.prefix).toBe("rprt");
   expect(TOKEN_KINDS.report_forecast.prefix).toBe("rprt_frcst");
   expect(TOKEN_KINDS.scenario_model.prefix).toBe("frcst_mdl");


### PR DESCRIPTION
## Summary
- add full list/get/update/delete coverage for Virtual Tag Configs alongside the existing create tool
- add create/get/update/delete tools for individual Virtual Tag Config values
- return complete configs with the ordered values and tokens needed for subsequent edits
- steer agents toward value-level tools for routine edits and reserve parent updates for settings, reordering, or full-list replacement
- support get-then-update workflows by ignoring empty `percentages` variants and accepting null open-ended date bounds
- upgrade `@vantage-sh/vantage-client` to 2.13.0 for the new endpoints

Supports [core PR #21110](https://github.com/vantage-sh/core/pull/21110).

## Endpoint coverage

Config-level tools:
- `GET /v2/virtual_tag_configs`
- `POST /v2/virtual_tag_configs`
- `GET /v2/virtual_tag_configs/:token`
- `PUT /v2/virtual_tag_configs/:token`
- `DELETE /v2/virtual_tag_configs/:token`

Value-level tools:
- `POST /v2/virtual_tag_configs/:config_token/values`
- `GET /v2/virtual_tag_configs/:config_token/values/:value_token`
- `PATCH /v2/virtual_tag_configs/:config_token/values/:value_token`
- `DELETE /v2/virtual_tag_configs/:config_token/values/:value_token`

Async update and processing-status endpoints are intentionally out of scope.

## AI Agent findings

A tool-selection pass covered direct, inferred, and ambiguous requests. The agent consistently separated whole-tag operations from individual mapping edits:

- `list-virtual-tag-configs`: “What Virtual Tags exist?”, “Find the tag with this key,” and token discovery
- `get-virtual-tag-config`: “Show every value on this tag,” ordered mapping inspection, and value-token discovery
- `create-virtual-tag-config`: creation of a new Virtual Tag only
- `update-virtual-tag-config`: config settings, renaming, reordering, or replacing/clearing the complete ordered mapping list
- `delete-virtual-tag-config`: deleting the entire Virtual Tag and all mappings
- `create-virtual-tag-config-value`: appending one new mapping without replacing siblings
- `get-virtual-tag-config-value`: inspecting one mapping before an edit
- `update-virtual-tag-config-value`: partially editing one mapping while preserving omitted fields and sibling order
- `delete-virtual-tag-config-value`: removing one mapping while preserving the containing tag

## Copy tweaks

Tool copy now:
- uses “Virtual Tag” for the user-facing concept while retaining “Virtual Tag Config” for the API resource
- recognizes both “mapping” and “value” terminology
- explicitly says create is not for editing an existing tag
- warns that parent `values` replaces the full ordered list and `[]` clears it
- states that value updates preserve omitted fields, allow `display_name: null` to clear the display name, and cannot reorder values
- distinguishes deleting one mapping from deleting the containing tag

## Safety
- config retrieval returns the complete values array; the upstream endpoint is not paginated, so no MCP-only pagination is added
- supplying `values` to the parent update replaces the complete ordered list; an empty array clears it
- individual value tools preserve omitted fields and cannot reorder siblings
- null date bounds round-trip as open-ended ranges
- delete tools distinguish one mapping from the entire containing tag

## Test plan
- [x] `npm run type-check`
- [x] `npm run lint`
- [x] `npm test -- --run` (1,024 tests)
- [x] agent selection passes for direct, inferred, and ambiguous virtual-tag requests

Tool-selection evals are not included because the eval harness is still isolated in draft [PR #170](https://github.com/vantage-sh/vantage-mcp-server/pull/170) and is not available on `main`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds destructive delete and PUT-style full value-list replacement on cost-attribution Virtual Tags; mitigated by validation, explicit tool copy, and the same MCP patterns used elsewhere.
> 
> **Overview**
> Expands Virtual Tag coverage from create-only to **full config CRUD** (`list`, `get`, `update`, `delete`) and adds **per-mapping value tools** (`create`, `get`, `update`, `delete`) wired to the v2 virtual tag APIs. **`@vantage-sh/vantage-client` is bumped to 2.13.0** for the new request/response types.
> 
> Shared Zod schemas now model richer value shapes (business metrics, cost metrics, percentages, date ranges, collapsed tag keys with optional VQL `filter`), and **`virtual_tag_config_value` (`vtag_val`)** is registered for token validation. **Create** is refactored to use those schemas; **update** on the parent config can replace or clear the entire ordered `values` list, while value-level updates are partial PATCH with guards (exactly one allocation type on create, no conflicting value types on update). Tool descriptions steer agents toward value-level edits vs wholesale list replacement.
> 
> Vitest coverage is added for all new tools and token-kind expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ede0c95c555f77cae3d0197606dd83f0d975a6bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->