### PR TITLE
feat: Add report annotations tool

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
         "@cloudflare/workers-oauth-provider": "^0.0.11",
         "@modelcontextprotocol/sdk": "1.29.0",
         "@sentry/cloudflare": "10.30.0",
-        "@vantage-sh/vantage-client": "2.15.0",
+        "@vantage-sh/vantage-client": "2.16.0",
         "agents": "^0.13.2",
         "axios": "1.13.5",
         "hono": "4.12.12",
@@ -4102,9 +4102,9 @@
       }
     },
     "node_modules/@vantage-sh/vantage-client": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/@vantage-sh/vantage-client/-/vantage-client-2.15.0.tgz",
-      "integrity": "sha512-yJuDBMMssNVKsbsfLCdaNxOFPmcEqqeZphYf2AW2B9yuAVoMTHiRFuySnpZpeBJeGos2Q3JlCKr7EWnB/l9N8w==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/@vantage-sh/vantage-client/-/vantage-client-2.16.0.tgz",
+      "integrity": "sha512-ioDN81WrUBj3kk32Lenz/PcNUfWBpxZt5LUK6cSKYT3oiey6KcD8ecw+6sxA4V2KVN9H2WwF5ialOQx6Za/V3A==",
       "license": "MIT"
     },
     "node_modules/@vercel/oidc": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
         "@cloudflare/workers-oauth-provider": "^0.0.11",
         "@modelcontextprotocol/sdk": "1.29.0",
         "@sentry/cloudflare": "10.30.0",
-        "@vantage-sh/vantage-client": "2.13.0",
+        "@vantage-sh/vantage-client": "2.15.0",
         "agents": "^0.13.2",
         "axios": "1.13.5",
         "hono": "4.12.12",
@@ -4102,9 +4102,9 @@
       }
     },
     "node_modules/@vantage-sh/vantage-client": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@vantage-sh/vantage-client/-/vantage-client-2.13.0.tgz",
-      "integrity": "sha512-hHh/x+A4SVTQOUjzGZJa/Bs1aKD7Ze5cAXTWgVdObE/eLsuTL2VFMM/98d8vsptNTCi3jQUUP4Qnt6+e7DK4pw==",
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/@vantage-sh/vantage-client/-/vantage-client-2.15.0.tgz",
+      "integrity": "sha512-yJuDBMMssNVKsbsfLCdaNxOFPmcEqqeZphYf2AW2B9yuAVoMTHiRFuySnpZpeBJeGos2Q3JlCKr7EWnB/l9N8w==",
       "license": "MIT"
     },
     "node_modules/@vercel/oidc": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@cloudflare/workers-oauth-provider": "^0.0.11",
     "@modelcontextprotocol/sdk": "1.29.0",
     "@sentry/cloudflare": "10.30.0",
-    "@vantage-sh/vantage-client": "2.13.0",
+    "@vantage-sh/vantage-client": "2.15.0",
     "agents": "^0.13.2",
     "axios": "1.13.5",
     "hono": "4.12.12",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@cloudflare/workers-oauth-provider": "^0.0.11",
     "@modelcontextprotocol/sdk": "1.29.0",
     "@sentry/cloudflare": "10.30.0",
-    "@vantage-sh/vantage-client": "2.15.0",
+    "@vantage-sh/vantage-client": "2.16.0",
     "agents": "^0.13.2",
     "axios": "1.13.5",
     "hono": "4.12.12",

--- a/src/tools/annotations/index.ts
+++ b/src/tools/annotations/index.ts
@@ -1,0 +1,1 @@
+import "./list-annotations";

--- a/src/tools/annotations/list-annotations.ts
+++ b/src/tools/annotations/list-annotations.ts
@@ -1,0 +1,48 @@
+import z from "zod";
+import paginationData from "../../utils/paginationData";
+import { vantageToken } from "../../utils/zod/vantage-token";
+import MCPUserError from "../structure/MCPUserError";
+import registerTool from "../structure/registerTool";
+
+const ANNOTATIONS_DEFAULT_LIMIT = 100;
+
+const description = `
+List report annotations available to the authenticated Vantage access token, ordered from newest to oldest. Optionally filter annotations to a specific Cost Report.
+`.trim();
+
+const args = {
+  page: z.number().int().min(1).optional().default(1).describe("Page number, defaults to 1"),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(5000)
+    .optional()
+    .default(ANNOTATIONS_DEFAULT_LIMIT)
+    .describe(`Number of annotations per page, defaults to ${ANNOTATIONS_DEFAULT_LIMIT} and has a maximum of 5000`),
+  report_token: vantageToken("cost_report", {
+    description: "When provided, return only annotations associated with this Cost Report.",
+  }).optional(),
+};
+
+export default registerTool({
+  name: "list-annotations",
+  title: "List Annotations",
+  description,
+  annotations: {
+    destructive: false,
+    openWorld: false,
+    readOnly: true,
+  },
+  args,
+  async execute(args, ctx) {
+    const response = await ctx.callVantageApi("/v2/annotations", args, "GET");
+    if (!response.ok) {
+      throw new MCPUserError({ errors: response.errors });
+    }
+    return {
+      annotations: response.data.annotations,
+      pagination: paginationData(response.data),
+    };
+  },
+});

--- a/src/tools/cost-alerts/list-cost-alerts.ts
+++ b/src/tools/cost-alerts/list-cost-alerts.ts
@@ -1,5 +1,7 @@
 import z from "zod";
+import paginationData from "../../utils/paginationData";
 import { vantageToken } from "../../utils/zod/vantage-token";
+import { DEFAULT_LIMIT } from "../structure/constants";
 import MCPUserError from "../structure/MCPUserError";
 import registerTool from "../structure/registerTool";
 
@@ -12,6 +14,15 @@ Do not use this for Report Notifications, scheduled report summaries, or recurri
 `.trim();
 
 const args = {
+  page: z.number().int().min(1).optional().default(1).describe("Page number, defaults to 1"),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(5000)
+    .optional()
+    .default(DEFAULT_LIMIT)
+    .describe(`Number of Cost Alerts per page, defaults to ${DEFAULT_LIMIT} and has a maximum of 5000`),
   q: z.string().optional().describe("Search cost alerts by title"),
   workspace_token: vantageToken("workspace", {
     description: "When provided, return only Cost Alerts in this Workspace.",
@@ -35,6 +46,7 @@ export default registerTool({
     }
     return {
       cost_alerts: response.data.cost_alerts,
+      pagination: paginationData(response.data),
     };
   },
 });

--- a/src/tools/cost-alerts/list-cost-alerts.ts
+++ b/src/tools/cost-alerts/list-cost-alerts.ts
@@ -1,19 +1,21 @@
 import z from "zod";
-import paginationData from "../../utils/paginationData";
-import { DEFAULT_LIMIT } from "../structure/constants";
+import { vantageToken } from "../../utils/zod/vantage-token";
 import MCPUserError from "../structure/MCPUserError";
 import registerTool from "../structure/registerTool";
 
 const description = `
 List Cost Alerts available in the Vantage account. Cost Alerts are threshold-based spending alerts for Cost Reports.
 
-Use this tool when a user asks to list, show, view, or find cost alerts, spending alerts, budget alerts, threshold alerts, or spend-limit notifications. Use the page value of 1 to start.
+Use this tool when a user asks to list, show, view, or find cost alerts, spending alerts, budget alerts, threshold alerts, or spend-limit notifications.
 
 Do not use this for Report Notifications, scheduled report summaries, or recurring Cost Report delivery.
 `.trim();
 
 const args = {
-  page: z.number().optional().default(1).describe("The page number to return, defaults to 1"),
+  q: z.string().optional().describe("Search cost alerts by title"),
+  workspace_token: vantageToken("workspace", {
+    description: "When provided, return only Cost Alerts in this Workspace.",
+  }).optional(),
 };
 
 export default registerTool({
@@ -27,14 +29,12 @@ export default registerTool({
   },
   args,
   async execute(args, ctx) {
-    const requestParams = { ...args, limit: DEFAULT_LIMIT };
-    const response = await ctx.callVantageApi("/v2/cost_alerts", requestParams, "GET");
+    const response = await ctx.callVantageApi("/v2/cost_alerts", args, "GET");
     if (!response.ok) {
       throw new MCPUserError({ errors: response.errors });
     }
     return {
       cost_alerts: response.data.cost_alerts,
-      pagination: paginationData(response.data),
     };
   },
 });

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,5 +1,6 @@
 // This file is auto-generated. Do not edit directly. Run npm run generate-tools-index to update.
 
+import "./annotations";
 import "./anomalies";
 import "./audit-logs";
 import "./billing-rules";

--- a/test/tools/annotations/list-annotations.test.ts
+++ b/test/tools/annotations/list-annotations.test.ts
@@ -1,0 +1,151 @@
+import { expect } from "vitest";
+import tool from "../../../src/tools/annotations/list-annotations";
+import {
+  type ExecutionTestTableItem,
+  type ExtractOutputSchema,
+  type ExtractValidators,
+  type InferValidators,
+  requestsInOrder,
+  type SchemaTestTableItem,
+  testTool,
+} from "../../../src/utils/testing";
+
+type Validators = ExtractValidators<typeof tool>;
+type OutputSchema = ExtractOutputSchema<typeof tool>;
+
+const noArguments = {} as InferValidators<Validators>;
+
+const validArguments: InferValidators<Validators> = {
+  page: 2,
+  limit: 25,
+  report_token: "rprt_fb27faa25ef5ea72",
+};
+
+const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
+  {
+    name: "no arguments",
+    data: noArguments,
+  },
+  {
+    name: "page, limit, and report token",
+    data: validArguments,
+  },
+  {
+    name: "limit above API maximum",
+    data: {
+      ...validArguments,
+      limit: 5001,
+    },
+    expectedIssues: ["Too big: expected number to be <=5000"],
+  },
+  {
+    name: "non-report token",
+    data: {
+      ...validArguments,
+      report_token: "wrkspc_e5c550d14cfa3101",
+    },
+    expectedIssues: ["Must be a Cost Report token (rprt_*)"],
+  },
+];
+
+const successData = {
+  annotations: [
+    {
+      token: "annotation_123",
+      report_tokens: ["rprt_fb27faa25ef5ea72"],
+      date: "2026-08-12",
+      message: "Deployment completed",
+    },
+    {
+      token: "annotation_456",
+      report_tokens: ["rprt_fb27faa25ef5ea72", "rprt_123"],
+      date: null,
+      message: null,
+    },
+  ],
+  links: {
+    next: "https://api.vantage.sh/v2/annotations?page=3",
+  },
+};
+
+const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
+  {
+    name: "successful call with defaults",
+    apiCallHandler: requestsInOrder([
+      {
+        endpoint: "/v2/annotations",
+        params: {
+          page: 1,
+          limit: 100,
+        },
+        method: "GET",
+        result: {
+          ok: true,
+          data: {
+            ...successData,
+            links: {},
+          },
+        },
+      },
+    ]),
+    handler: async ({ callExpectingSuccess }) => {
+      const res = await callExpectingSuccess(noArguments);
+      expect(res).toEqual({
+        annotations: successData.annotations,
+        pagination: {
+          hasNextPage: false,
+          nextPage: 0,
+        },
+      });
+    },
+  },
+  {
+    name: "successful call filtered by report",
+    apiCallHandler: requestsInOrder([
+      {
+        endpoint: "/v2/annotations",
+        params: validArguments,
+        method: "GET",
+        result: {
+          ok: true,
+          data: successData,
+        },
+      },
+    ]),
+    handler: async ({ callExpectingSuccess }) => {
+      const res = await callExpectingSuccess(validArguments);
+      expect(res).toEqual({
+        annotations: successData.annotations,
+        pagination: {
+          hasNextPage: true,
+          nextPage: 3,
+        },
+      });
+    },
+  },
+  {
+    name: "unsuccessful call",
+    apiCallHandler: requestsInOrder([
+      {
+        endpoint: "/v2/annotations",
+        params: {
+          page: 1,
+          limit: 100,
+        },
+        method: "GET",
+        result: {
+          ok: false,
+          errors: [{ message: "Access denied" }],
+        },
+      },
+    ]),
+    handler: async ({ callExpectingMCPUserError }) => {
+      const error = await callExpectingMCPUserError(noArguments);
+      expect(error.exception).toEqual({
+        errors: [{ message: "Access denied" }],
+      });
+    },
+  },
+];
+
+testTool(tool, argumentSchemaTests, executionTests);

--- a/test/tools/cost-alerts/list-cost-alerts.test.ts
+++ b/test/tools/cost-alerts/list-cost-alerts.test.ts
@@ -1,6 +1,7 @@
 import type { GetCostAlertsResponse } from "@vantage-sh/vantage-client";
 import { expect } from "vitest";
 import tool from "../../../src/tools/cost-alerts/list-cost-alerts";
+import { DEFAULT_LIMIT } from "../../../src/tools/structure/constants";
 import {
   type ExecutionTestTableItem,
   type ExtractOutputSchema,
@@ -14,22 +15,43 @@ import {
 type Validators = ExtractValidators<typeof tool>;
 type OutputSchema = ExtractOutputSchema<typeof tool>;
 
+const noArguments: InferValidators<Validators> = {
+  page: undefined,
+  limit: undefined,
+  q: undefined,
+  workspace_token: undefined,
+};
+
 const validArguments: InferValidators<Validators> = {
+  page: 2,
+  limit: 5000,
   q: "production",
   workspace_token: "wrkspc_123",
+};
+
+const defaultRequestArguments = {
+  page: 1,
+  limit: DEFAULT_LIMIT,
+  q: undefined,
+  workspace_token: undefined,
 };
 
 const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
   {
     name: "no filters",
-    data: {
-      q: undefined,
-      workspace_token: undefined,
-    },
+    data: noArguments,
   },
   {
     name: "search and workspace filters",
     data: validArguments,
+  },
+  {
+    name: "limit above API maximum",
+    data: {
+      ...validArguments,
+      limit: 5001,
+    },
+    expectedIssues: ["Too big: expected number to be <=5000"],
   },
   {
     name: "non-workspace token",
@@ -66,7 +88,7 @@ const successData: GetCostAlertsResponse = {
 
 const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
   {
-    name: "successful call",
+    name: "successful call with filters and pagination",
     apiCallHandler: requestsInOrder([
       {
         endpoint: "/v2/cost_alerts",
@@ -82,6 +104,39 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
       const res = await callExpectingSuccess(validArguments);
       expect(res).toEqual({
         cost_alerts: successData.cost_alerts,
+        pagination: {
+          hasNextPage: false,
+          nextPage: 0,
+        },
+      });
+    },
+  },
+  {
+    name: "successful call with pagination defaults",
+    apiCallHandler: requestsInOrder([
+      {
+        endpoint: "/v2/cost_alerts",
+        params: defaultRequestArguments,
+        method: "GET",
+        result: {
+          ok: true,
+          data: {
+            ...successData,
+            links: {
+              next: "https://api.vantage.sh/v2/cost_alerts?page=2",
+            },
+          },
+        },
+      },
+    ]),
+    handler: async ({ callExpectingSuccess }) => {
+      const res = await callExpectingSuccess(noArguments);
+      expect(res).toEqual({
+        cost_alerts: successData.cost_alerts,
+        pagination: {
+          hasNextPage: true,
+          nextPage: 2,
+        },
       });
     },
   },

--- a/test/tools/cost-alerts/list-cost-alerts.test.ts
+++ b/test/tools/cost-alerts/list-cost-alerts.test.ts
@@ -1,7 +1,6 @@
 import type { GetCostAlertsResponse } from "@vantage-sh/vantage-client";
 import { expect } from "vitest";
 import tool from "../../../src/tools/cost-alerts/list-cost-alerts";
-import { DEFAULT_LIMIT } from "../../../src/tools/structure/constants";
 import {
   type ExecutionTestTableItem,
   type ExtractOutputSchema,
@@ -16,19 +15,29 @@ type Validators = ExtractValidators<typeof tool>;
 type OutputSchema = ExtractOutputSchema<typeof tool>;
 
 const validArguments: InferValidators<Validators> = {
-  page: 1,
+  q: "production",
+  workspace_token: "wrkspc_123",
 };
 
 const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
   {
-    name: "default page",
+    name: "no filters",
     data: {
-      page: undefined,
+      q: undefined,
+      workspace_token: undefined,
     },
   },
   {
-    name: "valid page number",
+    name: "search and workspace filters",
     data: validArguments,
+  },
+  {
+    name: "non-workspace token",
+    data: {
+      ...validArguments,
+      workspace_token: "rprt_123",
+    },
+    expectedIssues: ["Must be a Workspace token (wrkspc_*)"],
   },
 ];
 
@@ -61,10 +70,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
     apiCallHandler: requestsInOrder([
       {
         endpoint: "/v2/cost_alerts",
-        params: {
-          page: 1,
-          limit: DEFAULT_LIMIT,
-        },
+        params: validArguments,
         method: "GET",
         result: {
           ok: true,
@@ -76,10 +82,6 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
       const res = await callExpectingSuccess(validArguments);
       expect(res).toEqual({
         cost_alerts: successData.cost_alerts,
-        pagination: {
-          hasNextPage: false,
-          nextPage: 0,
-        },
       });
     },
   },
@@ -88,10 +90,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
     apiCallHandler: requestsInOrder([
       {
         endpoint: "/v2/cost_alerts",
-        params: {
-          page: 1,
-          limit: DEFAULT_LIMIT,
-        },
+        params: validArguments,
         method: "GET",
         result: {
           ok: false,


### PR DESCRIPTION
## Summary
- add a read-only Model Context Protocol (MCP) tool for listing report annotations
- support Cost Report filtering, pagination, a 100-result default, and newest-first response semantics
- update the generated Vantage client for the annotations endpoint
- preserve Cost Alert search and Workspace filters while restoring page/limit pagination up to the Application Programming Interface (API) maximum of 5,000

Depends on [vantage-sh/core#21390](https://github.com/vantage-sh/core/pull/21390), [vantage-sh/core#21403](https://github.com/vantage-sh/core/pull/21403), and [vantage-sh/vantage-ts#64](https://github.com/vantage-sh/vantage-ts/pull/64), all merged.

## Test plan
- [x] `npm run type-check`
- [x] `npm run check:lint:all`
- [x] `npm test -- --run`

Made with [Cursor](https://cursor.com)