### PR TITLE
Get 'update-cost-report' attributes up to date

### DIFF
--- a/src/tools/cost-reports/schemas.ts
+++ b/src/tools/cost-reports/schemas.ts
@@ -41,6 +41,10 @@ export const businessMetricTokenForUpdate = z.object({
     .optional()
     .describe("Determines the scale of the BusinessMetric's values within the CostReport."),
   label_filter: z.array(z.string()).optional().describe("Include only values with these labels in the CostReport."),
+  label_filters: z
+    .record(z.string(), z.array(z.string()))
+    .optional()
+    .describe("Include only BusinessMetric values matching every label key and one of its values."),
   label: z.string().optional().describe("An optional label for this business metric on this report."),
   calculation_type: businessMetricCalcuationType
     .optional()
@@ -80,4 +84,5 @@ export const costReportSettingsForUpdate = z.object({
     .boolean()
     .optional()
     .describe("Report will show previous period cost, usage, or count comparison."),
+  complete_period: z.boolean().optional().describe("Report will restrict date ranges to completed periods only."),
 });

--- a/src/tools/cost-reports/update-cost-report.ts
+++ b/src/tools/cost-reports/update-cost-report.ts
@@ -36,7 +36,7 @@ export default registerTool({
       .optional()
       .transform((v) => (v === undefined ? undefined : v.join(",")))
       .describe(
-        "Updated grouping values. Valid groupings: account_id, billing_account_id, charge_type, cost_category, cost_subcategory, provider, region, resource_id, service, tagged, tag:<tag_value>."
+        "Updated grouping values. Valid groupings: account_id, billing_account_id, charge_type, cost_category, cost_subcategory, provider, region, resource_id, service, tagged, usage_unit, tag:<tag_value>."
       ),
     filter: z
       .string()
@@ -53,6 +53,15 @@ export default registerTool({
     folder_token: vantageToken("folder", {
       description: "Determines the Workspace the report is assigned to.",
     }).optional(),
+    default_forecast: z
+      .object({
+        kind: z.enum(["baseline", "report_forecast"]).describe("Updated default forecast selection kind."),
+        report_forecast_token: vantageToken("report_forecast", {
+          description: "Set when kind is report_forecast.",
+        }).optional(),
+      })
+      .optional()
+      .describe("Updated default forecast selection for the Cost Report."),
     settings: costReportSettingsForUpdate.optional().describe("Updated report settings."),
     previous_period_start_date: dateValidator(
       "Updated previous period start date. ISO 8601 formatted (YYYY-MM-DD)."

--- a/test/tools/cost-reports/update-cost-report.test.ts
+++ b/test/tools/cost-reports/update-cost-report.test.ts
@@ -23,6 +23,7 @@ const undefineds = {
   saved_filter_tokens: undefined,
   business_metric_tokens_with_metadata: undefined,
   folder_token: undefined,
+  default_forecast: undefined,
   settings: undefined,
   previous_period_start_date: undefined,
   previous_period_end_date: undefined,
@@ -51,9 +52,17 @@ const validInputArguments: InferValidators<Validators> = {
       business_metric_token: "bsnss_mtrc_123",
       unit_scale: "per_thousand" as const,
       label_filter: ["prod"] as ["prod"],
+      label_filters: {
+        team: ["platform", "finops"],
+        environment: ["production"],
+      },
     },
   ],
   folder_token: "fldr_123",
+  default_forecast: {
+    kind: "report_forecast" as const,
+    report_forecast_token: "rprt_frcst_123",
+  },
   settings: {
     include_credits: true,
     include_refunds: false,
@@ -63,6 +72,7 @@ const validInputArguments: InferValidators<Validators> = {
     unallocated: false,
     aggregate_by: "cost" as const,
     show_previous_period: true,
+    complete_period: true,
   },
   previous_period_start_date: "2023-01-01",
   previous_period_end_date: "2023-01-31",
@@ -100,6 +110,36 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
       cost_report_token: "rprt_123",
       date_interval: "last_30_days",
     },
+  },
+  {
+    name: "rejects null boolean settings",
+    data: {
+      ...minimalValidInputArguments,
+      settings: {
+        include_credits: null as never,
+      },
+    },
+    expectedIssues: ["Invalid input: expected boolean, received null"],
+  },
+  {
+    name: "rejects null aggregate_by",
+    data: {
+      ...minimalValidInputArguments,
+      settings: {
+        aggregate_by: null as never,
+      },
+    },
+    expectedIssues: ['Invalid option: expected one of "cost"|"usage"|"count"'],
+  },
+  {
+    name: "invalid default forecast kind",
+    data: {
+      ...minimalValidInputArguments,
+      default_forecast: {
+        kind: "unsupported" as never,
+      },
+    },
+    expectedIssues: ['Invalid option: expected one of "baseline"|"report_forecast"'],
   },
   poisonOneValue(validInputArguments, "start_date", dateValidatorPoisoner),
   poisonOneValue(validInputArguments, "end_date", dateValidatorPoisoner),
@@ -164,9 +204,17 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
               business_metric_token: "bsnss_mtrc_123",
               unit_scale: "per_thousand",
               label_filter: ["prod"],
+              label_filters: {
+                team: ["platform", "finops"],
+                environment: ["production"],
+              },
             },
           ],
           folder_token: "fldr_123",
+          default_forecast: {
+            kind: "report_forecast",
+            report_forecast_token: "rprt_frcst_123",
+          },
           settings: {
             include_credits: true,
             include_refunds: false,
@@ -176,6 +224,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
             unallocated: false,
             aggregate_by: "cost",
             show_previous_period: true,
+            complete_period: true,
           },
           previous_period_start_date: "2023-01-01",
           previous_period_end_date: "2023-01-31",


### PR DESCRIPTION
## What Changed

We were missing some attributes for `update-cost-report`, specifically called out was `complete_period`. This adds these attributes in `update-cost-report`

## Testing Done

Unit tests added

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema and MCP tool surface changes only; no auth or core runtime logic, with unit test coverage for new validation.
> 
> **Overview**
> Brings the **`update-cost-report`** MCP tool in line with the Cost Report API by exposing fields that were missing from validation and request payloads.
> 
> **Settings** now accept optional **`complete_period`** (restrict ranges to completed periods only). **Business metric metadata** adds optional **`label_filters`** (key → allowed values) alongside existing **`label_filter`**. The tool gains **`default_forecast`** (`baseline` or `report_forecast` plus optional token), and grouping docs include **`usage_unit`**.
> 
> Tests cover the new fields in happy-path PUT bodies and add schema cases for null settings, invalid **`aggregate_by`**, and invalid **`default_forecast`** kind.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a49afb3d16ffebf783f72a66515f0ea49ec1d3bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->