### PR TITLE
Fix pages deploy

### DIFF
--- a/.github/workflows/deploy-eval-results.yml
+++ b/.github/workflows/deploy-eval-results.yml
@@ -38,7 +38,7 @@ jobs:
 
       - uses: actions/configure-pages@v5
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: ./evals/site
 


### PR DESCRIPTION
## What Changed

Just fixing the github workflow

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only dependency version bump with no application or runtime behavior changes.
> 
> **Overview**
> **Fixes GitHub Pages deployment** for the eval results workflow by upgrading `actions/upload-pages-artifact` from **v3** to **v5** in `.github/workflows/deploy-eval-results.yml`.
> 
> No other workflow steps or build output paths change; this is an action version bump to align with current GitHub Pages deployment requirements.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3baca468afbcc998603f8fbe71c585db946dfb17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->