### PR TITLE
Defer provider resource type validation to Vantage

### DIFF
--- a/src/tools/provider-resources/list-provider-resources.ts
+++ b/src/tools/provider-resources/list-provider-resources.ts
@@ -84,21 +84,6 @@ Resources include metadata specific to their type (EC2 instances show instance t
 Each resource has a unique token that can be used to get more details or link to the Vantage Web UI.
 `.trim();
 
-// Common LLM hallucinations: Terraform-style names instead of correct VQL types
-const RESOURCE_TYPE_CORRECTIONS: Record<string, string> = {
-  aws_ec2_instance: "aws_instance",
-  aws_rds_instance: "aws_db_instance",
-  aws_rds_snapshot: "aws_db_snapshot",
-  aws_ebs_snapshot: "aws_instance_snapshot",
-};
-
-function correctResourceTypes(filter: string): string {
-  for (const [wrong, correct] of Object.entries(RESOURCE_TYPE_CORRECTIONS)) {
-    filter = filter.replaceAll(wrong, correct);
-  }
-  return filter;
-}
-
 export default registerTool({
   name: "list-provider-resources",
   title: "List Provider Resources",
@@ -136,9 +121,6 @@ export default registerTool({
       throw new MCPUserError({
         errors: [{ message: "workspace_token is required when filter is provided" }],
       });
-    }
-    if (args.filter) {
-      args.filter = correctResourceTypes(args.filter);
     }
     const response = await ctx.callVantageApi("/v2/resources", args, "GET");
     if (!response.ok) {

--- a/test/tools/provider-resources/list-provider-resources.test.ts
+++ b/test/tools/provider-resources/list-provider-resources.test.ts
@@ -184,6 +184,38 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
     },
   },
   {
+    name: "forwards resource types unchanged and returns API suggestions",
+    apiCallHandler: requestsInOrder([
+      {
+        endpoint: "/v2/resources",
+        params: {
+          page: 1,
+          resource_report_token: undefined,
+          filter: "(resources.provider = 'aws' AND resources.type = 'aws_ec2_instance')",
+          workspace_token: "wrkspc_123",
+          include_cost: false,
+        },
+        method: "GET",
+        result: {
+          ok: false,
+          errors: ["Invalid resource type: aws_ec2_instance. Did you mean aws_instance?"],
+        },
+      },
+    ]),
+    handler: async ({ callExpectingMCPUserError }) => {
+      const err = await callExpectingMCPUserError({
+        page: 1,
+        resource_report_token: undefined,
+        filter: "(resources.provider = 'aws' AND resources.type = 'aws_ec2_instance')",
+        workspace_token: "wrkspc_123",
+        include_cost: false,
+      });
+      expect(err.exception).toEqual({
+        errors: ["Invalid resource type: aws_ec2_instance. Did you mean aws_instance?"],
+      });
+    },
+  },
+  {
     name: "unsuccessful call",
     apiCallHandler: requestsInOrder([
       {


### PR DESCRIPTION
Removes the silent rewriting of bad vql resource types in favor of letting the API return an error with a suggestion https://github.com/vantage-sh/core/pull/21135/changes

I'm moving the aliases into the API code, so that other consumers of the API can enjoy the benefit of the alias list, so that it can return errors like "change aws_ec2_instance to aws_instance".


## Summary
- remove silent provider resource type rewrites from the Model Context Protocol (MCP) tool
- pass Vantage Query Language (VQL) filters unchanged to Core for validation
- preserve Core suggestion errors in the tool response so models can retry with the canonical type

Depends on [vantage-sh/core#21135](https://github.com/vantage-sh/core/pull/21135).

## Test plan
- [x] Run provider resources tool tests
- [x] Run TypeScript type checking
- [x] Run Biome lint

## Cursor session
[View the Cursor session](https://cursor.com/dashboard/shared-chats?shareId=aws-load-balancer-discussion-wbyDiHVrYeI7)

Made with [Cursor](https://cursor.com)