### PR TITLE
Add searching and filtering to a bunch of tools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4102,9 +4102,15 @@
       }
     },
     "node_modules/@vantage-sh/vantage-client": {
+<<<<<<< HEAD
       "version": "2.17.0",
       "resolved": "https://registry.npmjs.org/@vantage-sh/vantage-client/-/vantage-client-2.17.0.tgz",
       "integrity": "sha512-Tjm575h8i+hClsqttCA8qyXz+OvZLZqRRiqlugvtrWz5rfJsCPdtVM22nKQzGPgg3DwdxGqSlekcNmKtLZJAsA==",
+=======
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@vantage-sh/vantage-client/-/vantage-client-2.14.0.tgz",
+      "integrity": "sha512-HwTOttK/BlbI9+WrpBeTaYl51CgWGgF1keftyZLQNGPBDgWJkhRBqbSo1sQDNevb9MPANrCMke/CwcIr37fCow==",
+>>>>>>> 03839e7 (feat: Add searching and filtering to a bunch of tools.)
       "license": "MIT"
     },
     "node_modules/@vercel/oidc": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4102,15 +4102,9 @@
       }
     },
     "node_modules/@vantage-sh/vantage-client": {
-<<<<<<< HEAD
       "version": "2.17.0",
       "resolved": "https://registry.npmjs.org/@vantage-sh/vantage-client/-/vantage-client-2.17.0.tgz",
       "integrity": "sha512-Tjm575h8i+hClsqttCA8qyXz+OvZLZqRRiqlugvtrWz5rfJsCPdtVM22nKQzGPgg3DwdxGqSlekcNmKtLZJAsA==",
-=======
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/@vantage-sh/vantage-client/-/vantage-client-2.14.0.tgz",
-      "integrity": "sha512-HwTOttK/BlbI9+WrpBeTaYl51CgWGgF1keftyZLQNGPBDgWJkhRBqbSo1sQDNevb9MPANrCMke/CwcIr37fCow==",
->>>>>>> 03839e7 (feat: Add searching and filtering to a bunch of tools.)
       "license": "MIT"
     },
     "node_modules/@vercel/oidc": {

--- a/src/tools/budgets/list-budgets.ts
+++ b/src/tools/budgets/list-budgets.ts
@@ -1,5 +1,6 @@
 import z from "zod";
 import paginationData from "../../utils/paginationData";
+import { nonempty, vantageToken } from "../../utils/zod";
 import { DEFAULT_LIMIT } from "../structure/constants";
 import MCPUserError from "../structure/MCPUserError";
 import registerTool from "../structure/registerTool";
@@ -14,6 +15,10 @@ The token of a budget can be used to link the user to the budget in the Vantage 
 
 const args = {
   page: z.number().optional().default(1).describe("The page number to return, defaults to 1"),
+  q: nonempty().optional().describe("Search Budgets by name."),
+  workspace_token: vantageToken("workspace", {
+    description: "Only return Budgets in this Workspace.",
+  }).optional(),
 };
 
 export default registerTool({

--- a/src/tools/business-metrics/list-business-metrics.ts
+++ b/src/tools/business-metrics/list-business-metrics.ts
@@ -1,5 +1,6 @@
 import z from "zod";
 import paginationData from "../../utils/paginationData";
+import { nonempty } from "../../utils/zod";
 import MCPUserError from "../structure/MCPUserError";
 import registerTool from "../structure/registerTool";
 import { BUSINESS_METRICS_LIST_LIMIT } from "./schemas";
@@ -13,6 +14,7 @@ The token of a BusinessMetric can be used with get-business-metric, list-busines
 
 const args = {
   page: z.number().optional().default(1).describe("The page number to return, defaults to 1."),
+  q: nonempty().optional().describe("Search Business Metrics by title."),
 };
 
 export default registerTool({

--- a/src/tools/canvases/list-canvases.ts
+++ b/src/tools/canvases/list-canvases.ts
@@ -1,5 +1,6 @@
 import z from "zod";
 import paginationData from "../../utils/paginationData";
+import { nonempty, vantageToken } from "../../utils/zod";
 import { DEFAULT_LIMIT } from "../structure/constants";
 import MCPUserError from "../structure/MCPUserError";
 import registerTool from "../structure/registerTool";
@@ -12,6 +13,10 @@ The token of a canvas can be used to link the user to the canvas in the Vantage 
 
 const args = {
   page: z.number().optional().default(1).describe("The page number to return, defaults to 1"),
+  q: nonempty().optional().describe("Search Canvases by title."),
+  workspace_token: vantageToken("workspace", {
+    description: "Only return Canvases in this Workspace.",
+  }).optional(),
 };
 
 export default registerTool({

--- a/src/tools/cost-alerts/list-cost-alerts.ts
+++ b/src/tools/cost-alerts/list-cost-alerts.ts
@@ -1,7 +1,17 @@
 import z from "zod";
 import paginationData from "../../utils/paginationData";
+
+<<<<<<< HEAD
+
 import { vantageToken } from "../../utils/zod/vantage-token";
 import { DEFAULT_LIMIT } from "../structure/constants";
+
+=======
+
+import { nonempty, vantageToken } from "../../utils/zod";
+
+>>>>>>> 03839e7 (feat: Add searching and filtering to a bunch of tools.)
+
 import MCPUserError from "../structure/MCPUserError";
 import registerTool from "../structure/registerTool";
 

--- a/src/tools/cost-alerts/list-cost-alerts.ts
+++ b/src/tools/cost-alerts/list-cost-alerts.ts
@@ -1,17 +1,7 @@
 import z from "zod";
 import paginationData from "../../utils/paginationData";
-
-<<<<<<< HEAD
-
-import { vantageToken } from "../../utils/zod/vantage-token";
-import { DEFAULT_LIMIT } from "../structure/constants";
-
-=======
-
 import { nonempty, vantageToken } from "../../utils/zod";
-
->>>>>>> 03839e7 (feat: Add searching and filtering to a bunch of tools.)
-
+import { DEFAULT_LIMIT } from "../structure/constants";
 import MCPUserError from "../structure/MCPUserError";
 import registerTool from "../structure/registerTool";
 
@@ -33,7 +23,7 @@ const args = {
     .optional()
     .default(DEFAULT_LIMIT)
     .describe(`Number of Cost Alerts per page, defaults to ${DEFAULT_LIMIT} and has a maximum of 5000`),
-  q: z.string().optional().describe("Search cost alerts by title"),
+  q: nonempty().optional().describe("Search cost alerts by title"),
   workspace_token: vantageToken("workspace", {
     description: "When provided, return only Cost Alerts in this Workspace.",
   }).optional(),

--- a/src/tools/cost-reports/list-cost-reports.ts
+++ b/src/tools/cost-reports/list-cost-reports.ts
@@ -1,6 +1,6 @@
 import z from "zod";
 import paginationData from "../../utils/paginationData";
-import { vantageToken } from "../../utils/zod";
+import { nonempty, vantageToken } from "../../utils/zod";
 import { DEFAULT_LIMIT } from "../structure/constants";
 import MCPUserError from "../structure/MCPUserError";
 import registerTool from "../structure/registerTool";
@@ -18,6 +18,10 @@ const args = {
   page: z.number().optional().default(1).describe("The page number to return, defaults to 1"),
   folder_token: vantageToken("folder", {
     description: "Only return Cost Reports within this Folder.",
+  }).optional(),
+  q: nonempty().optional().describe("Search Cost Reports by title."),
+  workspace_token: vantageToken("workspace", {
+    description: "Only return Cost Reports in this Workspace.",
   }).optional(),
 };
 

--- a/src/tools/dashboards/list-dashboards.ts
+++ b/src/tools/dashboards/list-dashboards.ts
@@ -1,5 +1,6 @@
 import z from "zod";
 import paginationData from "../../utils/paginationData";
+import { nonempty, vantageToken } from "../../utils/zod";
 import MCPUserError from "../structure/MCPUserError";
 import registerTool from "../structure/registerTool";
 
@@ -11,6 +12,10 @@ The token of a dashboard can be used to link the user to the dashboard in the Va
 
 const args = {
   page: z.number().optional().default(1).describe("The page number to return, defaults to 1"),
+  q: nonempty().optional().describe("Search Dashboards by title."),
+  workspace_token: vantageToken("workspace", {
+    description: "Only return Dashboards in this Workspace.",
+  }).optional(),
 };
 
 export default registerTool({

--- a/src/tools/financial-commitment-reports/list-financial-commitment-reports.ts
+++ b/src/tools/financial-commitment-reports/list-financial-commitment-reports.ts
@@ -1,5 +1,6 @@
 import z from "zod";
 import paginationData from "../../utils/paginationData";
+import { nonempty, vantageToken } from "../../utils/zod";
 import { DEFAULT_LIMIT } from "../structure/constants";
 import MCPUserError from "../structure/MCPUserError";
 import registerTool from "../structure/registerTool";
@@ -11,6 +12,10 @@ Use the page value of 1 to start.
 
 const args = {
   page: z.number().optional().default(1).describe("The page number to return, defaults to 1"),
+  q: nonempty().optional().describe("Search Financial Commitment Reports by title."),
+  workspace_token: vantageToken("workspace", {
+    description: "Only return Financial Commitment Reports in this Workspace.",
+  }).optional(),
 };
 
 export default registerTool({

--- a/src/tools/folders/list-folders.ts
+++ b/src/tools/folders/list-folders.ts
@@ -1,5 +1,6 @@
 import z from "zod";
 import paginationData from "../../utils/paginationData";
+import { nonempty, vantageToken } from "../../utils/zod";
 import { DEFAULT_LIMIT } from "../structure/constants";
 import MCPUserError from "../structure/MCPUserError";
 import registerTool from "../structure/registerTool";
@@ -14,6 +15,10 @@ The 'token' of a Folder can be used to generate a link in the Vantage Web UI: ht
 
 const args = {
   page: z.number().optional().default(1).describe("The page number to return, defaults to 1"),
+  q: nonempty().optional().describe("Search Folders by title."),
+  workspace_token: vantageToken("workspace", {
+    description: "Only return Folders in this Workspace.",
+  }).optional(),
 };
 
 export default registerTool({

--- a/src/tools/network-flow-reports/list-network-flow-reports.ts
+++ b/src/tools/network-flow-reports/list-network-flow-reports.ts
@@ -1,5 +1,6 @@
 import z from "zod";
 import paginationData from "../../utils/paginationData";
+import { nonempty, vantageToken } from "../../utils/zod";
 import { DEFAULT_LIMIT } from "../structure/constants";
 import MCPUserError from "../structure/MCPUserError";
 import registerTool from "../structure/registerTool";
@@ -18,7 +19,10 @@ export default registerTool({
     readOnly: true,
   },
   args: {
-    q: z.string().min(1).optional().describe("Search reports by title."),
+    q: nonempty().optional().describe("Search Network Flow Reports by title."),
+    workspace_token: vantageToken("workspace", {
+      description: "Only return Network Flow Reports in this Workspace.",
+    }).optional(),
     page: z.number().int().min(1).optional().default(1).describe("Page number, defaults to 1"),
     limit: z.number().int().min(1).max(1000).optional().default(DEFAULT_LIMIT).describe("Number of reports per page"),
   },

--- a/src/tools/recommendation-views/list-recommendation-views.ts
+++ b/src/tools/recommendation-views/list-recommendation-views.ts
@@ -1,5 +1,6 @@
 import z from "zod";
 import paginationData from "../../utils/paginationData";
+import { nonempty, vantageToken } from "../../utils/zod";
 import { DEFAULT_LIMIT } from "../structure/constants";
 import MCPUserError from "../structure/MCPUserError";
 import registerTool from "../structure/registerTool";
@@ -13,6 +14,10 @@ The workspace token, date range, providers, accounts, regions, and tag fields pr
 `.trim();
 
 const args = {
+  q: nonempty().optional().describe("Search Recommendation Views by title."),
+  workspace_token: vantageToken("workspace", {
+    description: "Only return Recommendation Views in this Workspace.",
+  }).optional(),
   page: z.number().int().min(1).optional().default(1).describe("The page number to return, defaults to 1"),
   limit: z
     .number()

--- a/src/tools/report-notifications/list-report-notifications.ts
+++ b/src/tools/report-notifications/list-report-notifications.ts
@@ -1,5 +1,6 @@
 import z from "zod";
 import paginationData from "../../utils/paginationData";
+import { nonempty, vantageToken } from "../../utils/zod";
 import { DEFAULT_LIMIT } from "../structure/constants";
 import MCPUserError from "../structure/MCPUserError";
 import registerTool from "../structure/registerTool";
@@ -14,6 +15,10 @@ Do not use this for Cost Alerts, budget alerts, threshold alerts, or spend-limit
 
 const args = {
   page: z.number().optional().default(1).describe("The page number to return, defaults to 1"),
+  q: nonempty().optional().describe("Search Report Notifications by title."),
+  workspace_token: vantageToken("workspace", {
+    description: "Only return Report Notifications in this Workspace.",
+  }).optional(),
 };
 
 export default registerTool({

--- a/src/tools/resource-reports/list-resource-reports.ts
+++ b/src/tools/resource-reports/list-resource-reports.ts
@@ -1,5 +1,6 @@
 import z from "zod";
 import paginationData from "../../utils/paginationData";
+import { nonempty, vantageToken } from "../../utils/zod";
 import { DEFAULT_LIMIT } from "../structure/constants";
 import MCPUserError from "../structure/MCPUserError";
 import registerTool from "../structure/registerTool";
@@ -14,6 +15,10 @@ If a user wants to see a report, you can link them like this: https://console.va
 `.trim();
 
 const args = {
+  q: nonempty().optional().describe("Search Resource Reports by title."),
+  workspace_token: vantageToken("workspace", {
+    description: "Only return Resource Reports in this Workspace.",
+  }).optional(),
   page: z.number().optional().default(1).describe("The page number to return, defaults to 1"),
   limit: z
     .number()

--- a/src/tools/teams/get-teams.ts
+++ b/src/tools/teams/get-teams.ts
@@ -1,5 +1,6 @@
 import z from "zod";
 import paginationData from "../../utils/paginationData";
+import { nonempty, vantageToken } from "../../utils/zod";
 import { DEFAULT_LIMIT } from "../structure/constants";
 import MCPUserError from "../structure/MCPUserError";
 import registerTool from "../structure/registerTool";
@@ -10,6 +11,10 @@ Return all Teams that the user has access to.
 
 const args = {
   page: z.number().optional().default(1).describe("The page number to return, defaults to 1"),
+  q: nonempty().optional().describe("Search Teams by name."),
+  workspace_token: vantageToken("workspace", {
+    description: "Only return Teams with access to this Workspace.",
+  }).optional(),
 };
 
 export default registerTool({

--- a/src/tools/workspaces/list-workspaces.ts
+++ b/src/tools/workspaces/list-workspaces.ts
@@ -1,5 +1,6 @@
 import z from "zod";
 import paginationData from "../../utils/paginationData";
+import { nonempty } from "../../utils/zod";
 import { DEFAULT_LIMIT } from "../structure/constants";
 import MCPUserError from "../structure/MCPUserError";
 import registerTool from "../structure/registerTool";
@@ -11,6 +12,7 @@ Use get-myself to see the user's default workspace. Use get-workspace to retriev
 `.trim();
 
 const args = {
+  q: nonempty().optional().describe("Search Workspaces by name."),
   page: z.number().optional().default(1).describe("The page number to return, defaults to 1"),
   limit: z
     .number()

--- a/test/tools/budgets/list-budgets.test.ts
+++ b/test/tools/budgets/list-budgets.test.ts
@@ -16,6 +16,8 @@ type OutputSchema = ExtractOutputSchema<typeof tool>;
 
 const validArguments: InferValidators<Validators> = {
   page: 1,
+  q: "AWS",
+  workspace_token: "wrkspc_123",
 };
 
 const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
@@ -23,6 +25,8 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
     name: "default page",
     data: {
       page: undefined,
+      q: undefined,
+      workspace_token: undefined,
     },
   },
   {
@@ -66,6 +70,8 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
         params: {
           page: 1,
           limit: DEFAULT_LIMIT,
+          q: "AWS",
+          workspace_token: "wrkspc_123",
         },
         method: "GET",
         result: {
@@ -93,6 +99,8 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
         params: {
           page: 1,
           limit: DEFAULT_LIMIT,
+          q: "AWS",
+          workspace_token: "wrkspc_123",
         },
         method: "GET",
         result: {

--- a/test/tools/business-metrics/list-business-metrics.test.ts
+++ b/test/tools/business-metrics/list-business-metrics.test.ts
@@ -17,6 +17,7 @@ type OutputSchema = ExtractOutputSchema<typeof tool>;
 
 const validArguments: InferValidators<Validators> = {
   page: 1,
+  q: "requests",
 };
 
 const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
@@ -24,6 +25,7 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
     name: "default page",
     data: {
       page: undefined,
+      q: undefined,
     },
   },
   {
@@ -70,6 +72,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
         params: {
           page: 1,
           limit: BUSINESS_METRICS_LIST_LIMIT,
+          q: "requests",
         },
         method: "GET",
         result: {
@@ -97,6 +100,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
         params: {
           page: 1,
           limit: BUSINESS_METRICS_LIST_LIMIT,
+          q: "requests",
         },
         method: "GET",
         result: {

--- a/test/tools/canvases/list-canvases.test.ts
+++ b/test/tools/canvases/list-canvases.test.ts
@@ -16,6 +16,8 @@ type OutputSchema = ExtractOutputSchema<typeof tool>;
 
 const validArguments: InferValidators<Validators> = {
   page: 1,
+  q: "Monthly Costs",
+  workspace_token: "wrkspc_123",
 };
 
 const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
@@ -23,6 +25,8 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
     name: "default page",
     data: {
       page: undefined,
+      q: undefined,
+      workspace_token: undefined,
     },
   },
   {
@@ -57,6 +61,8 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
         params: {
           page: 1,
           limit: DEFAULT_LIMIT,
+          q: "Monthly Costs",
+          workspace_token: "wrkspc_123",
         },
         method: "GET",
         result: {
@@ -84,6 +90,8 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
         params: {
           page: 1,
           limit: DEFAULT_LIMIT,
+          q: "Monthly Costs",
+          workspace_token: "wrkspc_123",
         },
         method: "GET",
         result: {

--- a/test/tools/cost-alerts/list-cost-alerts.test.ts
+++ b/test/tools/cost-alerts/list-cost-alerts.test.ts
@@ -1,6 +1,7 @@
 import type { GetCostAlertsResponse } from "@vantage-sh/vantage-client";
 import { expect } from "vitest";
 import tool from "../../../src/tools/cost-alerts/list-cost-alerts";
+import { DEFAULT_LIMIT } from "../../../src/tools/structure/constants";
 import {
   type ExecutionTestTableItem,
   type ExtractOutputSchema,

--- a/test/tools/cost-alerts/list-cost-alerts.test.ts
+++ b/test/tools/cost-alerts/list-cost-alerts.test.ts
@@ -1,7 +1,6 @@
 import type { GetCostAlertsResponse } from "@vantage-sh/vantage-client";
 import { expect } from "vitest";
 import tool from "../../../src/tools/cost-alerts/list-cost-alerts";
-import { DEFAULT_LIMIT } from "../../../src/tools/structure/constants";
 import {
   type ExecutionTestTableItem,
   type ExtractOutputSchema,

--- a/test/tools/cost-reports/list-cost-reports.test.ts
+++ b/test/tools/cost-reports/list-cost-reports.test.ts
@@ -17,6 +17,8 @@ type OutputSchema = ExtractOutputSchema<typeof tool>;
 const validArguments: InferValidators<Validators> = {
   page: 1,
   folder_token: "fldr_123",
+  q: "Monthly AWS",
+  workspace_token: "wrkspc_123",
 };
 
 const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
@@ -25,6 +27,8 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
     data: {
       page: undefined,
       folder_token: undefined,
+      q: undefined,
+      workspace_token: undefined,
     },
   },
   {
@@ -81,6 +85,8 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
           page: 1,
           limit: DEFAULT_LIMIT,
           folder_token: "fldr_123",
+          q: "Monthly AWS",
+          workspace_token: "wrkspc_123",
         },
         method: "GET",
         result: {
@@ -109,6 +115,8 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
           page: 1,
           limit: DEFAULT_LIMIT,
           folder_token: "fldr_123",
+          q: "Monthly AWS",
+          workspace_token: "wrkspc_123",
         },
         method: "GET",
         result: {

--- a/test/tools/dashboards/list-dashboards.test.ts
+++ b/test/tools/dashboards/list-dashboards.test.ts
@@ -15,6 +15,8 @@ type OutputSchema = ExtractOutputSchema<typeof tool>;
 
 const validArguments: InferValidators<Validators> = {
   page: 1,
+  q: "AWS Cost",
+  workspace_token: "wrkspc_123",
 };
 
 const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
@@ -22,6 +24,8 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
     name: "default page",
     data: {
       page: undefined,
+      q: undefined,
+      workspace_token: undefined,
     },
   },
   {
@@ -67,6 +71,8 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
         params: {
           page: 1,
           limit: 64,
+          q: "AWS Cost",
+          workspace_token: "wrkspc_123",
         },
         method: "GET",
         result: {
@@ -94,6 +100,8 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
         params: {
           page: 1,
           limit: 64,
+          q: "AWS Cost",
+          workspace_token: "wrkspc_123",
         },
         method: "GET",
         result: {

--- a/test/tools/financial-commitment-reports/list-financial-commitment-reports.test.ts
+++ b/test/tools/financial-commitment-reports/list-financial-commitment-reports.test.ts
@@ -17,6 +17,8 @@ type OutputSchema = ExtractOutputSchema<typeof tool>;
 
 const validArguments: InferValidators<Validators> = {
   page: 1,
+  q: "AWS commitments",
+  workspace_token: "wrkspc_123",
 };
 
 const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
@@ -24,6 +26,8 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
     name: "default page",
     data: {
       page: undefined,
+      q: undefined,
+      workspace_token: undefined,
     },
   },
   {
@@ -67,6 +71,8 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
         params: {
           page: 1,
           limit: DEFAULT_LIMIT,
+          q: "AWS commitments",
+          workspace_token: "wrkspc_123",
         },
         method: "GET",
         result: {
@@ -103,7 +109,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
       },
     ]),
     handler: async ({ callExpectingSuccess }) => {
-      const res = await callExpectingSuccess({ page: undefined });
+      const res = await callExpectingSuccess({ page: undefined, q: undefined, workspace_token: undefined });
       expect(res).toEqual({
         financial_commitment_reports: successData.financial_commitment_reports,
         pagination: {
@@ -121,6 +127,8 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
         params: {
           page: 1,
           limit: DEFAULT_LIMIT,
+          q: "AWS commitments",
+          workspace_token: "wrkspc_123",
         },
         method: "GET",
         result: {

--- a/test/tools/folders/list-folders.test.ts
+++ b/test/tools/folders/list-folders.test.ts
@@ -16,6 +16,8 @@ type OutputSchema = ExtractOutputSchema<typeof tool>;
 
 const validArguments: InferValidators<Validators> = {
   page: 1,
+  q: "Finance",
+  workspace_token: "wrkspc_123",
 };
 
 const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
@@ -23,6 +25,8 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
     name: "default page",
     data: {
       page: undefined,
+      q: undefined,
+      workspace_token: undefined,
     },
   },
   {
@@ -66,6 +70,8 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
         params: {
           page: 1,
           limit: DEFAULT_LIMIT,
+          q: "Finance",
+          workspace_token: "wrkspc_123",
         },
         method: "GET",
         result: {
@@ -93,6 +99,8 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
         params: {
           page: 1,
           limit: DEFAULT_LIMIT,
+          q: "Finance",
+          workspace_token: "wrkspc_123",
         },
         method: "GET",
         result: {

--- a/test/tools/network-flow-reports/list-network-flow-reports.test.ts
+++ b/test/tools/network-flow-reports/list-network-flow-reports.test.ts
@@ -17,6 +17,7 @@ type OutputSchema = ExtractOutputSchema<typeof tool>;
 
 const validArguments: InferValidators<Validators> = {
   q: "cross-az",
+  workspace_token: "wrkspc_123",
   page: 2,
   limit: 25,
 };
@@ -24,7 +25,7 @@ const validArguments: InferValidators<Validators> = {
 const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
   {
     name: "uses pagination defaults",
-    data: { q: undefined, page: undefined, limit: undefined },
+    data: { q: undefined, workspace_token: undefined, page: undefined, limit: undefined },
   },
   {
     name: "accepts valid pagination",
@@ -32,12 +33,12 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
   },
   {
     name: "rejects page zero",
-    data: { q: undefined, page: 0, limit: 25 },
+    data: { q: undefined, workspace_token: undefined, page: 0, limit: 25 },
     expectedIssues: ["Too small: expected number to be >=1"],
   },
   {
     name: "rejects a limit over the API maximum",
-    data: { q: undefined, page: 1, limit: 1001 },
+    data: { q: undefined, workspace_token: undefined, page: 1, limit: 1001 },
     expectedIssues: ["Too big: expected number to be <=1000"],
   },
 ];
@@ -91,6 +92,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
         endpoint: "/v2/network_flow_reports",
         params: {
           q: undefined,
+          workspace_token: undefined,
           page: 1,
           limit: DEFAULT_LIMIT,
         } as GetNetworkFlowReportsRequest,
@@ -99,7 +101,12 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
       },
     ]),
     handler: async ({ callExpectingSuccess }) => {
-      const result = await callExpectingSuccess({ q: undefined, page: undefined, limit: undefined });
+      const result = await callExpectingSuccess({
+        q: undefined,
+        workspace_token: undefined,
+        page: undefined,
+        limit: undefined,
+      });
       expect(result).toEqual({
         network_flow_reports: [],
         pagination: { hasNextPage: false, nextPage: 0 },

--- a/test/tools/recommendation-views/list-recommendation-views.test.ts
+++ b/test/tools/recommendation-views/list-recommendation-views.test.ts
@@ -16,6 +16,8 @@ type Validators = ExtractValidators<typeof tool>;
 type OutputSchema = ExtractOutputSchema<typeof tool>;
 
 const validArguments: InferValidators<Validators> = {
+  q: "AWS",
+  workspace_token: "wrkspc_123",
   page: 1,
   limit: 10,
 };
@@ -24,6 +26,8 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
   {
     name: "default pagination arguments",
     data: {
+      q: undefined,
+      workspace_token: undefined,
       page: undefined,
       limit: undefined,
     },
@@ -35,6 +39,8 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
   {
     name: "invalid page below minimum",
     data: {
+      q: undefined,
+      workspace_token: undefined,
       page: 0,
       limit: undefined,
     },
@@ -43,6 +49,8 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
   {
     name: "invalid fractional page",
     data: {
+      q: undefined,
+      workspace_token: undefined,
       page: 1.5,
       limit: undefined,
     },
@@ -51,6 +59,8 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
   {
     name: "invalid limit below minimum",
     data: {
+      q: undefined,
+      workspace_token: undefined,
       page: undefined,
       limit: 0,
     },
@@ -59,6 +69,8 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
   {
     name: "invalid limit above maximum",
     data: {
+      q: undefined,
+      workspace_token: undefined,
       page: undefined,
       limit: 1001,
     },
@@ -115,6 +127,8 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
     ]),
     handler: async ({ callExpectingSuccess }) => {
       const res = await callExpectingSuccess({
+        q: undefined,
+        workspace_token: undefined,
         page: undefined,
         limit: undefined,
       });
@@ -169,6 +183,8 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
     ]),
     handler: async ({ callExpectingSuccess }) => {
       const res = await callExpectingSuccess({
+        q: undefined,
+        workspace_token: undefined,
         page: 2,
         limit: 10,
       });

--- a/test/tools/report-notifications/list-report-notifications.test.ts
+++ b/test/tools/report-notifications/list-report-notifications.test.ts
@@ -17,6 +17,8 @@ type OutputSchema = ExtractOutputSchema<typeof tool>;
 
 const validArguments: InferValidators<Validators> = {
   page: 1,
+  q: "Weekly Spend",
+  workspace_token: "wrkspc_123",
 };
 
 const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
@@ -24,6 +26,8 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
     name: "default page",
     data: {
       page: undefined,
+      q: undefined,
+      workspace_token: undefined,
     },
   },
   {
@@ -58,6 +62,8 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
         params: {
           page: 1,
           limit: DEFAULT_LIMIT,
+          q: "Weekly Spend",
+          workspace_token: "wrkspc_123",
         },
         method: "GET",
         result: {
@@ -85,6 +91,8 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
         params: {
           page: 1,
           limit: DEFAULT_LIMIT,
+          q: "Weekly Spend",
+          workspace_token: "wrkspc_123",
         },
         method: "GET",
         result: {

--- a/test/tools/resource-reports/list-resource-reports.test.ts
+++ b/test/tools/resource-reports/list-resource-reports.test.ts
@@ -15,6 +15,8 @@ type Validators = ExtractValidators<typeof tool>;
 type OutputSchema = ExtractOutputSchema<typeof tool>;
 
 const validArguments: InferValidators<Validators> = {
+  q: "AWS Resources",
+  workspace_token: "wrkspc_123",
   page: 1,
   limit: DEFAULT_LIMIT,
 };
@@ -23,6 +25,8 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
   {
     name: "default page",
     data: {
+      q: undefined,
+      workspace_token: undefined,
       page: undefined,
       limit: DEFAULT_LIMIT,
     },
@@ -65,6 +69,8 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
       {
         endpoint: "/v2/resource_reports",
         params: {
+          q: "AWS Resources",
+          workspace_token: "wrkspc_123",
           page: 1,
           limit: DEFAULT_LIMIT,
         },
@@ -92,6 +98,8 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
       {
         endpoint: "/v2/resource_reports",
         params: {
+          q: "AWS Resources",
+          workspace_token: "wrkspc_123",
           page: 1,
           limit: DEFAULT_LIMIT,
         },

--- a/test/tools/teams/get-teams.test.ts
+++ b/test/tools/teams/get-teams.test.ts
@@ -17,6 +17,8 @@ type OutputSchema = ExtractOutputSchema<typeof tool>;
 
 const validArguments: InferValidators<Validators> = {
   page: 1,
+  q: "Finance",
+  workspace_token: "wrkspc_123",
 };
 
 const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
@@ -24,6 +26,8 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
     name: "default page",
     data: {
       page: undefined,
+      q: undefined,
+      workspace_token: undefined,
     },
   },
   {
@@ -46,6 +50,8 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
         params: {
           page: 1,
           limit: DEFAULT_LIMIT,
+          q: "Finance",
+          workspace_token: "wrkspc_123",
         },
         method: "GET",
         result: {
@@ -73,6 +79,8 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
         params: {
           page: 1,
           limit: DEFAULT_LIMIT,
+          q: "Finance",
+          workspace_token: "wrkspc_123",
         },
         method: "GET",
         result: {

--- a/test/tools/workspaces/list-workspaces.test.ts
+++ b/test/tools/workspaces/list-workspaces.test.ts
@@ -17,6 +17,7 @@ type OutputSchema = ExtractOutputSchema<typeof tool>;
 const noArguments = {} as InferValidators<Validators>;
 
 const validArguments: InferValidators<Validators> = {
+  q: "Production",
   page: 1,
   limit: DEFAULT_LIMIT,
 };
@@ -61,6 +62,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
       {
         endpoint: "/v2/workspaces",
         params: {
+          q: "Production",
           page: 1,
           limit: DEFAULT_LIMIT,
         },
@@ -72,7 +74,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
       },
     ]),
     handler: async ({ callExpectingSuccess }) => {
-      const res = await callExpectingSuccess(noArguments);
+      const res = await callExpectingSuccess(validArguments);
       expect(res).toEqual({
         workspaces: successData.workspaces,
         pagination: {


### PR DESCRIPTION
## What Changed

At the API level I implemented a ton of searching and filtering functionality so that the MCP server didn't need to page through tons of results to find specific items.

## Testing Done 

- [x] Unit tests updated
- [x] Tested locally


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only tool argument schema and test updates only; no write paths or auth changes.
> 
> **Overview**
> Extends numerous **read-only list/get MCP tools** so agents can narrow results server-side instead of paging through everything.
> 
> Most workspace-scoped list endpoints gain optional **`q`** (non-empty trimmed string search by title or name) and **`workspace_token`** (filter to one workspace). **`list-business-metrics`**, **`list-workspaces`**, and **`list-cost-alerts`** get **`q`** only where applicable; cost alerts already had workspace filtering. Search args that used raw `z.string()` or `z.string().min(1)` now use the shared **`nonempty()`** helper, and **`vantageToken`** imports are consolidated through **`../../utils/zod`**.
> 
> Unit tests were updated so mocked API calls include the new query parameters when provided.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa909aaf3ad981283ea7e72fe940f27fb98469c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->