### PR TITLE
feat: Add annotation management tools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
         "@cloudflare/workers-oauth-provider": "^0.0.11",
         "@modelcontextprotocol/sdk": "1.29.0",
         "@sentry/cloudflare": "10.30.0",
-        "@vantage-sh/vantage-client": "2.16.0",
+        "@vantage-sh/vantage-client": "github:vantage-sh/vantage-ts#brooke/van-2162-create-annotations",
         "agents": "^0.13.2",
         "axios": "1.13.5",
         "hono": "4.12.12",
@@ -4102,9 +4102,8 @@
       }
     },
     "node_modules/@vantage-sh/vantage-client": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/@vantage-sh/vantage-client/-/vantage-client-2.16.0.tgz",
-      "integrity": "sha512-ioDN81WrUBj3kk32Lenz/PcNUfWBpxZt5LUK6cSKYT3oiey6KcD8ecw+6sxA4V2KVN9H2WwF5ialOQx6Za/V3A==",
+      "version": "2.17.0",
+      "resolved": "git+ssh://git@github.com/vantage-sh/vantage-ts.git#1e15196b500bde207f3571a41cc449694e2a4bfd",
       "license": "MIT"
     },
     "node_modules/@vercel/oidc": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4103,7 +4103,7 @@
     },
     "node_modules/@vantage-sh/vantage-client": {
       "version": "2.17.0",
-      "resolved": "git+ssh://git@github.com/vantage-sh/vantage-ts.git#da3eacdc58c47019d610f2b12fb8547fd2f7d968",
+      "resolved": "git+ssh://git@github.com/vantage-sh/vantage-ts.git#d9861adebfbd83e048092fe33b6466225fd87b74",
       "license": "MIT"
     },
     "node_modules/@vercel/oidc": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4103,7 +4103,7 @@
     },
     "node_modules/@vantage-sh/vantage-client": {
       "version": "2.17.0",
-      "resolved": "git+ssh://git@github.com/vantage-sh/vantage-ts.git#1e15196b500bde207f3571a41cc449694e2a4bfd",
+      "resolved": "git+ssh://git@github.com/vantage-sh/vantage-ts.git#da3eacdc58c47019d610f2b12fb8547fd2f7d968",
       "license": "MIT"
     },
     "node_modules/@vercel/oidc": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
         "@cloudflare/workers-oauth-provider": "^0.0.11",
         "@modelcontextprotocol/sdk": "1.29.0",
         "@sentry/cloudflare": "10.30.0",
-        "@vantage-sh/vantage-client": "github:vantage-sh/vantage-ts#brooke/van-2162-create-annotations",
+        "@vantage-sh/vantage-client": "2.17.0",
         "agents": "^0.13.2",
         "axios": "1.13.5",
         "hono": "4.12.12",
@@ -4103,7 +4103,8 @@
     },
     "node_modules/@vantage-sh/vantage-client": {
       "version": "2.17.0",
-      "resolved": "git+ssh://git@github.com/vantage-sh/vantage-ts.git#d9861adebfbd83e048092fe33b6466225fd87b74",
+      "resolved": "https://registry.npmjs.org/@vantage-sh/vantage-client/-/vantage-client-2.17.0.tgz",
+      "integrity": "sha512-Tjm575h8i+hClsqttCA8qyXz+OvZLZqRRiqlugvtrWz5rfJsCPdtVM22nKQzGPgg3DwdxGqSlekcNmKtLZJAsA==",
       "license": "MIT"
     },
     "node_modules/@vercel/oidc": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@cloudflare/workers-oauth-provider": "^0.0.11",
     "@modelcontextprotocol/sdk": "1.29.0",
     "@sentry/cloudflare": "10.30.0",
-    "@vantage-sh/vantage-client": "github:vantage-sh/vantage-ts#brooke/van-2162-create-annotations",
+    "@vantage-sh/vantage-client": "2.17.0",
     "agents": "^0.13.2",
     "axios": "1.13.5",
     "hono": "4.12.12",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@cloudflare/workers-oauth-provider": "^0.0.11",
     "@modelcontextprotocol/sdk": "1.29.0",
     "@sentry/cloudflare": "10.30.0",
-    "@vantage-sh/vantage-client": "2.16.0",
+    "@vantage-sh/vantage-client": "github:vantage-sh/vantage-ts#brooke/van-2162-create-annotations",
     "agents": "^0.13.2",
     "axios": "1.13.5",
     "hono": "4.12.12",

--- a/src/tools/annotations/create-annotation.ts
+++ b/src/tools/annotations/create-annotation.ts
@@ -1,0 +1,34 @@
+import z from "zod";
+import dateValidator from "../../utils/dateValidator";
+import { vantageToken } from "../../utils/zod";
+import MCPUserError from "../structure/MCPUserError";
+import registerTool from "../structure/registerTool";
+
+const description = `
+Create an Annotation on a Cost Report for a specific date. Use this tool when a user asks to add a note, explanation, or event marker to a Cost Report.
+`.trim();
+
+export default registerTool({
+  name: "create-annotation",
+  title: "Create Annotation",
+  description,
+  annotations: {
+    destructive: false,
+    openWorld: false,
+    readOnly: false,
+  },
+  args: {
+    report_token: vantageToken("cost_report", {
+      description: "Cost Report to annotate.",
+    }),
+    date: dateValidator("Date of the Annotation in ISO 8601 format (YYYY-MM-DD)."),
+    message: z.string().min(1).describe("Message to display for the Annotation."),
+  },
+  async execute(args, ctx) {
+    const response = await ctx.callVantageApi("/v2/annotations", args, "POST");
+    if (!response.ok) {
+      throw new MCPUserError({ errors: response.errors });
+    }
+    return response.data;
+  },
+});

--- a/src/tools/annotations/create-annotation.ts
+++ b/src/tools/annotations/create-annotation.ts
@@ -5,7 +5,7 @@ import MCPUserError from "../structure/MCPUserError";
 import registerTool from "../structure/registerTool";
 
 const description = `
-Create an Annotation on a Cost Report for a specific date. Use this tool when a user asks to add a note, explanation, or event marker to a Cost Report.
+Create an Annotation on one or more Cost Reports for a specific date. Use this tool when a user asks to add a note, explanation, or event marker to Cost Reports.
 `.trim();
 
 export default registerTool({
@@ -18,9 +18,15 @@ export default registerTool({
     readOnly: false,
   },
   args: {
-    report_token: vantageToken("cost_report", {
-      description: "Cost Report to annotate.",
-    }),
+    report_tokens: z
+      .array(
+        vantageToken("cost_report", {
+          description: "Cost Report to annotate.",
+        })
+      )
+      .min(1)
+      .describe("Cost Reports to annotate."),
+    title: z.string().min(1).optional().describe("Annotation title. Generated automatically when omitted."),
     date: dateValidator("Date of the Annotation in ISO 8601 format (YYYY-MM-DD)."),
     message: z.string().min(1).describe("Message to display for the Annotation."),
   },

--- a/src/tools/annotations/delete-annotation.ts
+++ b/src/tools/annotations/delete-annotation.ts
@@ -20,11 +20,7 @@ export default registerTool({
     annotation_token: vantageToken("annotation"),
   },
   async execute(args, ctx) {
-    const response = await ctx.callVantageApi(
-      `/v2/annotations/${pathEncode(args.annotation_token)}`,
-      {},
-      "DELETE"
-    );
+    const response = await ctx.callVantageApi(`/v2/annotations/${pathEncode(args.annotation_token)}`, {}, "DELETE");
     if (!response.ok) {
       throw new MCPUserError({ errors: response.errors });
     }

--- a/src/tools/annotations/delete-annotation.ts
+++ b/src/tools/annotations/delete-annotation.ts
@@ -20,7 +20,11 @@ export default registerTool({
     annotation_token: vantageToken("annotation"),
   },
   async execute(args, ctx) {
-    const response = await ctx.callVantageApi(`/v2/annotations/${pathEncode(args.annotation_token)}`, {}, "DELETE");
+    const response = await ctx.callVantageApi(
+      `/v2/annotations/${pathEncode(args.annotation_token)}`,
+      {},
+      "DELETE"
+    );
     if (!response.ok) {
       throw new MCPUserError({ errors: response.errors });
     }

--- a/src/tools/annotations/delete-annotation.ts
+++ b/src/tools/annotations/delete-annotation.ts
@@ -1,0 +1,29 @@
+import { pathEncode } from "@vantage-sh/vantage-client";
+import { vantageToken } from "../../utils/zod";
+import MCPUserError from "../structure/MCPUserError";
+import registerTool from "../structure/registerTool";
+
+const description = `
+Delete an Annotation by its token. This action is irreversible. Use list-annotations to find the annotation_token.
+`.trim();
+
+export default registerTool({
+  name: "delete-annotation",
+  title: "Delete Annotation",
+  description,
+  annotations: {
+    destructive: true,
+    openWorld: false,
+    readOnly: false,
+  },
+  args: {
+    annotation_token: vantageToken("annotation"),
+  },
+  async execute(args, ctx) {
+    const response = await ctx.callVantageApi(`/v2/annotations/${pathEncode(args.annotation_token)}`, {}, "DELETE");
+    if (!response.ok) {
+      throw new MCPUserError({ errors: response.errors });
+    }
+    return { token: args.annotation_token };
+  },
+});

--- a/src/tools/annotations/index.ts
+++ b/src/tools/annotations/index.ts
@@ -1,1 +1,4 @@
+import "./create-annotation";
+import "./delete-annotation";
 import "./list-annotations";
+import "./update-annotation";

--- a/src/tools/annotations/update-annotation.ts
+++ b/src/tools/annotations/update-annotation.ts
@@ -6,7 +6,7 @@ import MCPUserError from "../structure/MCPUserError";
 import registerTool from "../structure/registerTool";
 
 const description = `
-Update the date, message, or associated Cost Report of an existing Annotation. Use list-annotations to find the annotation_token.
+Update the title, date, message, or associated Cost Reports of an existing Annotation. Use list-annotations to find the annotation_token.
 `.trim();
 
 export default registerTool({
@@ -20,11 +20,18 @@ export default registerTool({
   },
   args: {
     annotation_token: vantageToken("annotation"),
+    title: z.string().min(1).optional().describe("Updated Annotation title."),
     date: dateValidator("Updated Annotation date in ISO 8601 format (YYYY-MM-DD).").optional(),
     message: z.string().min(1).optional().describe("Updated message for the Annotation."),
-    report_token: vantageToken("cost_report", {
-      description: "Replacement Cost Report for the Annotation.",
-    }).optional(),
+    report_tokens: z
+      .array(
+        vantageToken("cost_report", {
+          description: "Replacement Cost Report for the Annotation.",
+        })
+      )
+      .min(1)
+      .optional()
+      .describe("Replacement Cost Reports for the Annotation."),
   },
   async execute(args, ctx) {
     const { annotation_token, ...body } = args;

--- a/src/tools/annotations/update-annotation.ts
+++ b/src/tools/annotations/update-annotation.ts
@@ -6,7 +6,7 @@ import MCPUserError from "../structure/MCPUserError";
 import registerTool from "../structure/registerTool";
 
 const description = `
-Update the date or message of an existing Annotation. Use list-annotations to find the annotation_token.
+Update the date, message, or associated Cost Report of an existing Annotation. Use list-annotations to find the annotation_token.
 `.trim();
 
 export default registerTool({
@@ -22,6 +22,9 @@ export default registerTool({
     annotation_token: vantageToken("annotation"),
     date: dateValidator("Updated Annotation date in ISO 8601 format (YYYY-MM-DD).").optional(),
     message: z.string().min(1).optional().describe("Updated message for the Annotation."),
+    report_token: vantageToken("cost_report", {
+      description: "Replacement Cost Report for the Annotation.",
+    }).optional(),
   },
   async execute(args, ctx) {
     const { annotation_token, ...body } = args;

--- a/src/tools/annotations/update-annotation.ts
+++ b/src/tools/annotations/update-annotation.ts
@@ -6,7 +6,7 @@ import MCPUserError from "../structure/MCPUserError";
 import registerTool from "../structure/registerTool";
 
 const description = `
-Update the title, date, message, or associated Cost Reports of an existing Annotation. Use list-annotations to find the annotation_token.
+Update the title, date, message, or associated Cost Reports of an existing Annotation. Providing report_tokens replaces all existing Report associations. Use list-annotations to find the annotation_token.
 `.trim();
 
 export default registerTool({

--- a/src/tools/annotations/update-annotation.ts
+++ b/src/tools/annotations/update-annotation.ts
@@ -1,0 +1,38 @@
+import { pathEncode, type UpdateAnnotationRequest } from "@vantage-sh/vantage-client";
+import z from "zod";
+import dateValidator from "../../utils/dateValidator";
+import { vantageToken } from "../../utils/zod";
+import MCPUserError from "../structure/MCPUserError";
+import registerTool from "../structure/registerTool";
+
+const description = `
+Update the date or message of an existing Annotation. Use list-annotations to find the annotation_token.
+`.trim();
+
+export default registerTool({
+  name: "update-annotation",
+  title: "Update Annotation",
+  description,
+  annotations: {
+    destructive: true,
+    openWorld: false,
+    readOnly: false,
+  },
+  args: {
+    annotation_token: vantageToken("annotation"),
+    date: dateValidator("Updated Annotation date in ISO 8601 format (YYYY-MM-DD).").optional(),
+    message: z.string().min(1).optional().describe("Updated message for the Annotation."),
+  },
+  async execute(args, ctx) {
+    const { annotation_token, ...body } = args;
+    const response = await ctx.callVantageApi(
+      `/v2/annotations/${pathEncode(annotation_token)}`,
+      body as UpdateAnnotationRequest,
+      "PUT"
+    );
+    if (!response.ok) {
+      throw new MCPUserError({ errors: response.errors });
+    }
+    return response.data;
+  },
+});

--- a/src/utils/zod/token-kinds.ts
+++ b/src/utils/zod/token-kinds.ts
@@ -10,6 +10,10 @@ export const TOKEN_KINDS = {
     prefix: "rsrc_accss_grnt",
     label: "Access Grant",
   },
+  annotation: {
+    prefix: "issue",
+    label: "Annotation",
+  },
   anomaly_alert: {
     prefix: "anmly_alrt",
     label: "Anomaly Alert",

--- a/test/tools/annotations/create-annotation.test.ts
+++ b/test/tools/annotations/create-annotation.test.ts
@@ -1,0 +1,90 @@
+import { expect } from "vitest";
+import tool from "../../../src/tools/annotations/create-annotation";
+import { requestsInOrder, testTool } from "../../../src/utils/testing";
+
+const validArguments = {
+  report_token: "rprt_123",
+  date: "2026-08-12",
+  message: "Infrastructure migration completed",
+};
+
+const annotation = {
+  token: "issue_123",
+  report_tokens: ["rprt_123"],
+  date: "2026-08-12",
+  message: "Infrastructure migration completed",
+};
+
+testTool(
+  tool,
+  [
+    {
+      name: "takes a Report token, date, and message",
+      data: validArguments,
+    },
+    {
+      name: "rejects an invalid Report token",
+      data: {
+        ...validArguments,
+        report_token: "issue_123",
+      },
+      expectedIssues: ["Must be a Cost Report token (rprt_*)"],
+    },
+    {
+      name: "rejects an invalid date",
+      data: {
+        ...validArguments,
+        date: "not-a-date",
+      },
+      expectedIssues: ["Invalid date input, must be YYYY-MM-DD format and a reasonable date."],
+    },
+    {
+      name: "rejects an empty message",
+      data: {
+        ...validArguments,
+        message: "",
+      },
+      expectedIssues: ["Too small: expected string to have >=1 characters"],
+    },
+  ],
+  [
+    {
+      name: "successful call",
+      apiCallHandler: requestsInOrder([
+        {
+          endpoint: "/v2/annotations",
+          params: validArguments,
+          method: "POST",
+          result: {
+            ok: true,
+            data: annotation,
+          },
+        },
+      ]),
+      handler: async ({ callExpectingSuccess }) => {
+        const response = await callExpectingSuccess(validArguments);
+        expect(response).toEqual(annotation);
+      },
+    },
+    {
+      name: "unsuccessful call",
+      apiCallHandler: requestsInOrder([
+        {
+          endpoint: "/v2/annotations",
+          params: validArguments,
+          method: "POST",
+          result: {
+            ok: false,
+            errors: [{ message: "Report not found" }],
+          },
+        },
+      ]),
+      handler: async ({ callExpectingMCPUserError }) => {
+        const error = await callExpectingMCPUserError(validArguments);
+        expect(error.exception).toEqual({
+          errors: [{ message: "Report not found" }],
+        });
+      },
+    },
+  ]
+);

--- a/test/tools/annotations/create-annotation.test.ts
+++ b/test/tools/annotations/create-annotation.test.ts
@@ -3,14 +3,16 @@ import tool from "../../../src/tools/annotations/create-annotation";
 import { requestsInOrder, testTool } from "../../../src/utils/testing";
 
 const validArguments = {
-  report_token: "rprt_123",
+  report_tokens: ["rprt_123", "rprt_456"],
+  title: "Migration completed",
   date: "2026-08-12",
   message: "Infrastructure migration completed",
 };
 
 const annotation = {
   token: "issue_123",
-  report_tokens: ["rprt_123"],
+  title: "Migration completed",
+  report_tokens: ["rprt_123", "rprt_456"],
   date: "2026-08-12",
   message: "Infrastructure migration completed",
 };
@@ -19,16 +21,39 @@ testTool(
   tool,
   [
     {
-      name: "takes a Report token, date, and message",
+      name: "takes Report tokens, title, date, and message",
       data: validArguments,
+    },
+    {
+      name: "allows the title to be omitted",
+      data: {
+        ...validArguments,
+        title: undefined,
+      },
     },
     {
       name: "rejects an invalid Report token",
       data: {
         ...validArguments,
-        report_token: "issue_123",
+        report_tokens: ["rprt_123", "issue_123"],
       },
       expectedIssues: ["Must be a Cost Report token (rprt_*)"],
+    },
+    {
+      name: "rejects an empty Report token list",
+      data: {
+        ...validArguments,
+        report_tokens: [],
+      },
+      expectedIssues: ["Too small: expected array to have >=1 items"],
+    },
+    {
+      name: "rejects an empty title",
+      data: {
+        ...validArguments,
+        title: "",
+      },
+      expectedIssues: ["Too small: expected string to have >=1 characters"],
     },
     {
       name: "rejects an invalid date",

--- a/test/tools/annotations/delete-annotation.test.ts
+++ b/test/tools/annotations/delete-annotation.test.ts
@@ -1,0 +1,67 @@
+import { pathEncode } from "@vantage-sh/vantage-client";
+import { expect } from "vitest";
+import tool from "../../../src/tools/annotations/delete-annotation";
+import { requestsInOrder, testTool } from "../../../src/utils/testing";
+
+testTool(
+  tool,
+  [
+    {
+      name: "takes an Annotation token",
+      data: {
+        annotation_token: "issue_123",
+      },
+    },
+    {
+      name: "rejects an invalid Annotation token",
+      data: {
+        annotation_token: "rprt_123",
+      },
+      expectedIssues: ["Must be a Annotation token (issue_*)"],
+    },
+  ],
+  [
+    {
+      name: "successful call",
+      apiCallHandler: requestsInOrder([
+        {
+          endpoint: `/v2/annotations/${pathEncode("issue_123")}`,
+          params: {},
+          method: "DELETE",
+          result: {
+            ok: true,
+            data: undefined,
+          },
+        },
+      ]),
+      handler: async ({ callExpectingSuccess }) => {
+        const response = await callExpectingSuccess({
+          annotation_token: "issue_123",
+        });
+        expect(response).toEqual({ token: "issue_123" });
+      },
+    },
+    {
+      name: "unsuccessful call",
+      apiCallHandler: requestsInOrder([
+        {
+          endpoint: `/v2/annotations/${pathEncode("issue_missing")}`,
+          params: {},
+          method: "DELETE",
+          result: {
+            ok: false,
+            errors: [{ message: "Annotation not found" }],
+          },
+        },
+      ]),
+      handler: async ({ callExpectingMCPUserError }) => {
+        const error = await callExpectingMCPUserError({
+          annotation_token: "issue_missing",
+        });
+        expect(error.exception).toEqual({
+          errors: [{ message: "Annotation not found" }],
+        });
+      },
+    },
+  ]
+);

--- a/test/tools/annotations/list-annotations.test.ts
+++ b/test/tools/annotations/list-annotations.test.ts
@@ -52,12 +52,14 @@ const successData = {
   annotations: [
     {
       token: "annotation_123",
+      title: "Deployment completed",
       report_tokens: ["rprt_fb27faa25ef5ea72"],
       date: "2026-08-12",
       message: "Deployment completed",
     },
     {
       token: "annotation_456",
+      title: "Pricing update",
       report_tokens: ["rprt_fb27faa25ef5ea72", "rprt_123"],
       date: null,
       message: null,

--- a/test/tools/annotations/update-annotation.test.ts
+++ b/test/tools/annotations/update-annotation.test.ts
@@ -1,0 +1,108 @@
+import { pathEncode } from "@vantage-sh/vantage-client";
+import { expect } from "vitest";
+import tool from "../../../src/tools/annotations/update-annotation";
+import { requestsInOrder, testTool } from "../../../src/utils/testing";
+
+const validArguments = {
+  annotation_token: "issue_123",
+  date: "2026-08-14",
+  message: "Infrastructure migration rescheduled",
+};
+
+const annotation = {
+  token: "issue_123",
+  report_tokens: ["rprt_123"],
+  date: "2026-08-14",
+  message: "Infrastructure migration rescheduled",
+};
+
+testTool(
+  tool,
+  [
+    {
+      name: "takes an Annotation token, date, and message",
+      data: validArguments,
+    },
+    {
+      name: "takes only a message",
+      data: {
+        annotation_token: "issue_123",
+        date: undefined,
+        message: "Updated message",
+      },
+    },
+    {
+      name: "rejects an invalid Annotation token",
+      data: {
+        ...validArguments,
+        annotation_token: "rprt_123",
+      },
+      expectedIssues: ["Must be a Annotation token (issue_*)"],
+    },
+    {
+      name: "rejects an invalid date",
+      data: {
+        ...validArguments,
+        date: "not-a-date",
+      },
+      expectedIssues: ["Invalid date input, must be YYYY-MM-DD format and a reasonable date."],
+    },
+    {
+      name: "rejects an empty message",
+      data: {
+        ...validArguments,
+        message: "",
+      },
+      expectedIssues: ["Too small: expected string to have >=1 characters"],
+    },
+  ],
+  [
+    {
+      name: "successful call",
+      apiCallHandler: requestsInOrder([
+        {
+          endpoint: `/v2/annotations/${pathEncode("issue_123")}`,
+          params: {
+            date: "2026-08-14",
+            message: "Infrastructure migration rescheduled",
+          },
+          method: "PUT",
+          result: {
+            ok: true,
+            data: annotation,
+          },
+        },
+      ]),
+      handler: async ({ callExpectingSuccess }) => {
+        const response = await callExpectingSuccess(validArguments);
+        expect(response).toEqual(annotation);
+      },
+    },
+    {
+      name: "unsuccessful call",
+      apiCallHandler: requestsInOrder([
+        {
+          endpoint: `/v2/annotations/${pathEncode("issue_missing")}`,
+          params: {
+            message: "Updated message",
+          },
+          method: "PUT",
+          result: {
+            ok: false,
+            errors: [{ message: "Annotation not found" }],
+          },
+        },
+      ]),
+      handler: async ({ callExpectingMCPUserError }) => {
+        const error = await callExpectingMCPUserError({
+          annotation_token: "issue_missing",
+          date: undefined,
+          message: "Updated message",
+        });
+        expect(error.exception).toEqual({
+          errors: [{ message: "Annotation not found" }],
+        });
+      },
+    },
+  ]
+);

--- a/test/tools/annotations/update-annotation.test.ts
+++ b/test/tools/annotations/update-annotation.test.ts
@@ -5,14 +5,16 @@ import { requestsInOrder, testTool } from "../../../src/utils/testing";
 
 const validArguments = {
   annotation_token: "issue_123",
+  title: "Migration rescheduled",
   date: "2026-08-14",
   message: "Infrastructure migration rescheduled",
-  report_token: "rprt_456",
+  report_tokens: ["rprt_456", "rprt_789"],
 };
 
 const annotation = {
   token: "issue_123",
-  report_tokens: ["rprt_456"],
+  title: "Migration rescheduled",
+  report_tokens: ["rprt_456", "rprt_789"],
   date: "2026-08-14",
   message: "Infrastructure migration rescheduled",
 };
@@ -21,25 +23,37 @@ testTool(
   tool,
   [
     {
-      name: "takes an Annotation token, date, and message",
+      name: "takes an Annotation token, title, date, message, and Report tokens",
       data: validArguments,
     },
     {
       name: "takes only a message",
       data: {
         annotation_token: "issue_123",
+        title: undefined,
         date: undefined,
         message: "Updated message",
-        report_token: undefined,
+        report_tokens: undefined,
       },
     },
     {
-      name: "takes only a replacement Report token",
+      name: "takes only replacement Report tokens",
       data: {
         annotation_token: "issue_123",
+        title: undefined,
         date: undefined,
         message: undefined,
-        report_token: "rprt_456",
+        report_tokens: ["rprt_456", "rprt_789"],
+      },
+    },
+    {
+      name: "takes only a title",
+      data: {
+        annotation_token: "issue_123",
+        title: "Updated title",
+        date: undefined,
+        message: undefined,
+        report_tokens: undefined,
       },
     },
     {
@@ -54,9 +68,25 @@ testTool(
       name: "rejects an invalid Report token",
       data: {
         ...validArguments,
-        report_token: "issue_123",
+        report_tokens: ["rprt_456", "issue_123"],
       },
       expectedIssues: ["Must be a Cost Report token (rprt_*)"],
+    },
+    {
+      name: "rejects an empty Report token list",
+      data: {
+        ...validArguments,
+        report_tokens: [],
+      },
+      expectedIssues: ["Too small: expected array to have >=1 items"],
+    },
+    {
+      name: "rejects an empty title",
+      data: {
+        ...validArguments,
+        title: "",
+      },
+      expectedIssues: ["Too small: expected string to have >=1 characters"],
     },
     {
       name: "rejects an invalid date",
@@ -82,9 +112,10 @@ testTool(
         {
           endpoint: `/v2/annotations/${pathEncode("issue_123")}`,
           params: {
+            title: "Migration rescheduled",
             date: "2026-08-14",
             message: "Infrastructure migration rescheduled",
-            report_token: "rprt_456",
+            report_tokens: ["rprt_456", "rprt_789"],
           },
           method: "PUT",
           result: {
@@ -116,9 +147,10 @@ testTool(
       handler: async ({ callExpectingMCPUserError }) => {
         const error = await callExpectingMCPUserError({
           annotation_token: "issue_missing",
+          title: undefined,
           date: undefined,
           message: "Updated message",
-          report_token: undefined,
+          report_tokens: undefined,
         });
         expect(error.exception).toEqual({
           errors: [{ message: "Annotation not found" }],

--- a/test/tools/annotations/update-annotation.test.ts
+++ b/test/tools/annotations/update-annotation.test.ts
@@ -7,11 +7,12 @@ const validArguments = {
   annotation_token: "issue_123",
   date: "2026-08-14",
   message: "Infrastructure migration rescheduled",
+  report_token: "rprt_456",
 };
 
 const annotation = {
   token: "issue_123",
-  report_tokens: ["rprt_123"],
+  report_tokens: ["rprt_456"],
   date: "2026-08-14",
   message: "Infrastructure migration rescheduled",
 };
@@ -29,6 +30,16 @@ testTool(
         annotation_token: "issue_123",
         date: undefined,
         message: "Updated message",
+        report_token: undefined,
+      },
+    },
+    {
+      name: "takes only a replacement Report token",
+      data: {
+        annotation_token: "issue_123",
+        date: undefined,
+        message: undefined,
+        report_token: "rprt_456",
       },
     },
     {
@@ -38,6 +49,14 @@ testTool(
         annotation_token: "rprt_123",
       },
       expectedIssues: ["Must be a Annotation token (issue_*)"],
+    },
+    {
+      name: "rejects an invalid Report token",
+      data: {
+        ...validArguments,
+        report_token: "issue_123",
+      },
+      expectedIssues: ["Must be a Cost Report token (rprt_*)"],
     },
     {
       name: "rejects an invalid date",
@@ -65,6 +84,7 @@ testTool(
           params: {
             date: "2026-08-14",
             message: "Infrastructure migration rescheduled",
+            report_token: "rprt_456",
           },
           method: "PUT",
           result: {
@@ -98,6 +118,7 @@ testTool(
           annotation_token: "issue_missing",
           date: undefined,
           message: "Updated message",
+          report_token: undefined,
         });
         expect(error.exception).toEqual({
           errors: [{ message: "Annotation not found" }],


### PR DESCRIPTION
## Summary
- add `create-annotation`, `update-annotation`, and `delete-annotation` Model Context Protocol (MCP) tools
- support creating and updating Annotations across multiple Cost Reports through `report_tokens`
- accept an optional title on create and support title updates
- return titles from annotation list and mutation responses
- validate Report and Annotation token prefixes, non-empty Report arrays, titles, dates, and messages
- cover successful requests, validation failures, and Application Programming Interface (API) errors

## Dependencies
- [x] Merge [core#21422](https://github.com/vantage-sh/core/pull/21422)
- [x] Publish `@vantage-sh/vantage-client@2.17.0`
- [x] Replace the temporary Git dependency with the published client

## Test plan
- [x] `npx vitest run test/tools/annotations` (36 tests)
- [x] `npm run type-check`
- [x] Biome checks for changed annotation tools and tests

[Linear issue VAN-2162](https://linear.app/vantage-sh/issue/VAN-2162/add-annotations-to-the-api)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces mutating API calls (including irreversible delete) and replaces report associations on update; validation and tests follow existing tool patterns.
> 
> **Overview**
> Adds **create**, **update**, and **delete** annotation MCP tools so agents can manage Cost Report markers end-to-end, alongside the existing **list-annotations** tool.
> 
> **create-annotation** posts to `/v2/annotations` with one or more `report_tokens`, a required date and message, and an optional title. **update-annotation** PUTs partial changes (title, date, message, or full replacement of linked reports via `report_tokens`). **delete-annotation** removes an annotation by `issue_*` token.
> 
> Registers the **annotation** token kind (`issue_*`) for validation and bumps **`@vantage-sh/vantage-client`** to **2.17.0** for `UpdateAnnotationRequest` and related API types. List-annotation tests now expect **title** on returned annotations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc18737be242f09f971bbeedfff84c846c2317d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->