### PR TITLE
Support provider resource folders

### DIFF
--- a/src/tools/folders/create-folder.ts
+++ b/src/tools/folders/create-folder.ts
@@ -5,7 +5,7 @@ import registerTool from "../structure/registerTool";
 import { folderType } from "./schemas";
 
 const description = `
-Create a Folder for organizing Cost Reports or Resource Reports. Use ProviderResourceFolder for Resource Reports; otherwise the API defaults to CostFolder.
+Create a folder for organizing Cost Reports or Resource Reports. Set type to ProviderResourceFolder for Resource Reports; omit it to create the default CostFolder.
 `.trim();
 
 export default registerTool({
@@ -21,7 +21,7 @@ export default registerTool({
     title: z.string().min(1).describe("The title of the Folder."),
     type: folderType
       .optional()
-      .describe("The Folder type. Use ProviderResourceFolder for Resource Reports. Defaults to CostFolder."),
+      .describe("Folder type. Set to ProviderResourceFolder for Resource Reports; omit for the default CostFolder."),
     parent_folder_token: vantageToken("folder", {
       description: "Parent Folder to nest this Folder under.",
     }).optional(),

--- a/src/tools/folders/create-folder.ts
+++ b/src/tools/folders/create-folder.ts
@@ -2,10 +2,10 @@ import z from "zod";
 import { vantageToken } from "../../utils/zod";
 import MCPUserError from "../structure/MCPUserError";
 import registerTool from "../structure/registerTool";
+import { folderType } from "./schemas";
 
 const description = `
-Create a Folder for organizing Cost Reports. Folders can be nested by specifying a parent_folder_token.
-SavedFilters can be applied to the Folder so that any Cost Report within it inherits those filters.
+Create a Folder for organizing Cost Reports or Resource Reports. Use ProviderResourceFolder for Resource Reports; otherwise the API defaults to CostFolder.
 `.trim();
 
 export default registerTool({
@@ -19,6 +19,9 @@ export default registerTool({
   },
   args: {
     title: z.string().min(1).describe("The title of the Folder."),
+    type: folderType
+      .optional()
+      .describe("The Folder type. Use ProviderResourceFolder for Resource Reports. Defaults to CostFolder."),
     parent_folder_token: vantageToken("folder", {
       description: "Parent Folder to nest this Folder under.",
     }).optional(),

--- a/src/tools/folders/create-folder.ts
+++ b/src/tools/folders/create-folder.ts
@@ -5,7 +5,7 @@ import registerTool from "../structure/registerTool";
 import { folderType } from "./schemas";
 
 const description = `
-Create a folder for organizing Cost Reports or Resource Reports. Set type to ProviderResourceFolder for Resource Reports; omit it to create the default CostFolder.
+Create a folder for organizing Cost Reports or Resource Reports. Set type to CostFolder for Cost Reports or ProviderResourceFolder for Resource Reports.
 `.trim();
 
 export default registerTool({
@@ -19,9 +19,9 @@ export default registerTool({
   },
   args: {
     title: z.string().min(1).describe("The title of the Folder."),
-    type: folderType
-      .optional()
-      .describe("Folder type. Set to ProviderResourceFolder for Resource Reports; omit for the default CostFolder."),
+    type: folderType.describe(
+      "Folder type. Set to CostFolder for Cost Reports or ProviderResourceFolder for Resource Reports."
+    ),
     parent_folder_token: vantageToken("folder", {
       description: "Parent Folder to nest this Folder under.",
     }).optional(),

--- a/src/tools/folders/delete-folder.ts
+++ b/src/tools/folders/delete-folder.ts
@@ -4,7 +4,7 @@ import MCPUserError from "../structure/MCPUserError";
 import registerTool from "../structure/registerTool";
 
 const description = `
-Deletes a Folder. Cost Reports within the Folder will not be deleted.
+Deletes a Folder. Reports within the Folder will not be deleted.
 `.trim();
 
 export default registerTool({

--- a/src/tools/folders/list-folders.ts
+++ b/src/tools/folders/list-folders.ts
@@ -4,13 +4,10 @@ import { nonempty, vantageToken } from "../../utils/zod";
 import { DEFAULT_LIMIT } from "../structure/constants";
 import MCPUserError from "../structure/MCPUserError";
 import registerTool from "../structure/registerTool";
+import { folderType } from "./schemas";
 
 const description = `
-List all Folders for organizing Cost Reports. Folders can be nested within other Folders via the parent_folder_token field.
-When you first call this function, use the "page" parameter of 1.
-The 'title' of a Folder describes its purpose.
-The 'saved_filter_tokens' field contains tokens of SavedFilters applied to Cost Reports within the Folder.
-The 'token' of a Folder can be used to generate a link in the Vantage Web UI: https://console.vantage.sh/go/<token>
+List Cost Report and Resource Report Folders, optionally filtered by Folder type. Folder tokens link to https://console.vantage.sh/go/<token>.
 `.trim();
 
 const args = {
@@ -19,6 +16,7 @@ const args = {
   workspace_token: vantageToken("workspace", {
     description: "Only return Folders in this Workspace.",
   }).optional(),
+  type: folderType.optional().describe("Filter by Folder type."),
 };
 
 export default registerTool({

--- a/src/tools/folders/list-folders.ts
+++ b/src/tools/folders/list-folders.ts
@@ -7,7 +7,7 @@ import registerTool from "../structure/registerTool";
 import { folderType } from "./schemas";
 
 const description = `
-List Cost Report and Resource Report Folders, optionally filtered by Folder type. Folder tokens link to https://console.vantage.sh/go/<token>.
+List folders for Cost Reports or Resource Reports, optionally filtering by title, Workspace, or folder type. Use CostFolder for Cost Report folders and ProviderResourceFolder for Resource Report folders; folder tokens link to https://console.vantage.sh/go/<token>.
 `.trim();
 
 const args = {
@@ -16,7 +16,9 @@ const args = {
   workspace_token: vantageToken("workspace", {
     description: "Only return Folders in this Workspace.",
   }).optional(),
-  type: folderType.optional().describe("Filter by Folder type."),
+  type: folderType
+    .optional()
+    .describe("Only return Cost Report folders (CostFolder) or Resource Report folders (ProviderResourceFolder)."),
 };
 
 export default registerTool({

--- a/src/tools/folders/schemas.ts
+++ b/src/tools/folders/schemas.ts
@@ -1,0 +1,3 @@
+import z from "zod";
+
+export const folderType = z.enum(["CostFolder", "ProviderResourceFolder"]);

--- a/src/tools/folders/update-folder.ts
+++ b/src/tools/folders/update-folder.ts
@@ -5,7 +5,7 @@ import MCPUserError from "../structure/MCPUserError";
 import registerTool from "../structure/registerTool";
 
 const description = `
-Updates a Folder for organizing Cost Reports. You can update its title, move it to a different parent Folder, or change its SavedFilter tokens.
+Updates a Folder's title, parent, or SavedFilter tokens. Folder type cannot be changed after creation.
 `.trim();
 
 export default registerTool({

--- a/test/tools/folders/create-folder.test.ts
+++ b/test/tools/folders/create-folder.test.ts
@@ -14,6 +14,7 @@ type Validators = ExtractValidators<typeof tool>;
 type OutputSchema = ExtractOutputSchema<typeof tool>;
 
 const undefineds = {
+  type: undefined,
   parent_folder_token: undefined,
   saved_filter_tokens: undefined,
   workspace_token: undefined,
@@ -25,7 +26,8 @@ const minimalValidInputArguments: InferValidators<Validators> = {
 };
 
 const validInputArguments: InferValidators<Validators> = {
-  title: "Platform Team Reports",
+  title: "Infrastructure Resources",
+  type: "ProviderResourceFolder",
   parent_folder_token: "fldr_123",
   saved_filter_tokens: ["svd_fltr_abc", "svd_fltr_def"],
   workspace_token: "wrkspc_123",
@@ -37,8 +39,16 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
     data: minimalValidInputArguments,
   },
   {
-    name: "all valid arguments",
+    name: "provider resource folder",
     data: validInputArguments,
+  },
+  {
+    name: "invalid folder type",
+    data: {
+      ...minimalValidInputArguments,
+      type: "DashboardFolder" as any,
+    },
+    expectedIssues: ['Invalid option: expected one of "CostFolder"|"ProviderResourceFolder"'],
   },
   {
     name: "empty title",
@@ -52,8 +62,8 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
 
 const successData = {
   token: "fldr_789",
-  title: "Platform Team Reports",
-  type: "cost_reports",
+  title: "Infrastructure Resources",
+  type: "ProviderResourceFolder",
   parent_folder_token: "fldr_123",
   saved_filter_tokens: ["svd_fltr_abc", "svd_fltr_def"],
   workspace_token: "wrkspc_123",
@@ -63,7 +73,7 @@ const successData = {
 
 const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
   {
-    name: "successful call",
+    name: "creates a provider resource folder",
     apiCallHandler: requestsInOrder([
       {
         endpoint: "/v2/folders",

--- a/test/tools/folders/create-folder.test.ts
+++ b/test/tools/folders/create-folder.test.ts
@@ -14,7 +14,6 @@ type Validators = ExtractValidators<typeof tool>;
 type OutputSchema = ExtractOutputSchema<typeof tool>;
 
 const undefineds = {
-  type: undefined,
   parent_folder_token: undefined,
   saved_filter_tokens: undefined,
   workspace_token: undefined,
@@ -23,6 +22,7 @@ const undefineds = {
 const minimalValidInputArguments: InferValidators<Validators> = {
   ...undefineds,
   title: "My Folder",
+  type: "CostFolder",
 };
 
 const validInputArguments: InferValidators<Validators> = {
@@ -35,12 +35,20 @@ const validInputArguments: InferValidators<Validators> = {
 
 const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
   {
-    name: "minimal valid arguments",
+    name: "cost report folder",
     data: minimalValidInputArguments,
   },
   {
     name: "provider resource folder",
     data: validInputArguments,
+  },
+  {
+    name: "folder type is required",
+    data: {
+      ...undefineds,
+      title: "My Folder",
+    } as any,
+    expectedIssues: ['Invalid option: expected one of "CostFolder"|"ProviderResourceFolder"'],
   },
   {
     name: "invalid folder type",

--- a/test/tools/folders/create-folder.test.ts
+++ b/test/tools/folders/create-folder.test.ts
@@ -63,6 +63,7 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
     data: {
       ...undefineds,
       title: "",
+      type: "CostFolder",
     },
     expectedIssues: ["Too small: expected string to have >=1 characters"],
   },

--- a/test/tools/folders/get-folder.test.ts
+++ b/test/tools/folders/get-folder.test.ts
@@ -5,8 +5,8 @@ import { requestsInOrder, testTool } from "../../../src/utils/testing";
 
 const success: GetFolderResponse = {
   token: "fldr_123",
-  title: "Platform Team Reports",
-  type: "cost_reports",
+  title: "Infrastructure Resources",
+  type: "ProviderResourceFolder",
   saved_filter_tokens: [],
   created_at: "2023-01-01T00:00:00Z",
   updated_at: "2023-01-01T00:00:00Z",

--- a/test/tools/folders/list-folders.test.ts
+++ b/test/tools/folders/list-folders.test.ts
@@ -18,6 +18,7 @@ const validArguments: InferValidators<Validators> = {
   page: 1,
   q: "Finance",
   workspace_token: "wrkspc_123",
+  type: "ProviderResourceFolder",
 };
 
 const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
@@ -27,11 +28,22 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
       page: undefined,
       q: undefined,
       workspace_token: undefined,
+      type: undefined,
     },
   },
   {
-    name: "valid page number",
+    name: "provider resource folder filter",
     data: validArguments,
+  },
+  {
+    name: "invalid folder type",
+    data: {
+      page: 1,
+      q: undefined,
+      workspace_token: undefined,
+      type: "DashboardFolder" as any,
+    },
+    expectedIssues: ['Invalid option: expected one of "CostFolder"|"ProviderResourceFolder"'],
   },
 ];
 
@@ -39,23 +51,13 @@ const successData = {
   folders: [
     {
       token: "fldr_123",
-      title: "Platform Team Reports",
-      type: "cost_reports",
+      title: "Infrastructure Resources",
+      type: "ProviderResourceFolder",
       parent_folder_token: undefined,
       saved_filter_tokens: [],
       workspace_token: "wrkspc_123",
       created_at: "2024-01-01T00:00:00Z",
       updated_at: "2024-01-01T00:00:00Z",
-    },
-    {
-      token: "fldr_456",
-      title: "Sub Folder",
-      type: "cost_reports",
-      parent_folder_token: "fldr_123",
-      saved_filter_tokens: ["svd_fltr_abc"],
-      workspace_token: "wrkspc_123",
-      created_at: "2024-01-02T00:00:00Z",
-      updated_at: "2024-01-02T00:00:00Z",
     },
   ],
   links: {},
@@ -63,12 +65,13 @@ const successData = {
 
 const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
   {
-    name: "successful call",
+    name: "filters provider resource folders",
     apiCallHandler: requestsInOrder([
       {
         endpoint: "/v2/folders",
         params: {
           page: 1,
+          type: "ProviderResourceFolder",
           limit: DEFAULT_LIMIT,
           q: "Finance",
           workspace_token: "wrkspc_123",
@@ -98,6 +101,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
         endpoint: "/v2/folders",
         params: {
           page: 1,
+          type: "ProviderResourceFolder",
           limit: DEFAULT_LIMIT,
           q: "Finance",
           workspace_token: "wrkspc_123",

--- a/test/tools/folders/update-folder.test.ts
+++ b/test/tools/folders/update-folder.test.ts
@@ -46,7 +46,7 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
 const successData: GetFolderResponse = {
   token: "fldr_123",
   title: "Updated Team Reports",
-  type: "cost_reports",
+  type: "CostFolder",
   parent_folder_token: "fldr_parent",
   saved_filter_tokens: ["svd_fltr_abc"],
   created_at: "2023-01-01T00:00:00Z",


### PR DESCRIPTION
## Summary
- allow `create-folder` to create Cost Report or Provider Resource folders
- add folder-type filtering to `list-folders`
- clarify the report-to-folder type mapping and default behavior for MCP clients

## Prompt selection checks
Tried 26 direct, inferred, and sibling-confusion variants. All selected the expected tool and arguments.

Direct prompts included:
- `Create a provider resource folder named Infrastructure in wrkspc_123.` → `create-folder` with `ProviderResourceFolder`
- `Create a folder named Finance in wrkspc_123 for cost reports.` → `create-folder` with `CostFolder`
- `Make a Resource Report folder called Compute under fldr_parent.` → `create-folder` with `ProviderResourceFolder`
- `List all provider resource folders in wrkspc_123.` → `list-folders` with `ProviderResourceFolder`
- `Show Cost Report folders whose title contains Finance.` → `list-folders` with `CostFolder`

Inferred prompts included:
- `I need a place called Compute Inventory to organize my saved infrastructure views in wrkspc_123.`
- `Set up an AWS Resources folder in wrkspc_123 so I can put resource reports in it later.`
- `Make a folder called Monthly Spend in wrkspc_123.`
- `Where are the folders I use for infrastructure inventory?`
- `Find folders called EC2 in wrkspc_123, but only the ones used for resource reports.`

Sibling-confusion prompts included:
- `Create a resource report folder called Inventory in wrkspc_123.` → `create-folder`
- `Create a resource report called Inventory in wrkspc_123.` → `create-resource-report`
- `List resource report folders.` → `list-folders`
- `List resource reports.` → `list-resource-reports`
- `Create a folder for cloud resources called Inventory in wrkspc_123.` → `create-folder`
- `Create a folder named Inventory and put a resource report in it.` → starts with `create-folder` as a multi-step request

## Test plan
- [x] `npm run type-check`
- [x] `npm run lint`
- [x] `npm test -- --run` (1,068 tests)

Made with [Cursor](https://cursor.com)