### PR TITLE
Add Budget Alert tools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
         "@cloudflare/workers-oauth-provider": "^0.0.11",
         "@modelcontextprotocol/sdk": "1.29.0",
         "@sentry/cloudflare": "10.30.0",
-        "@vantage-sh/vantage-client": "2.17.0",
+        "@vantage-sh/vantage-client": "2.18.0",
         "agents": "^0.13.2",
         "axios": "1.13.5",
         "hono": "4.12.12",
@@ -4102,9 +4102,9 @@
       }
     },
     "node_modules/@vantage-sh/vantage-client": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/@vantage-sh/vantage-client/-/vantage-client-2.17.0.tgz",
-      "integrity": "sha512-Tjm575h8i+hClsqttCA8qyXz+OvZLZqRRiqlugvtrWz5rfJsCPdtVM22nKQzGPgg3DwdxGqSlekcNmKtLZJAsA==",
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/@vantage-sh/vantage-client/-/vantage-client-2.18.0.tgz",
+      "integrity": "sha512-7zsClWtAs+Xk2oAgX712SGmiqZHLzVodedPeyPl2mnosfQKXoE4I/idbmKFA9JtK7IFcySA5YPa2qq0kZOImIg==",
       "license": "MIT"
     },
     "node_modules/@vercel/oidc": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@cloudflare/workers-oauth-provider": "^0.0.11",
     "@modelcontextprotocol/sdk": "1.29.0",
     "@sentry/cloudflare": "10.30.0",
-    "@vantage-sh/vantage-client": "2.17.0",
+    "@vantage-sh/vantage-client": "2.18.0",
     "agents": "^0.13.2",
     "axios": "1.13.5",
     "hono": "4.12.12",

--- a/src/tools/budget-alerts/create-budget-alert.ts
+++ b/src/tools/budget-alerts/create-budget-alert.ts
@@ -1,0 +1,55 @@
+import type { CreateBudgetAlertRequest } from "@vantage-sh/vantage-client";
+import MCPUserError from "../structure/MCPUserError";
+import registerTool from "../structure/registerTool";
+import {
+  budgetAlertBudgetTokens,
+  budgetAlertDurationInDays,
+  budgetAlertPeriodToTrack,
+  budgetAlertRecipientChannels,
+  budgetAlertRecipientEmails,
+  budgetAlertThreshold,
+  budgetAlertUserTokens,
+} from "./schemas";
+
+const description = `
+Create a Budget Alert that notifies users or connected channels when one or more Budgets reach a percentage threshold during a monthly time window.
+`.trim();
+
+export default registerTool({
+  name: "create-budget-alert",
+  title: "Create Budget Alert",
+  description,
+  annotations: {
+    destructive: false,
+    openWorld: false,
+    readOnly: false,
+  },
+  args: {
+    budget_tokens: budgetAlertBudgetTokens.describe("Budgets monitored by this Budget Alert."),
+    threshold: budgetAlertThreshold.describe(
+      "Budget percentage that triggers the alert; 100 means costs have reached 100% of the Budget."
+    ),
+    user_tokens: budgetAlertUserTokens.optional().describe("Users that receive the Budget Alert."),
+    recipient_emails: budgetAlertRecipientEmails
+      .optional()
+      .describe(
+        "Email addresses that receive the Budget Alert. Each address must belong to an organization user or a verified domain."
+      ),
+    duration_in_days: budgetAlertDurationInDays.describe(
+      "Number of days from the start or end of the month in which the threshold triggers the alert; use an empty string for the full month."
+    ),
+    period_to_track: budgetAlertPeriodToTrack
+      .optional()
+      .describe("Side of the month from which duration_in_days is measured; defaults to start_of_the_month."),
+    recipient_channels: budgetAlertRecipientChannels
+      .optional()
+      .describe("Connected Slack or Microsoft Teams channels that receive the Budget Alert."),
+  },
+  async execute(args, ctx) {
+    const response = await ctx.callVantageApi("/v2/budget_alerts", args as CreateBudgetAlertRequest, "POST");
+    if (!response.ok) {
+      throw new MCPUserError({ errors: response.errors });
+    }
+    return response.data;
+  },
+});

--- a/src/tools/budget-alerts/delete-budget-alert.ts
+++ b/src/tools/budget-alerts/delete-budget-alert.ts
@@ -1,0 +1,29 @@
+import { pathEncode } from "@vantage-sh/vantage-client";
+import { vantageToken } from "../../utils/zod";
+import MCPUserError from "../structure/MCPUserError";
+import registerTool from "../structure/registerTool";
+
+const description = `
+Delete a Budget Alert by token. This permanently removes the alert without deleting its monitored Budgets.
+`.trim();
+
+export default registerTool({
+  name: "delete-budget-alert",
+  title: "Delete Budget Alert",
+  description,
+  annotations: {
+    destructive: true,
+    openWorld: false,
+    readOnly: false,
+  },
+  args: {
+    budget_alert_token: vantageToken("budget_alert"),
+  },
+  async execute(args, ctx) {
+    const response = await ctx.callVantageApi(`/v2/budget_alerts/${pathEncode(args.budget_alert_token)}`, {}, "DELETE");
+    if (!response.ok) {
+      throw new MCPUserError({ errors: response.errors });
+    }
+    return { token: args.budget_alert_token };
+  },
+});

--- a/src/tools/budget-alerts/get-budget-alert.ts
+++ b/src/tools/budget-alerts/get-budget-alert.ts
@@ -1,0 +1,29 @@
+import { pathEncode } from "@vantage-sh/vantage-client";
+import { vantageToken } from "../../utils/zod";
+import MCPUserError from "../structure/MCPUserError";
+import registerTool from "../structure/registerTool";
+
+const description = `
+Get a specific Budget Alert by token. Budget Alerts monitor Budget objects.
+`.trim();
+
+export default registerTool({
+  name: "get-budget-alert",
+  title: "Get Budget Alert",
+  description,
+  annotations: {
+    destructive: false,
+    openWorld: false,
+    readOnly: true,
+  },
+  args: {
+    budget_alert_token: vantageToken("budget_alert"),
+  },
+  async execute(args, ctx) {
+    const response = await ctx.callVantageApi(`/v2/budget_alerts/${pathEncode(args.budget_alert_token)}`, {}, "GET");
+    if (!response.ok) {
+      throw new MCPUserError({ errors: response.errors });
+    }
+    return response.data;
+  },
+});

--- a/src/tools/budget-alerts/index.ts
+++ b/src/tools/budget-alerts/index.ts
@@ -1,0 +1,5 @@
+import "./create-budget-alert";
+import "./delete-budget-alert";
+import "./get-budget-alert";
+import "./list-budget-alerts";
+import "./update-budget-alert";

--- a/src/tools/budget-alerts/list-budget-alerts.ts
+++ b/src/tools/budget-alerts/list-budget-alerts.ts
@@ -1,0 +1,48 @@
+import z from "zod";
+import paginationData from "../../utils/paginationData";
+import { vantageToken } from "../../utils/zod";
+import { DEFAULT_LIMIT } from "../structure/constants";
+import MCPUserError from "../structure/MCPUserError";
+import registerTool from "../structure/registerTool";
+
+const description = `
+List Budget Alerts in Vantage. Budget Alerts notify users or connected channels when one or more Budgets reach a percentage threshold during a monthly time window.
+`.trim();
+
+export default registerTool({
+  name: "list-budget-alerts",
+  title: "List Budget Alerts",
+  description,
+  annotations: {
+    destructive: false,
+    openWorld: false,
+    readOnly: true,
+  },
+  args: {
+    page: z.number().int().min(1).optional().default(1).describe("Page number, defaults to 1"),
+    limit: z
+      .number()
+      .int()
+      .min(1)
+      .max(1000)
+      .optional()
+      .default(DEFAULT_LIMIT)
+      .describe(`Number of Budget Alerts per page, defaults to ${DEFAULT_LIMIT} and has a maximum of 1000`),
+    workspace_token: vantageToken("workspace", {
+      description: "When provided, return only Budget Alerts in this Workspace.",
+    }).optional(),
+    budget_token: vantageToken("budget", {
+      description: "When provided, return only Budget Alerts monitoring this Budget.",
+    }).optional(),
+  },
+  async execute(args, ctx) {
+    const response = await ctx.callVantageApi("/v2/budget_alerts", args, "GET");
+    if (!response.ok) {
+      throw new MCPUserError({ errors: response.errors });
+    }
+    return {
+      budget_alerts: response.data.budget_alerts,
+      pagination: paginationData(response.data),
+    };
+  },
+});

--- a/src/tools/budget-alerts/schemas.ts
+++ b/src/tools/budget-alerts/schemas.ts
@@ -1,0 +1,12 @@
+import z from "zod";
+import { nonempty, vantageToken } from "../../utils/zod";
+
+export const budgetAlertBudgetTokens = z.array(vantageToken("budget")).min(1);
+export const budgetAlertThreshold = z.number().int().min(0);
+export const budgetAlertUserTokens = z.array(vantageToken("user"));
+export const budgetAlertRecipientEmails = z.array(z.email());
+export const budgetAlertDurationInDays = z
+  .string()
+  .regex(/^\d*$/, "Must be a whole number of days or an empty string for the full month");
+export const budgetAlertPeriodToTrack = z.enum(["start_of_the_month", "end_of_the_month"]);
+export const budgetAlertRecipientChannels = z.array(nonempty());

--- a/src/tools/budget-alerts/update-budget-alert.ts
+++ b/src/tools/budget-alerts/update-budget-alert.ts
@@ -1,0 +1,62 @@
+import { pathEncode, type UpdateBudgetAlertRequest } from "@vantage-sh/vantage-client";
+import { vantageToken } from "../../utils/zod";
+import MCPUserError from "../structure/MCPUserError";
+import registerTool from "../structure/registerTool";
+import {
+  budgetAlertBudgetTokens,
+  budgetAlertDurationInDays,
+  budgetAlertPeriodToTrack,
+  budgetAlertRecipientChannels,
+  budgetAlertRecipientEmails,
+  budgetAlertThreshold,
+  budgetAlertUserTokens,
+} from "./schemas";
+
+const description = `
+Update an existing Budget Alert's monitored Budgets, percentage threshold, monthly time window, or recipients. Budget Alerts monitor Budget objects.
+`.trim();
+
+export default registerTool({
+  name: "update-budget-alert",
+  title: "Update Budget Alert",
+  description,
+  annotations: {
+    destructive: true,
+    openWorld: false,
+    readOnly: false,
+  },
+  args: {
+    budget_alert_token: vantageToken("budget_alert"),
+    budget_tokens: budgetAlertBudgetTokens.optional().describe("Updated Budgets monitored by this Budget Alert."),
+    threshold: budgetAlertThreshold
+      .optional()
+      .describe("Updated Budget percentage that triggers the alert; 100 means the Budget has been fully reached."),
+    user_tokens: budgetAlertUserTokens.optional().describe("Updated users that receive the Budget Alert."),
+    recipient_emails: budgetAlertRecipientEmails
+      .optional()
+      .describe(
+        "Updated email addresses that receive the Budget Alert. Each address must belong to an organization user or a verified domain."
+      ),
+    duration_in_days: budgetAlertDurationInDays
+      .optional()
+      .describe("Updated number of days in the monthly time window; use an empty string for the full month."),
+    period_to_track: budgetAlertPeriodToTrack
+      .optional()
+      .describe("Updated side of the month from which duration_in_days is measured."),
+    recipient_channels: budgetAlertRecipientChannels
+      .optional()
+      .describe("Updated connected Slack or Microsoft Teams channels that receive the Budget Alert."),
+  },
+  async execute(args, ctx) {
+    const { budget_alert_token, ...body } = args;
+    const response = await ctx.callVantageApi(
+      `/v2/budget_alerts/${pathEncode(budget_alert_token)}`,
+      body as UpdateBudgetAlertRequest,
+      "PUT"
+    );
+    if (!response.ok) {
+      throw new MCPUserError({ errors: response.errors });
+    }
+    return response.data;
+  },
+});

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -4,6 +4,7 @@ import "./annotations";
 import "./anomalies";
 import "./audit-logs";
 import "./billing-rules";
+import "./budget-alerts";
 import "./budgets";
 import "./business-metrics";
 import "./canvases";

--- a/test/tools/budget-alerts/create-budget-alert.test.ts
+++ b/test/tools/budget-alerts/create-budget-alert.test.ts
@@ -1,0 +1,120 @@
+import type { CreateBudgetAlertResponse } from "@vantage-sh/vantage-client";
+import { expect } from "vitest";
+import tool from "../../../src/tools/budget-alerts/create-budget-alert";
+import {
+  type ExecutionTestTableItem,
+  type ExtractOutputSchema,
+  type ExtractValidators,
+  type InferValidators,
+  requestsInOrder,
+  type SchemaTestTableItem,
+  testTool,
+} from "../../../src/utils/testing";
+
+type Validators = ExtractValidators<typeof tool>;
+type OutputSchema = ExtractOutputSchema<typeof tool>;
+
+const validArguments: InferValidators<Validators> = {
+  budget_tokens: ["bdgt_123", "bdgt_456"],
+  threshold: 75,
+  user_tokens: ["usr_123"],
+  recipient_emails: ["finops@example.com"],
+  duration_in_days: "7",
+  period_to_track: "start_of_the_month",
+  recipient_channels: ["#finops"],
+};
+
+const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
+  {
+    name: "minimal full-month alert",
+    data: {
+      budget_tokens: ["bdgt_123"],
+      threshold: 100,
+      duration_in_days: "",
+      user_tokens: undefined,
+      recipient_emails: undefined,
+      period_to_track: undefined,
+      recipient_channels: undefined,
+    },
+  },
+  { name: "all valid arguments", data: validArguments },
+  {
+    name: "requires at least one Budget",
+    data: { ...validArguments, budget_tokens: [] },
+    expectedIssues: ["Too small: expected array to have >=1 items"],
+  },
+  {
+    name: "threshold must be a whole percentage",
+    data: { ...validArguments, threshold: 75.5 },
+    expectedIssues: ["Invalid input: expected int, received number"],
+  },
+  {
+    name: "duration must be whole days",
+    data: { ...validArguments, duration_in_days: "7.5" },
+    expectedIssues: ["Must be a whole number of days or an empty string for the full month"],
+  },
+  {
+    name: "period must be a supported month boundary",
+    data: { ...validArguments, period_to_track: "middle_of_the_month" as never },
+    expectedIssues: ['Invalid option: expected one of "start_of_the_month"|"end_of_the_month"'],
+  },
+  {
+    name: "validates user tokens",
+    data: { ...validArguments, user_tokens: ["team_123"] },
+    expectedIssues: ["Must be a User token (usr_*)"],
+  },
+  {
+    name: "validates recipient emails",
+    data: { ...validArguments, recipient_emails: ["not-an-email"] },
+    expectedIssues: ["Invalid email address"],
+  },
+];
+
+const successData: CreateBudgetAlertResponse = {
+  token: "bdgt_alrt_123",
+  budget_tokens: validArguments.budget_tokens,
+  created_at: "2024-03-19T00:00:00Z",
+  workspace_token: "wrkspc_123",
+  user_token: "usr_123",
+  user_tokens: validArguments.user_tokens ?? [],
+  recipient_emails: validArguments.recipient_emails ?? [],
+  duration_in_days: 7,
+  threshold: validArguments.threshold,
+  period_to_track: validArguments.period_to_track ?? null,
+  integration_provider: "slack",
+  recipient_channels: validArguments.recipient_channels ?? null,
+};
+
+const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
+  {
+    name: "successful call",
+    apiCallHandler: requestsInOrder([
+      {
+        endpoint: "/v2/budget_alerts",
+        params: validArguments,
+        method: "POST",
+        result: { ok: true, data: successData },
+      },
+    ]),
+    handler: async ({ callExpectingSuccess }) => {
+      expect(await callExpectingSuccess(validArguments)).toEqual(successData);
+    },
+  },
+  {
+    name: "unsuccessful call",
+    apiCallHandler: requestsInOrder([
+      {
+        endpoint: "/v2/budget_alerts",
+        params: validArguments,
+        method: "POST",
+        result: { ok: false, errors: [{ message: "Budget not found" }] },
+      },
+    ]),
+    handler: async ({ callExpectingMCPUserError }) => {
+      const error = await callExpectingMCPUserError(validArguments);
+      expect(error.exception).toEqual({ errors: [{ message: "Budget not found" }] });
+    },
+  },
+];
+
+testTool(tool, argumentSchemaTests, executionTests);

--- a/test/tools/budget-alerts/delete-budget-alert.test.ts
+++ b/test/tools/budget-alerts/delete-budget-alert.test.ts
@@ -1,0 +1,49 @@
+import { pathEncode } from "@vantage-sh/vantage-client";
+import { expect } from "vitest";
+import tool from "../../../src/tools/budget-alerts/delete-budget-alert";
+import { requestsInOrder, testTool } from "../../../src/utils/testing";
+
+testTool(
+  tool,
+  [
+    { name: "takes budget_alert_token", data: { budget_alert_token: "bdgt_alrt_123" } },
+    {
+      name: "rejects a non-Budget Alert token",
+      data: { budget_alert_token: "bdgt_123" },
+      expectedIssues: ["Must be a Budget Alert token (bdgt_alrt_*)"],
+    },
+  ],
+  [
+    {
+      name: "successful call",
+      apiCallHandler: requestsInOrder([
+        {
+          endpoint: `/v2/budget_alerts/${pathEncode("bdgt_alrt_123")}`,
+          params: {},
+          method: "DELETE",
+          result: { ok: true, data: undefined },
+        },
+      ]),
+      handler: async ({ callExpectingSuccess }) => {
+        expect(await callExpectingSuccess({ budget_alert_token: "bdgt_alrt_123" })).toEqual({
+          token: "bdgt_alrt_123",
+        });
+      },
+    },
+    {
+      name: "unsuccessful call",
+      apiCallHandler: requestsInOrder([
+        {
+          endpoint: `/v2/budget_alerts/${pathEncode("bdgt_alrt_missing")}`,
+          params: {},
+          method: "DELETE",
+          result: { ok: false, errors: [{ message: "Budget alert not found" }] },
+        },
+      ]),
+      handler: async ({ callExpectingMCPUserError }) => {
+        const error = await callExpectingMCPUserError({ budget_alert_token: "bdgt_alrt_missing" });
+        expect(error.exception).toEqual({ errors: [{ message: "Budget alert not found" }] });
+      },
+    },
+  ]
+);

--- a/test/tools/budget-alerts/get-budget-alert.test.ts
+++ b/test/tools/budget-alerts/get-budget-alert.test.ts
@@ -1,0 +1,62 @@
+import { type GetBudgetAlertResponse, pathEncode } from "@vantage-sh/vantage-client";
+import { expect } from "vitest";
+import tool from "../../../src/tools/budget-alerts/get-budget-alert";
+import { requestsInOrder, testTool } from "../../../src/utils/testing";
+
+const success: GetBudgetAlertResponse = {
+  token: "bdgt_alrt_123",
+  budget_tokens: ["bdgt_123"],
+  created_at: "2024-03-19T00:00:00Z",
+  workspace_token: "wrkspc_123",
+  user_token: "usr_123",
+  user_tokens: ["usr_123"],
+  recipient_emails: ["finops@example.com"],
+  duration_in_days: null,
+  threshold: 100,
+  period_to_track: null,
+  integration_provider: null,
+  recipient_channels: null,
+};
+
+testTool(
+  tool,
+  [
+    { name: "takes budget_alert_token", data: { budget_alert_token: "bdgt_alrt_123" } },
+    {
+      name: "rejects a non-Budget Alert token",
+      data: { budget_alert_token: "bdgt_123" },
+      expectedIssues: ["Must be a Budget Alert token (bdgt_alrt_*)"],
+    },
+  ],
+  [
+    {
+      name: "successful call",
+      apiCallHandler: requestsInOrder([
+        {
+          endpoint: `/v2/budget_alerts/${pathEncode("bdgt_alrt_123")}`,
+          params: {},
+          method: "GET",
+          result: { ok: true, data: success },
+        },
+      ]),
+      handler: async ({ callExpectingSuccess }) => {
+        expect(await callExpectingSuccess({ budget_alert_token: "bdgt_alrt_123" })).toEqual(success);
+      },
+    },
+    {
+      name: "unsuccessful call",
+      apiCallHandler: requestsInOrder([
+        {
+          endpoint: `/v2/budget_alerts/${pathEncode("bdgt_alrt_missing")}`,
+          params: {},
+          method: "GET",
+          result: { ok: false, errors: [{ message: "Budget alert not found" }] },
+        },
+      ]),
+      handler: async ({ callExpectingMCPUserError }) => {
+        const error = await callExpectingMCPUserError({ budget_alert_token: "bdgt_alrt_missing" });
+        expect(error.exception).toEqual({ errors: [{ message: "Budget alert not found" }] });
+      },
+    },
+  ]
+);

--- a/test/tools/budget-alerts/list-budget-alerts.test.ts
+++ b/test/tools/budget-alerts/list-budget-alerts.test.ts
@@ -1,0 +1,126 @@
+import type { GetBudgetAlertsResponse } from "@vantage-sh/vantage-client";
+import { expect } from "vitest";
+import tool from "../../../src/tools/budget-alerts/list-budget-alerts";
+import { DEFAULT_LIMIT } from "../../../src/tools/structure/constants";
+import {
+  type ExecutionTestTableItem,
+  type ExtractOutputSchema,
+  type ExtractValidators,
+  type InferValidators,
+  requestsInOrder,
+  type SchemaTestTableItem,
+  testTool,
+} from "../../../src/utils/testing";
+
+type Validators = ExtractValidators<typeof tool>;
+type OutputSchema = ExtractOutputSchema<typeof tool>;
+
+const noArguments: InferValidators<Validators> = {
+  page: undefined,
+  limit: undefined,
+  workspace_token: undefined,
+  budget_token: undefined,
+};
+
+const validArguments: InferValidators<Validators> = {
+  page: 2,
+  limit: 1000,
+  workspace_token: "wrkspc_123",
+  budget_token: "bdgt_123",
+};
+
+const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
+  { name: "no filters", data: noArguments },
+  { name: "workspace and budget filters", data: validArguments },
+  {
+    name: "limit above API maximum",
+    data: { ...validArguments, limit: 1001 },
+    expectedIssues: ["Too big: expected number to be <=1000"],
+  },
+  {
+    name: "invalid budget token",
+    data: { ...validArguments, budget_token: "rprt_123" },
+    expectedIssues: ["Must be a Budget token (bdgt_*)"],
+  },
+];
+
+const budgetAlert = {
+  token: "bdgt_alrt_123",
+  budget_tokens: ["bdgt_123"],
+  created_at: "2024-03-19T00:00:00Z",
+  workspace_token: "wrkspc_123",
+  user_token: "usr_123",
+  user_tokens: ["usr_123"],
+  recipient_emails: ["finops@example.com"],
+  duration_in_days: 7,
+  threshold: 75,
+  period_to_track: "start_of_the_month",
+  integration_provider: "slack",
+  recipient_channels: ["#finops"],
+};
+
+const successData: GetBudgetAlertsResponse = {
+  budget_alerts: [budgetAlert],
+  links: { next: "https://api.vantage.sh/v2/budget_alerts?page=3" },
+};
+
+const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
+  {
+    name: "successful call",
+    apiCallHandler: requestsInOrder([
+      {
+        endpoint: "/v2/budget_alerts",
+        params: validArguments,
+        method: "GET",
+        result: { ok: true, data: successData },
+      },
+    ]),
+    handler: async ({ callExpectingSuccess }) => {
+      const result = await callExpectingSuccess(validArguments);
+      expect(result).toEqual({
+        budget_alerts: [budgetAlert],
+        pagination: { hasNextPage: true, nextPage: 3 },
+      });
+    },
+  },
+  {
+    name: "successful call with defaults",
+    apiCallHandler: requestsInOrder([
+      {
+        endpoint: "/v2/budget_alerts",
+        params: {
+          page: 1,
+          limit: DEFAULT_LIMIT,
+          workspace_token: undefined,
+          budget_token: undefined,
+        },
+        method: "GET",
+        result: { ok: true, data: { budget_alerts: [], links: {} } },
+      },
+    ]),
+    handler: async ({ callExpectingSuccess }) => {
+      const result = await callExpectingSuccess(noArguments);
+      expect(result).toEqual({
+        budget_alerts: [],
+        pagination: { hasNextPage: false, nextPage: 0 },
+      });
+    },
+  },
+  {
+    name: "unsuccessful call",
+    apiCallHandler: requestsInOrder([
+      {
+        endpoint: "/v2/budget_alerts",
+        params: validArguments,
+        method: "GET",
+        result: { ok: false, errors: [{ message: "Access denied" }] },
+      },
+    ]),
+    handler: async ({ callExpectingMCPUserError }) => {
+      const error = await callExpectingMCPUserError(validArguments);
+      expect(error.exception).toEqual({ errors: [{ message: "Access denied" }] });
+    },
+  },
+];
+
+testTool(tool, argumentSchemaTests, executionTests);

--- a/test/tools/budget-alerts/update-budget-alert.test.ts
+++ b/test/tools/budget-alerts/update-budget-alert.test.ts
@@ -1,0 +1,128 @@
+import { pathEncode, type UpdateBudgetAlertResponse } from "@vantage-sh/vantage-client";
+import { expect } from "vitest";
+import tool from "../../../src/tools/budget-alerts/update-budget-alert";
+import {
+  type ExecutionTestTableItem,
+  type ExtractOutputSchema,
+  type ExtractValidators,
+  type InferValidators,
+  requestsInOrder,
+  type SchemaTestTableItem,
+  testTool,
+} from "../../../src/utils/testing";
+
+type Validators = ExtractValidators<typeof tool>;
+type OutputSchema = ExtractOutputSchema<typeof tool>;
+
+const validArguments: InferValidators<Validators> = {
+  budget_alert_token: "bdgt_alrt_123",
+  budget_tokens: ["bdgt_456"],
+  threshold: 90,
+  user_tokens: [],
+  recipient_emails: ["finops@example.com"],
+  duration_in_days: "5",
+  period_to_track: "end_of_the_month",
+  recipient_channels: ["FinOps"],
+};
+
+const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
+  {
+    name: "token only",
+    data: {
+      budget_alert_token: "bdgt_alrt_123",
+      budget_tokens: undefined,
+      threshold: undefined,
+      user_tokens: undefined,
+      recipient_emails: undefined,
+      duration_in_days: undefined,
+      period_to_track: undefined,
+      recipient_channels: undefined,
+    },
+  },
+  { name: "all valid updates", data: validArguments },
+  {
+    name: "rejects an empty Budget list",
+    data: { ...validArguments, budget_tokens: [] },
+    expectedIssues: ["Too small: expected array to have >=1 items"],
+  },
+  {
+    name: "rejects a negative threshold",
+    data: { ...validArguments, threshold: -1 },
+    expectedIssues: ["Too small: expected number to be >=0"],
+  },
+  {
+    name: "rejects non-numeric duration",
+    data: { ...validArguments, duration_in_days: "five" },
+    expectedIssues: ["Must be a whole number of days or an empty string for the full month"],
+  },
+  {
+    name: "rejects an invalid recipient email",
+    data: { ...validArguments, recipient_emails: ["not-an-email"] },
+    expectedIssues: ["Invalid email address"],
+  },
+];
+
+const successData: UpdateBudgetAlertResponse = {
+  token: "bdgt_alrt_123",
+  budget_tokens: ["bdgt_456"],
+  created_at: "2024-03-19T00:00:00Z",
+  workspace_token: "wrkspc_123",
+  user_token: "usr_123",
+  user_tokens: [],
+  recipient_emails: ["finops@example.com"],
+  duration_in_days: 5,
+  threshold: 90,
+  period_to_track: "end_of_the_month",
+  integration_provider: "microsoft_graph",
+  recipient_channels: ["FinOps"],
+};
+
+const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
+  {
+    name: "successful call",
+    apiCallHandler: requestsInOrder([
+      {
+        endpoint: `/v2/budget_alerts/${pathEncode("bdgt_alrt_123")}`,
+        params: {
+          budget_tokens: ["bdgt_456"],
+          threshold: 90,
+          user_tokens: [],
+          recipient_emails: ["finops@example.com"],
+          duration_in_days: "5",
+          period_to_track: "end_of_the_month",
+          recipient_channels: ["FinOps"],
+        },
+        method: "PUT",
+        result: { ok: true, data: successData },
+      },
+    ]),
+    handler: async ({ callExpectingSuccess }) => {
+      expect(await callExpectingSuccess(validArguments)).toEqual(successData);
+    },
+  },
+  {
+    name: "unsuccessful call",
+    apiCallHandler: requestsInOrder([
+      {
+        endpoint: `/v2/budget_alerts/${pathEncode("bdgt_alrt_123")}`,
+        params: {
+          budget_tokens: ["bdgt_456"],
+          threshold: 90,
+          user_tokens: [],
+          recipient_emails: ["finops@example.com"],
+          duration_in_days: "5",
+          period_to_track: "end_of_the_month",
+          recipient_channels: ["FinOps"],
+        },
+        method: "PUT",
+        result: { ok: false, errors: [{ message: "Budget alert not found" }] },
+      },
+    ]),
+    handler: async ({ callExpectingMCPUserError }) => {
+      const error = await callExpectingMCPUserError(validArguments);
+      expect(error.exception).toEqual({ errors: [{ message: "Budget alert not found" }] });
+    },
+  },
+];
+
+testTool(tool, argumentSchemaTests, executionTests);

--- a/test/tools/report-notifications/create-report-notification.test.ts
+++ b/test/tools/report-notifications/create-report-notification.test.ts
@@ -78,6 +78,7 @@ const successData: CreateReportNotificationResponse = {
   title: "Weekly Spend Summary",
   cost_report_token: "rprt_123",
   user_tokens: ["usr_123"],
+  recipient_emails: ["finance@example.com"],
   recipient_channels: ["#finance"],
   frequency: "weekly",
   change: "dollars",

--- a/test/tools/report-notifications/get-report-notification.test.ts
+++ b/test/tools/report-notifications/get-report-notification.test.ts
@@ -8,6 +8,7 @@ const success: GetReportNotificationResponse = {
   title: "Weekly Spend Summary",
   cost_report_token: "rprt_123",
   user_tokens: ["usr_123"],
+  recipient_emails: ["finance@example.com"],
   recipient_channels: ["#finance"],
   frequency: "weekly",
   change: "percentage",

--- a/test/tools/report-notifications/list-report-notifications.test.ts
+++ b/test/tools/report-notifications/list-report-notifications.test.ts
@@ -43,6 +43,7 @@ const successData: GetReportNotificationsResponse = {
       title: "Weekly Spend Summary",
       cost_report_token: "rprt_123",
       user_tokens: ["usr_123"],
+      recipient_emails: ["finance@example.com"],
       recipient_channels: ["#finance"],
       frequency: "weekly",
       change: "percentage",

--- a/test/tools/report-notifications/update-report-notification.test.ts
+++ b/test/tools/report-notifications/update-report-notification.test.ts
@@ -78,6 +78,7 @@ const successData: UpdateReportNotificationResponse = {
   title: "Updated Spend Summary",
   cost_report_token: "rprt_456",
   user_tokens: ["usr_123", "usr_456"],
+  recipient_emails: ["finance@example.com"],
   recipient_channels: ["#finance"],
   frequency: "monthly",
   change: "dollars",

--- a/test/tools/virtual-tag-configs/create-virtual-tag-config.test.ts
+++ b/test/tools/virtual-tag-configs/create-virtual-tag-config.test.ts
@@ -85,6 +85,8 @@ const successData = {
   token: "vtag_1234",
   created_by_token: null,
   key: "cost_center",
+  hidden: false,
+  preferred: false,
   overridable: true,
   backfill_until: "2024-01-01",
   collapsed_tag_keys: [],

--- a/test/tools/virtual-tag-configs/get-virtual-tag-config.test.ts
+++ b/test/tools/virtual-tag-configs/get-virtual-tag-config.test.ts
@@ -11,6 +11,8 @@ const successData: GetVirtualTagConfigResponse = {
   token: "vtag_123",
   created_by_token: null,
   key: "team",
+  hidden: false,
+  preferred: false,
   overridable: true,
   backfill_until: "2026-01-01",
   collapsed_tag_keys: [],

--- a/test/tools/virtual-tag-configs/list-virtual-tag-configs.test.ts
+++ b/test/tools/virtual-tag-configs/list-virtual-tag-configs.test.ts
@@ -13,6 +13,8 @@ const successData: GetVirtualTagConfigsResponse = {
       token: "vtag_123",
       created_by_token: null,
       key: "team",
+      hidden: false,
+      preferred: false,
       overridable: true,
       backfill_until: "2026-01-01",
       collapsed_tag_keys: [],

--- a/test/tools/virtual-tag-configs/update-virtual-tag-config.test.ts
+++ b/test/tools/virtual-tag-configs/update-virtual-tag-config.test.ts
@@ -109,6 +109,8 @@ const successData: UpdateVirtualTagConfigResponse = {
   token: "vtag_123",
   created_by_token: null,
   key: "team",
+  hidden: false,
+  preferred: false,
   overridable: true,
   backfill_until: "2026-01-01",
   collapsed_tag_keys: [],


### PR DESCRIPTION
## What Changed

Adding tools for Budget alerts

## Testing Done 

- [x] Unit tests added

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces create/update/delete tools that change budget alerting and notification routing; risk is moderated by existing `registerTool` patterns, input validation, and unit tests.
> 
> **Overview**
> Adds **Budget Alert** support to the MCP server via create, list, get, update, and delete tools wired to `/v2/budget_alerts`, with shared Zod schemas for thresholds, monthly windows, budgets, users, emails, and Slack/Teams channels. The tools index registers the new `budget-alerts` module, and each tool has matching Vitest coverage.
> 
> **`@vantage-sh/vantage-client`** is bumped from **2.17.0** to **2.18.0** (lockfile included). Report-notification and virtual-tag-config tests are updated only to include new response fields (`recipient_emails`, `hidden`, `preferred`) from the client types—no changes to those tool implementations in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc713efec9237111aa4746c5b790923bc0142915. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->