### PR TITLE
Add filtering to cost-provider-accounts and eval

### DIFF
--- a/.agents/skills/writing-evals/SKILL.md
+++ b/.agents/skills/writing-evals/SKILL.md
@@ -76,6 +76,7 @@ evals/
   promptfooconfig.ts
 ```
 
+OpenAI tools are built with `strict: false`. The Responses API otherwise fills omitted optional args with `""` / placeholders (`x`, `.*`, …), which makes exact arg scoring fail even when tool selection is correct. Do not switch OpenAI evals to Chat Completions solely to avoid that — some models (e.g. `gpt-5.6-luna`) reject function tools on `/v1/chat/completions` unless `reasoning_effort` is `none`.
 Case files live under `evals/cases/<resource>/` so they stay out of Vitest's path and match `src/tools/<resource>/`. Use the `.eval.ts` suffix so they are distinct from the tool file and the unit test. `promptfooconfig.ts` picks up every `**/*.eval.ts` file automatically. The adapter imports `src/tools` once and reads tools out of the live `registerTool` registry — adding a new tool to the codebase makes it available to evals automatically; you just need to write its case file.
 
 ## The matrix
@@ -141,7 +142,8 @@ return buildToolCases({
 });
 ```
 
-Named distractors are loaded first and the remaining slots are sampled automatically. Provide at most four unique, registered tool names; do not include the target itself.
+- Named distractors are loaded first and the remaining slots are sampled automatically. Provide at most four unique, registered tool names; do not include the target itself.
+- `buildToolCases` sets `options.disableVarExpansion: true` so promptfoo does not expand the `distractors` / `expected` arrays into separate test cases.
 
 ## Reading failures
 

--- a/evals/_lib/buildAiSdkTools.ts
+++ b/evals/_lib/buildAiSdkTools.ts
@@ -13,6 +13,9 @@ export function buildAiSdkTools(names: readonly string[]): ToolSet {
     out[name] = tool({
       description: props.description,
       inputSchema: z.object(props.args),
+      // OpenAI Responses API fills omitted optionals with "" / placeholders unless
+      // strict is explicitly false. Chat Completions omits them correctly either way.
+      strict: false,
       execute: async () => ({}),
     });
   }

--- a/evals/_lib/buildCases.ts
+++ b/evals/_lib/buildCases.ts
@@ -31,6 +31,11 @@ export function buildToolCases(definition: ToolEvalDefinition): TestCase[] {
         expected: prompt.expected,
         ...(definition.distractors ? { distractors: definition.distractors } : {}),
       },
+      // Keep array vars (expected, distractors) intact. Without this, promptfoo
+      // expands string arrays into a cartesian product of separate test cases.
+      options: {
+        disableVarExpansion: true,
+      },
       metadata: {
         tool: definition.target,
         resource: definition.resource,

--- a/evals/_lib/evalArgs.ts
+++ b/evals/_lib/evalArgs.ts
@@ -69,7 +69,11 @@ export function validateEvalScope(args: Pick<ParsedEvalArgs, "all" | "tool">): s
     return "Choose either --tool <name> or the eval:all command, not both.";
   }
   if (!args.all && !args.tool) {
-    return "--tool <name> is required. To deliberately refresh every tool, use npm run eval:all -- --model <id[-effort]>.";
+    return [
+      "--tool <name> is required.",
+      "Pass flags after `--` so npm forwards them to the script, e.g. npm run eval -- --tool get-myself --model gpt-5.6-sol-high.",
+      "To deliberately refresh every tool, use npm run eval:all -- --model <id[-effort]>.",
+    ].join(" ");
   }
   return undefined;
 }

--- a/evals/cases/cost-providers/get-cost-provider-accounts.eval.ts
+++ b/evals/cases/cost-providers/get-cost-provider-accounts.eval.ts
@@ -1,0 +1,28 @@
+import { buildToolCases } from "../../_lib/buildCases";
+
+const TARGET = "get-cost-provider-accounts";
+
+export default function generateTests() {
+  return buildToolCases({
+    target: TARGET,
+    resource: "cost-providers",
+    distractors: ["list-cost-providers", "list-cost-integrations", "list-costs", "list-provider-resources"],
+    directPrompts: [
+      {
+        input: "Use get-cost-provider-accounts to list the AWS accounts in workspace wrkspc_abc123.",
+        expected: [{ toolName: TARGET, input: { workspace_token: "wrkspc_abc123", provider: "aws" } }],
+      },
+    ],
+    inferredPrompts: [
+      {
+        input:
+          "I need human-readable titles for all connected billing accounts in workspace wrkspc_abc123 so I can use their account IDs in a VQL filter.",
+        expected: [{ toolName: TARGET, input: { workspace_token: "wrkspc_abc123" } }],
+      },
+      {
+        input: "In workspace wrkspc_abc123, search connected billing accounts for titles matching McpTest.",
+        expected: [{ toolName: TARGET, input: { workspace_token: "wrkspc_abc123", q: "McpTest" } }],
+      },
+    ],
+  });
+}

--- a/evals/results/gpt-5.6-luna/cost-providers/get-cost-provider-accounts.json
+++ b/evals/results/gpt-5.6-luna/cost-providers/get-cost-provider-accounts.json
@@ -1,0 +1,1177 @@
+{
+  "evalId": null,
+  "results": {
+    "version": 3,
+    "timestamp": "2026-08-31T22:28:09.006Z",
+    "results": [
+      {
+        "cost": 0,
+        "gradingResult": {
+          "pass": true,
+          "score": 1,
+          "reason": "All assertions passed",
+          "namedScores": {},
+          "tokensUsed": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 0
+          },
+          "componentResults": [
+            {
+              "pass": true,
+              "score": 1,
+              "reason": "Expected tool call matched.",
+              "assertion": {
+                "type": "javascript",
+                "value": "file://_lib/assertToolCalls.ts"
+              }
+            }
+          ]
+        },
+        "id": "db8baf49-9521-4cfe-8df0-faa4a9c4748c",
+        "latencyMs": 1414,
+        "namedScores": {},
+        "prompt": {
+          "raw": "Use get-cost-provider-accounts to list the AWS accounts in workspace wrkspc_abc123.",
+          "label": "{{prompt}}",
+          "config": {
+            "disableVarExpansion": true
+          }
+        },
+        "promptId": "effa18501e44aafd9bc42a2f64ffc9b6350f94025520ca2ed382f9bdc4b6e982",
+        "promptIdx": 1,
+        "provider": {
+          "id": "tool-selection:gpt-5.6-luna:mixed",
+          "label": "gpt-5.6-luna · mixed"
+        },
+        "response": {
+          "output": {
+            "toolCalls": [
+              {
+                "toolName": "get-cost-provider-accounts",
+                "input": {
+                  "workspace_token": "wrkspc_abc123",
+                  "provider": "aws"
+                }
+              }
+            ],
+            "text": ""
+          },
+          "metadata": {
+            "modelId": "gpt-5.6-luna",
+            "mode": "mixed",
+            "target": "get-cost-provider-accounts",
+            "toolNames": [
+              "get-cost-provider-accounts",
+              "list-cost-providers",
+              "list-cost-integrations",
+              "list-costs",
+              "list-provider-resources"
+            ],
+            "toolCalls": [
+              {
+                "toolName": "get-cost-provider-accounts",
+                "input": {
+                  "workspace_token": "wrkspc_abc123",
+                  "provider": "aws"
+                }
+              }
+            ]
+          }
+        },
+        "score": 1,
+        "success": true,
+        "testCase": {
+          "description": "get-cost-provider-accounts · direct · Use get-cost-provider-accounts to list the AWS accounts in workspace wrkspc_abc123.",
+          "vars": {
+            "prompt": "Use get-cost-provider-accounts to list the AWS accounts in workspace wrkspc_abc123.",
+            "target": "get-cost-provider-accounts",
+            "expected": [
+              {
+                "toolName": "get-cost-provider-accounts",
+                "input": {
+                  "workspace_token": "wrkspc_abc123",
+                  "provider": "aws"
+                }
+              }
+            ],
+            "distractors": [
+              "list-cost-providers",
+              "list-cost-integrations",
+              "list-costs",
+              "list-provider-resources"
+            ]
+          },
+          "options": {
+            "disableVarExpansion": true
+          },
+          "metadata": {
+            "tool": "get-cost-provider-accounts",
+            "resource": "cost-providers",
+            "phrasing": "direct"
+          },
+          "assert": [
+            {
+              "type": "javascript",
+              "value": "file://_lib/assertToolCalls.ts"
+            }
+          ]
+        },
+        "testIdx": 0,
+        "tokenUsage": {
+          "prompt": 0,
+          "completion": 0,
+          "cached": 0,
+          "total": 0,
+          "numRequests": 1,
+          "completionDetails": {
+            "reasoning": 0,
+            "acceptedPrediction": 0,
+            "rejectedPrediction": 0,
+            "cacheReadInputTokens": 0,
+            "cacheCreationInputTokens": 0
+          },
+          "assertions": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 1,
+            "completionDetails": {
+              "reasoning": 0,
+              "acceptedPrediction": 0,
+              "rejectedPrediction": 0,
+              "cacheReadInputTokens": 0,
+              "cacheCreationInputTokens": 0
+            }
+          }
+        },
+        "vars": {
+          "prompt": "Use get-cost-provider-accounts to list the AWS accounts in workspace wrkspc_abc123.",
+          "target": "get-cost-provider-accounts",
+          "expected": [
+            {
+              "toolName": "get-cost-provider-accounts",
+              "input": {
+                "workspace_token": "wrkspc_abc123",
+                "provider": "aws"
+              }
+            }
+          ],
+          "distractors": [
+            "list-cost-providers",
+            "list-cost-integrations",
+            "list-costs",
+            "list-provider-resources"
+          ]
+        },
+        "metadata": {
+          "tool": "get-cost-provider-accounts",
+          "resource": "cost-providers",
+          "phrasing": "direct",
+          "modelId": "gpt-5.6-luna",
+          "mode": "mixed",
+          "target": "get-cost-provider-accounts",
+          "toolNames": [
+            "get-cost-provider-accounts",
+            "list-cost-providers",
+            "list-cost-integrations",
+            "list-costs",
+            "list-provider-resources"
+          ],
+          "toolCalls": [
+            {
+              "toolName": "get-cost-provider-accounts",
+              "input": {
+                "workspace_token": "wrkspc_abc123",
+                "provider": "aws"
+              }
+            }
+          ],
+          "_promptfooFileMetadata": {}
+        },
+        "failureReason": 0
+      },
+      {
+        "cost": 0,
+        "gradingResult": {
+          "pass": true,
+          "score": 1,
+          "reason": "All assertions passed",
+          "namedScores": {},
+          "tokensUsed": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 0
+          },
+          "componentResults": [
+            {
+              "pass": true,
+              "score": 1,
+              "reason": "Expected tool call matched.",
+              "assertion": {
+                "type": "javascript",
+                "value": "file://_lib/assertToolCalls.ts"
+              }
+            }
+          ]
+        },
+        "id": "709d83df-04c3-4780-a5a3-9eff7207853b",
+        "latencyMs": 1797,
+        "namedScores": {},
+        "prompt": {
+          "raw": "Use get-cost-provider-accounts to list the AWS accounts in workspace wrkspc_abc123.",
+          "label": "{{prompt}}",
+          "config": {
+            "disableVarExpansion": true
+          }
+        },
+        "promptId": "effa18501e44aafd9bc42a2f64ffc9b6350f94025520ca2ed382f9bdc4b6e982",
+        "promptIdx": 0,
+        "provider": {
+          "id": "tool-selection:gpt-5.6-luna:isolated",
+          "label": "gpt-5.6-luna · isolated"
+        },
+        "response": {
+          "output": {
+            "toolCalls": [
+              {
+                "toolName": "get-cost-provider-accounts",
+                "input": {
+                  "workspace_token": "wrkspc_abc123",
+                  "provider": "aws"
+                }
+              }
+            ],
+            "text": ""
+          },
+          "metadata": {
+            "modelId": "gpt-5.6-luna",
+            "mode": "isolated",
+            "target": "get-cost-provider-accounts",
+            "toolNames": [
+              "get-cost-provider-accounts"
+            ],
+            "toolCalls": [
+              {
+                "toolName": "get-cost-provider-accounts",
+                "input": {
+                  "workspace_token": "wrkspc_abc123",
+                  "provider": "aws"
+                }
+              }
+            ]
+          }
+        },
+        "score": 1,
+        "success": true,
+        "testCase": {
+          "description": "get-cost-provider-accounts · direct · Use get-cost-provider-accounts to list the AWS accounts in workspace wrkspc_abc123.",
+          "vars": {
+            "prompt": "Use get-cost-provider-accounts to list the AWS accounts in workspace wrkspc_abc123.",
+            "target": "get-cost-provider-accounts",
+            "expected": [
+              {
+                "toolName": "get-cost-provider-accounts",
+                "input": {
+                  "workspace_token": "wrkspc_abc123",
+                  "provider": "aws"
+                }
+              }
+            ],
+            "distractors": [
+              "list-cost-providers",
+              "list-cost-integrations",
+              "list-costs",
+              "list-provider-resources"
+            ]
+          },
+          "options": {
+            "disableVarExpansion": true
+          },
+          "metadata": {
+            "tool": "get-cost-provider-accounts",
+            "resource": "cost-providers",
+            "phrasing": "direct"
+          },
+          "assert": [
+            {
+              "type": "javascript",
+              "value": "file://_lib/assertToolCalls.ts"
+            }
+          ]
+        },
+        "testIdx": 0,
+        "tokenUsage": {
+          "prompt": 0,
+          "completion": 0,
+          "cached": 0,
+          "total": 0,
+          "numRequests": 1,
+          "completionDetails": {
+            "reasoning": 0,
+            "acceptedPrediction": 0,
+            "rejectedPrediction": 0,
+            "cacheReadInputTokens": 0,
+            "cacheCreationInputTokens": 0
+          },
+          "assertions": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 1,
+            "completionDetails": {
+              "reasoning": 0,
+              "acceptedPrediction": 0,
+              "rejectedPrediction": 0,
+              "cacheReadInputTokens": 0,
+              "cacheCreationInputTokens": 0
+            }
+          }
+        },
+        "vars": {
+          "prompt": "Use get-cost-provider-accounts to list the AWS accounts in workspace wrkspc_abc123.",
+          "target": "get-cost-provider-accounts",
+          "expected": [
+            {
+              "toolName": "get-cost-provider-accounts",
+              "input": {
+                "workspace_token": "wrkspc_abc123",
+                "provider": "aws"
+              }
+            }
+          ],
+          "distractors": [
+            "list-cost-providers",
+            "list-cost-integrations",
+            "list-costs",
+            "list-provider-resources"
+          ]
+        },
+        "metadata": {
+          "tool": "get-cost-provider-accounts",
+          "resource": "cost-providers",
+          "phrasing": "direct",
+          "modelId": "gpt-5.6-luna",
+          "mode": "isolated",
+          "target": "get-cost-provider-accounts",
+          "toolNames": [
+            "get-cost-provider-accounts"
+          ],
+          "toolCalls": [
+            {
+              "toolName": "get-cost-provider-accounts",
+              "input": {
+                "workspace_token": "wrkspc_abc123",
+                "provider": "aws"
+              }
+            }
+          ],
+          "_promptfooFileMetadata": {}
+        },
+        "failureReason": 0
+      },
+      {
+        "cost": 0,
+        "gradingResult": {
+          "pass": true,
+          "score": 1,
+          "reason": "All assertions passed",
+          "namedScores": {},
+          "tokensUsed": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 0
+          },
+          "componentResults": [
+            {
+              "pass": true,
+              "score": 1,
+              "reason": "Expected tool call matched.",
+              "assertion": {
+                "type": "javascript",
+                "value": "file://_lib/assertToolCalls.ts"
+              }
+            }
+          ]
+        },
+        "id": "9326d6eb-b169-4d0a-a0b9-de62b35afecc",
+        "latencyMs": 1208,
+        "namedScores": {},
+        "prompt": {
+          "raw": "I need human-readable titles for all connected billing accounts in workspace wrkspc_abc123 so I can use their account IDs in a VQL filter.",
+          "label": "{{prompt}}",
+          "config": {
+            "disableVarExpansion": true
+          }
+        },
+        "promptId": "effa18501e44aafd9bc42a2f64ffc9b6350f94025520ca2ed382f9bdc4b6e982",
+        "promptIdx": 0,
+        "provider": {
+          "id": "tool-selection:gpt-5.6-luna:isolated",
+          "label": "gpt-5.6-luna · isolated"
+        },
+        "response": {
+          "output": {
+            "toolCalls": [
+              {
+                "toolName": "get-cost-provider-accounts",
+                "input": {
+                  "workspace_token": "wrkspc_abc123"
+                }
+              }
+            ],
+            "text": ""
+          },
+          "metadata": {
+            "modelId": "gpt-5.6-luna",
+            "mode": "isolated",
+            "target": "get-cost-provider-accounts",
+            "toolNames": [
+              "get-cost-provider-accounts"
+            ],
+            "toolCalls": [
+              {
+                "toolName": "get-cost-provider-accounts",
+                "input": {
+                  "workspace_token": "wrkspc_abc123"
+                }
+              }
+            ]
+          }
+        },
+        "score": 1,
+        "success": true,
+        "testCase": {
+          "description": "get-cost-provider-accounts · inferred · I need human-readable titles for all connected billing accounts in workspace wrkspc_abc123 so I can use their account IDs in a VQL filter.",
+          "vars": {
+            "prompt": "I need human-readable titles for all connected billing accounts in workspace wrkspc_abc123 so I can use their account IDs in a VQL filter.",
+            "target": "get-cost-provider-accounts",
+            "expected": [
+              {
+                "toolName": "get-cost-provider-accounts",
+                "input": {
+                  "workspace_token": "wrkspc_abc123"
+                }
+              }
+            ],
+            "distractors": [
+              "list-cost-providers",
+              "list-cost-integrations",
+              "list-costs",
+              "list-provider-resources"
+            ]
+          },
+          "options": {
+            "disableVarExpansion": true
+          },
+          "metadata": {
+            "tool": "get-cost-provider-accounts",
+            "resource": "cost-providers",
+            "phrasing": "inferred"
+          },
+          "assert": [
+            {
+              "type": "javascript",
+              "value": "file://_lib/assertToolCalls.ts"
+            }
+          ]
+        },
+        "testIdx": 1,
+        "tokenUsage": {
+          "prompt": 0,
+          "completion": 0,
+          "cached": 0,
+          "total": 0,
+          "numRequests": 1,
+          "completionDetails": {
+            "reasoning": 0,
+            "acceptedPrediction": 0,
+            "rejectedPrediction": 0,
+            "cacheReadInputTokens": 0,
+            "cacheCreationInputTokens": 0
+          },
+          "assertions": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 1,
+            "completionDetails": {
+              "reasoning": 0,
+              "acceptedPrediction": 0,
+              "rejectedPrediction": 0,
+              "cacheReadInputTokens": 0,
+              "cacheCreationInputTokens": 0
+            }
+          }
+        },
+        "vars": {
+          "prompt": "I need human-readable titles for all connected billing accounts in workspace wrkspc_abc123 so I can use their account IDs in a VQL filter.",
+          "target": "get-cost-provider-accounts",
+          "expected": [
+            {
+              "toolName": "get-cost-provider-accounts",
+              "input": {
+                "workspace_token": "wrkspc_abc123"
+              }
+            }
+          ],
+          "distractors": [
+            "list-cost-providers",
+            "list-cost-integrations",
+            "list-costs",
+            "list-provider-resources"
+          ]
+        },
+        "metadata": {
+          "tool": "get-cost-provider-accounts",
+          "resource": "cost-providers",
+          "phrasing": "inferred",
+          "modelId": "gpt-5.6-luna",
+          "mode": "isolated",
+          "target": "get-cost-provider-accounts",
+          "toolNames": [
+            "get-cost-provider-accounts"
+          ],
+          "toolCalls": [
+            {
+              "toolName": "get-cost-provider-accounts",
+              "input": {
+                "workspace_token": "wrkspc_abc123"
+              }
+            }
+          ],
+          "_promptfooFileMetadata": {}
+        },
+        "failureReason": 0
+      },
+      {
+        "cost": 0,
+        "gradingResult": {
+          "pass": true,
+          "score": 1,
+          "reason": "All assertions passed",
+          "namedScores": {},
+          "tokensUsed": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 0
+          },
+          "componentResults": [
+            {
+              "pass": true,
+              "score": 1,
+              "reason": "Expected tool call matched.",
+              "assertion": {
+                "type": "javascript",
+                "value": "file://_lib/assertToolCalls.ts"
+              }
+            }
+          ]
+        },
+        "id": "128d7e8e-380c-42ae-86af-9ab54c8fda86",
+        "latencyMs": 2179,
+        "namedScores": {},
+        "prompt": {
+          "raw": "I need human-readable titles for all connected billing accounts in workspace wrkspc_abc123 so I can use their account IDs in a VQL filter.",
+          "label": "{{prompt}}",
+          "config": {
+            "disableVarExpansion": true
+          }
+        },
+        "promptId": "effa18501e44aafd9bc42a2f64ffc9b6350f94025520ca2ed382f9bdc4b6e982",
+        "promptIdx": 1,
+        "provider": {
+          "id": "tool-selection:gpt-5.6-luna:mixed",
+          "label": "gpt-5.6-luna · mixed"
+        },
+        "response": {
+          "output": {
+            "toolCalls": [
+              {
+                "toolName": "get-cost-provider-accounts",
+                "input": {
+                  "workspace_token": "wrkspc_abc123"
+                }
+              }
+            ],
+            "text": ""
+          },
+          "metadata": {
+            "modelId": "gpt-5.6-luna",
+            "mode": "mixed",
+            "target": "get-cost-provider-accounts",
+            "toolNames": [
+              "get-cost-provider-accounts",
+              "list-cost-providers",
+              "list-cost-integrations",
+              "list-costs",
+              "list-provider-resources"
+            ],
+            "toolCalls": [
+              {
+                "toolName": "get-cost-provider-accounts",
+                "input": {
+                  "workspace_token": "wrkspc_abc123"
+                }
+              }
+            ]
+          }
+        },
+        "score": 1,
+        "success": true,
+        "testCase": {
+          "description": "get-cost-provider-accounts · inferred · I need human-readable titles for all connected billing accounts in workspace wrkspc_abc123 so I can use their account IDs in a VQL filter.",
+          "vars": {
+            "prompt": "I need human-readable titles for all connected billing accounts in workspace wrkspc_abc123 so I can use their account IDs in a VQL filter.",
+            "target": "get-cost-provider-accounts",
+            "expected": [
+              {
+                "toolName": "get-cost-provider-accounts",
+                "input": {
+                  "workspace_token": "wrkspc_abc123"
+                }
+              }
+            ],
+            "distractors": [
+              "list-cost-providers",
+              "list-cost-integrations",
+              "list-costs",
+              "list-provider-resources"
+            ]
+          },
+          "options": {
+            "disableVarExpansion": true
+          },
+          "metadata": {
+            "tool": "get-cost-provider-accounts",
+            "resource": "cost-providers",
+            "phrasing": "inferred"
+          },
+          "assert": [
+            {
+              "type": "javascript",
+              "value": "file://_lib/assertToolCalls.ts"
+            }
+          ]
+        },
+        "testIdx": 1,
+        "tokenUsage": {
+          "prompt": 0,
+          "completion": 0,
+          "cached": 0,
+          "total": 0,
+          "numRequests": 1,
+          "completionDetails": {
+            "reasoning": 0,
+            "acceptedPrediction": 0,
+            "rejectedPrediction": 0,
+            "cacheReadInputTokens": 0,
+            "cacheCreationInputTokens": 0
+          },
+          "assertions": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 1,
+            "completionDetails": {
+              "reasoning": 0,
+              "acceptedPrediction": 0,
+              "rejectedPrediction": 0,
+              "cacheReadInputTokens": 0,
+              "cacheCreationInputTokens": 0
+            }
+          }
+        },
+        "vars": {
+          "prompt": "I need human-readable titles for all connected billing accounts in workspace wrkspc_abc123 so I can use their account IDs in a VQL filter.",
+          "target": "get-cost-provider-accounts",
+          "expected": [
+            {
+              "toolName": "get-cost-provider-accounts",
+              "input": {
+                "workspace_token": "wrkspc_abc123"
+              }
+            }
+          ],
+          "distractors": [
+            "list-cost-providers",
+            "list-cost-integrations",
+            "list-costs",
+            "list-provider-resources"
+          ]
+        },
+        "metadata": {
+          "tool": "get-cost-provider-accounts",
+          "resource": "cost-providers",
+          "phrasing": "inferred",
+          "modelId": "gpt-5.6-luna",
+          "mode": "mixed",
+          "target": "get-cost-provider-accounts",
+          "toolNames": [
+            "get-cost-provider-accounts",
+            "list-cost-providers",
+            "list-cost-integrations",
+            "list-costs",
+            "list-provider-resources"
+          ],
+          "toolCalls": [
+            {
+              "toolName": "get-cost-provider-accounts",
+              "input": {
+                "workspace_token": "wrkspc_abc123"
+              }
+            }
+          ],
+          "_promptfooFileMetadata": {}
+        },
+        "failureReason": 0
+      },
+      {
+        "cost": 0,
+        "gradingResult": {
+          "pass": true,
+          "score": 1,
+          "reason": "All assertions passed",
+          "namedScores": {},
+          "tokensUsed": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 0
+          },
+          "componentResults": [
+            {
+              "pass": true,
+              "score": 1,
+              "reason": "Expected tool call matched.",
+              "assertion": {
+                "type": "javascript",
+                "value": "file://_lib/assertToolCalls.ts"
+              }
+            }
+          ]
+        },
+        "id": "b8e42394-0cdc-4cdb-980e-f54b53bfd8c7",
+        "latencyMs": 1209,
+        "namedScores": {},
+        "prompt": {
+          "raw": "In workspace wrkspc_abc123, search connected billing accounts for titles matching McpTest.",
+          "label": "{{prompt}}",
+          "config": {
+            "disableVarExpansion": true
+          }
+        },
+        "promptId": "effa18501e44aafd9bc42a2f64ffc9b6350f94025520ca2ed382f9bdc4b6e982",
+        "promptIdx": 0,
+        "provider": {
+          "id": "tool-selection:gpt-5.6-luna:isolated",
+          "label": "gpt-5.6-luna · isolated"
+        },
+        "response": {
+          "output": {
+            "toolCalls": [
+              {
+                "toolName": "get-cost-provider-accounts",
+                "input": {
+                  "workspace_token": "wrkspc_abc123",
+                  "q": "McpTest"
+                }
+              }
+            ],
+            "text": ""
+          },
+          "metadata": {
+            "modelId": "gpt-5.6-luna",
+            "mode": "isolated",
+            "target": "get-cost-provider-accounts",
+            "toolNames": [
+              "get-cost-provider-accounts"
+            ],
+            "toolCalls": [
+              {
+                "toolName": "get-cost-provider-accounts",
+                "input": {
+                  "workspace_token": "wrkspc_abc123",
+                  "q": "McpTest"
+                }
+              }
+            ]
+          }
+        },
+        "score": 1,
+        "success": true,
+        "testCase": {
+          "description": "get-cost-provider-accounts · inferred · In workspace wrkspc_abc123, search connected billing accounts for titles matching McpTest.",
+          "vars": {
+            "prompt": "In workspace wrkspc_abc123, search connected billing accounts for titles matching McpTest.",
+            "target": "get-cost-provider-accounts",
+            "expected": [
+              {
+                "toolName": "get-cost-provider-accounts",
+                "input": {
+                  "workspace_token": "wrkspc_abc123",
+                  "q": "McpTest"
+                }
+              }
+            ],
+            "distractors": [
+              "list-cost-providers",
+              "list-cost-integrations",
+              "list-costs",
+              "list-provider-resources"
+            ]
+          },
+          "options": {
+            "disableVarExpansion": true
+          },
+          "metadata": {
+            "tool": "get-cost-provider-accounts",
+            "resource": "cost-providers",
+            "phrasing": "inferred"
+          },
+          "assert": [
+            {
+              "type": "javascript",
+              "value": "file://_lib/assertToolCalls.ts"
+            }
+          ]
+        },
+        "testIdx": 2,
+        "tokenUsage": {
+          "prompt": 0,
+          "completion": 0,
+          "cached": 0,
+          "total": 0,
+          "numRequests": 1,
+          "completionDetails": {
+            "reasoning": 0,
+            "acceptedPrediction": 0,
+            "rejectedPrediction": 0,
+            "cacheReadInputTokens": 0,
+            "cacheCreationInputTokens": 0
+          },
+          "assertions": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 1,
+            "completionDetails": {
+              "reasoning": 0,
+              "acceptedPrediction": 0,
+              "rejectedPrediction": 0,
+              "cacheReadInputTokens": 0,
+              "cacheCreationInputTokens": 0
+            }
+          }
+        },
+        "vars": {
+          "prompt": "In workspace wrkspc_abc123, search connected billing accounts for titles matching McpTest.",
+          "target": "get-cost-provider-accounts",
+          "expected": [
+            {
+              "toolName": "get-cost-provider-accounts",
+              "input": {
+                "workspace_token": "wrkspc_abc123",
+                "q": "McpTest"
+              }
+            }
+          ],
+          "distractors": [
+            "list-cost-providers",
+            "list-cost-integrations",
+            "list-costs",
+            "list-provider-resources"
+          ]
+        },
+        "metadata": {
+          "tool": "get-cost-provider-accounts",
+          "resource": "cost-providers",
+          "phrasing": "inferred",
+          "modelId": "gpt-5.6-luna",
+          "mode": "isolated",
+          "target": "get-cost-provider-accounts",
+          "toolNames": [
+            "get-cost-provider-accounts"
+          ],
+          "toolCalls": [
+            {
+              "toolName": "get-cost-provider-accounts",
+              "input": {
+                "workspace_token": "wrkspc_abc123",
+                "q": "McpTest"
+              }
+            }
+          ],
+          "_promptfooFileMetadata": {}
+        },
+        "failureReason": 0
+      },
+      {
+        "cost": 0,
+        "gradingResult": {
+          "pass": true,
+          "score": 1,
+          "reason": "All assertions passed",
+          "namedScores": {},
+          "tokensUsed": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 0
+          },
+          "componentResults": [
+            {
+              "pass": true,
+              "score": 1,
+              "reason": "Expected tool call matched.",
+              "assertion": {
+                "type": "javascript",
+                "value": "file://_lib/assertToolCalls.ts"
+              }
+            }
+          ]
+        },
+        "id": "a9e69fb7-60fb-4f31-a4c3-ee625ab19697",
+        "latencyMs": 1485,
+        "namedScores": {},
+        "prompt": {
+          "raw": "In workspace wrkspc_abc123, search connected billing accounts for titles matching McpTest.",
+          "label": "{{prompt}}",
+          "config": {
+            "disableVarExpansion": true
+          }
+        },
+        "promptId": "effa18501e44aafd9bc42a2f64ffc9b6350f94025520ca2ed382f9bdc4b6e982",
+        "promptIdx": 1,
+        "provider": {
+          "id": "tool-selection:gpt-5.6-luna:mixed",
+          "label": "gpt-5.6-luna · mixed"
+        },
+        "response": {
+          "output": {
+            "toolCalls": [
+              {
+                "toolName": "get-cost-provider-accounts",
+                "input": {
+                  "workspace_token": "wrkspc_abc123",
+                  "q": "McpTest"
+                }
+              }
+            ],
+            "text": ""
+          },
+          "metadata": {
+            "modelId": "gpt-5.6-luna",
+            "mode": "mixed",
+            "target": "get-cost-provider-accounts",
+            "toolNames": [
+              "get-cost-provider-accounts",
+              "list-cost-providers",
+              "list-cost-integrations",
+              "list-costs",
+              "list-provider-resources"
+            ],
+            "toolCalls": [
+              {
+                "toolName": "get-cost-provider-accounts",
+                "input": {
+                  "workspace_token": "wrkspc_abc123",
+                  "q": "McpTest"
+                }
+              }
+            ]
+          }
+        },
+        "score": 1,
+        "success": true,
+        "testCase": {
+          "description": "get-cost-provider-accounts · inferred · In workspace wrkspc_abc123, search connected billing accounts for titles matching McpTest.",
+          "vars": {
+            "prompt": "In workspace wrkspc_abc123, search connected billing accounts for titles matching McpTest.",
+            "target": "get-cost-provider-accounts",
+            "expected": [
+              {
+                "toolName": "get-cost-provider-accounts",
+                "input": {
+                  "workspace_token": "wrkspc_abc123",
+                  "q": "McpTest"
+                }
+              }
+            ],
+            "distractors": [
+              "list-cost-providers",
+              "list-cost-integrations",
+              "list-costs",
+              "list-provider-resources"
+            ]
+          },
+          "options": {
+            "disableVarExpansion": true
+          },
+          "metadata": {
+            "tool": "get-cost-provider-accounts",
+            "resource": "cost-providers",
+            "phrasing": "inferred"
+          },
+          "assert": [
+            {
+              "type": "javascript",
+              "value": "file://_lib/assertToolCalls.ts"
+            }
+          ]
+        },
+        "testIdx": 2,
+        "tokenUsage": {
+          "prompt": 0,
+          "completion": 0,
+          "cached": 0,
+          "total": 0,
+          "numRequests": 1,
+          "completionDetails": {
+            "reasoning": 0,
+            "acceptedPrediction": 0,
+            "rejectedPrediction": 0,
+            "cacheReadInputTokens": 0,
+            "cacheCreationInputTokens": 0
+          },
+          "assertions": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 1,
+            "completionDetails": {
+              "reasoning": 0,
+              "acceptedPrediction": 0,
+              "rejectedPrediction": 0,
+              "cacheReadInputTokens": 0,
+              "cacheCreationInputTokens": 0
+            }
+          }
+        },
+        "vars": {
+          "prompt": "In workspace wrkspc_abc123, search connected billing accounts for titles matching McpTest.",
+          "target": "get-cost-provider-accounts",
+          "expected": [
+            {
+              "toolName": "get-cost-provider-accounts",
+              "input": {
+                "workspace_token": "wrkspc_abc123",
+                "q": "McpTest"
+              }
+            }
+          ],
+          "distractors": [
+            "list-cost-providers",
+            "list-cost-integrations",
+            "list-costs",
+            "list-provider-resources"
+          ]
+        },
+        "metadata": {
+          "tool": "get-cost-provider-accounts",
+          "resource": "cost-providers",
+          "phrasing": "inferred",
+          "modelId": "gpt-5.6-luna",
+          "mode": "mixed",
+          "target": "get-cost-provider-accounts",
+          "toolNames": [
+            "get-cost-provider-accounts",
+            "list-cost-providers",
+            "list-cost-integrations",
+            "list-costs",
+            "list-provider-resources"
+          ],
+          "toolCalls": [
+            {
+              "toolName": "get-cost-provider-accounts",
+              "input": {
+                "workspace_token": "wrkspc_abc123",
+                "q": "McpTest"
+              }
+            }
+          ],
+          "_promptfooFileMetadata": {}
+        },
+        "failureReason": 0
+      }
+    ],
+    "prompts": [],
+    "stats": {
+      "successes": 6,
+      "failures": 0,
+      "errors": 0,
+      "tokenUsage": {
+        "prompt": 0,
+        "completion": 0,
+        "cached": 0,
+        "total": 0,
+        "numRequests": 6,
+        "completionDetails": {
+          "reasoning": 0,
+          "acceptedPrediction": 0,
+          "rejectedPrediction": 0
+        }
+      }
+    }
+  },
+  "config": {
+    "tags": {},
+    "description": "Vantage MCP tool-selection evals",
+    "prompts": [
+      "{{prompt}}"
+    ],
+    "providers": [
+      {
+        "id": "file://_lib/provider.ts",
+        "label": "gpt-5.6-luna · isolated",
+        "config": {
+          "modelId": "gpt-5.6-luna",
+          "mode": "isolated"
+        }
+      },
+      {
+        "id": "file://_lib/provider.ts",
+        "label": "gpt-5.6-luna · mixed",
+        "config": {
+          "modelId": "gpt-5.6-luna",
+          "mode": "mixed"
+        }
+      }
+    ],
+    "tests": [
+      "file://cases/cost-providers/get-cost-provider-accounts.eval.ts",
+      "file://cases/current-user/get-myself.eval.ts"
+    ],
+    "env": {},
+    "extensions": [],
+    "metadata": {},
+    "evaluateOptions": {
+      "maxConcurrency": 4
+    }
+  },
+  "shareableUrl": null,
+  "metadata": {
+    "promptfooVersion": "0.122.0",
+    "nodeVersion": "v23.11.0",
+    "platform": "darwin",
+    "arch": "arm64",
+    "exportedAt": "2026-08-31T22:28:08.679Z",
+    "evaluationCreatedAt": "2026-08-31T22:28:05.683Z"
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
         "@cloudflare/workers-oauth-provider": "^0.0.11",
         "@modelcontextprotocol/sdk": "1.29.0",
         "@sentry/cloudflare": "10.30.0",
-        "@vantage-sh/vantage-client": "2.18.0",
+        "@vantage-sh/vantage-client": "2.22.0",
         "agents": "^0.13.2",
         "axios": "1.13.5",
         "hono": "4.12.12",
@@ -8003,9 +8003,9 @@
       }
     },
     "node_modules/@vantage-sh/vantage-client": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/@vantage-sh/vantage-client/-/vantage-client-2.18.0.tgz",
-      "integrity": "sha512-7zsClWtAs+Xk2oAgX712SGmiqZHLzVodedPeyPl2mnosfQKXoE4I/idbmKFA9JtK7IFcySA5YPa2qq0kZOImIg==",
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/@vantage-sh/vantage-client/-/vantage-client-2.22.0.tgz",
+      "integrity": "sha512-SsVBu5Ch8FstKBGP1qOkJabDWTFK+6EQs0KZctEsSVnMWcpeVVMOlQD51CHFXluLxFBARWJIH/AO8NscNK5DrQ==",
       "license": "MIT"
     },
     "node_modules/@vercel/oidc": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@cloudflare/workers-oauth-provider": "^0.0.11",
     "@modelcontextprotocol/sdk": "1.29.0",
     "@sentry/cloudflare": "10.30.0",
-    "@vantage-sh/vantage-client": "2.18.0",
+    "@vantage-sh/vantage-client": "2.22.0",
     "agents": "^0.13.2",
     "axios": "1.13.5",
     "hono": "4.12.12",

--- a/src/tools/cost-providers/get-cost-provider-accounts.ts
+++ b/src/tools/cost-providers/get-cost-provider-accounts.ts
@@ -1,15 +1,13 @@
+import { VANTAGE_PROVIDERS } from "@vantage-sh/vantage-client";
 import z from "zod";
 import paginationData from "../../utils/paginationData";
-import { vantageToken } from "../../utils/zod";
-import { DEFAULT_LIMIT } from "../structure/constants";
+import { nonempty, vantageToken } from "../../utils/zod";
 import MCPUserError from "../structure/MCPUserError";
 import registerTool from "../structure/registerTool";
 
 const description = `
-Get the list of Cost Provider Accounts that the current user has access to in their workspace and their names.
-This is useful for mapping IDs you have gotten from other endpoints to human-readable names, or if you need to get the
-ID of a Cost Provider Account to use in places. The account_id in this result can be passed as the account_id in VQL queries.
-When possible, use the provider or account_id filters to narrow results. Results are paginated for large accounts.
+Get Cost Provider Accounts in a workspace with human-readable titles.
+Useful for mapping account IDs to names, or looking up an account_id for VQL.
 `.trim();
 
 export default registerTool({
@@ -18,10 +16,13 @@ export default registerTool({
   description,
   args: {
     workspace_token: vantageToken("workspace"),
-    account_id: z.string().optional().describe("Filter by a specific account ID"),
-    provider: z.string().optional().describe("Provider to filter provider accounts to"),
-    page: z.number().optional().default(1).describe("The page number to return, defaults to 1"),
-    limit: z.number().optional().default(DEFAULT_LIMIT).describe("The number of results to return per page"),
+    account_id: nonempty().optional().describe("Filter by a specific account ID."),
+    account_name: nonempty().optional().describe("Filter by account name (exact match)."),
+    provider: z
+      .enum(VANTAGE_PROVIDERS)
+      .optional()
+      .describe("Provider to filter provider accounts to. Use list-cost-providers to discover connected providers."),
+    q: nonempty().optional().describe("Search Cost Provider Accounts by title."),
   },
   annotations: {
     destructive: false,
@@ -29,15 +30,7 @@ export default registerTool({
     readOnly: true,
   },
   async execute(args, ctx) {
-    const response = await ctx.callVantageApi(
-      "/v2/cost_provider_accounts",
-      {
-        ...args,
-        // @ts-expect-error: This is a workaround so we don't have to keep patching the type here
-        provider: args.provider,
-      },
-      "GET"
-    );
+    const response = await ctx.callVantageApi("/v2/cost_provider_accounts", args, "GET");
     if (!response.ok) {
       throw new MCPUserError({ errors: response.errors });
     }

--- a/src/tools/cost-providers/get-cost-provider-accounts.ts
+++ b/src/tools/cost-providers/get-cost-provider-accounts.ts
@@ -1,6 +1,5 @@
 import { VANTAGE_PROVIDERS } from "@vantage-sh/vantage-client";
 import z from "zod";
-import paginationData from "../../utils/paginationData";
 import { nonempty, vantageToken } from "../../utils/zod";
 import MCPUserError from "../structure/MCPUserError";
 import registerTool from "../structure/registerTool";
@@ -34,9 +33,6 @@ export default registerTool({
     if (!response.ok) {
       throw new MCPUserError({ errors: response.errors });
     }
-    return {
-      cost_provider_accounts: response.data.cost_provider_accounts,
-      pagination: paginationData(response.data),
-    };
+    return response.data;
   },
 });

--- a/test/evals/buildAiSdkTools.test.ts
+++ b/test/evals/buildAiSdkTools.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest";
+import { buildAiSdkTools } from "../../evals/_lib/buildAiSdkTools";
+
+describe("buildAiSdkTools", () => {
+  it("sets strict: false so OpenAI omits unused optional tool args", () => {
+    const tools = buildAiSdkTools(["get-myself"]);
+    expect(tools["get-myself"]?.strict).toBe(false);
+  });
+});

--- a/test/evals/buildCases.test.ts
+++ b/test/evals/buildCases.test.ts
@@ -11,9 +11,11 @@ describe("buildToolCases", () => {
       inferredPrompts: [],
     });
 
+    expect(cases).toHaveLength(1);
     expect(cases[0].vars).toMatchObject({
       target: "get-myself",
       distractors: ["list-workspaces"],
     });
+    expect(cases[0].options).toEqual({ disableVarExpansion: true });
   });
 });

--- a/test/evals/evalArgs.test.ts
+++ b/test/evals/evalArgs.test.ts
@@ -22,7 +22,9 @@ describe("eval command arguments", () => {
 
   it("rejects an implicit full eval", () => {
     const parsed = parseEvalArgs(["--model", "gpt-5.6-sol-high"]);
-    expect(validateEvalScope(parsed)).toMatch(/--tool <name> is required/);
+    const error = validateEvalScope(parsed);
+    expect(error).toMatch(/--tool <name> is required/);
+    expect(error).toMatch(/npm run eval -- --tool/);
   });
 
   it("rejects combining a targeted and full eval", () => {

--- a/test/tools/cost-providers/get-cost-provider-accounts.test.ts
+++ b/test/tools/cost-providers/get-cost-provider-accounts.test.ts
@@ -1,7 +1,6 @@
-import type { GetCostProviderAccountsResponse } from "@vantage-sh/vantage-client";
+import { type GetCostProviderAccountsResponse, VANTAGE_PROVIDERS } from "@vantage-sh/vantage-client";
 import { expect } from "vitest";
 import tool from "../../../src/tools/cost-providers/get-cost-provider-accounts";
-import { DEFAULT_LIMIT } from "../../../src/tools/structure/constants";
 import {
   type ExecutionTestTableItem,
   type ExtractOutputSchema,
@@ -20,9 +19,9 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
     data: {
       workspace_token: "wrkspc_123",
       account_id: undefined,
+      account_name: undefined,
       provider: undefined,
-      page: undefined,
-      limit: undefined,
+      q: undefined,
     },
   },
   {
@@ -30,9 +29,9 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
     data: {
       workspace_token: "wrkspc_123",
       account_id: "acct_123",
+      account_name: undefined,
       provider: undefined,
-      page: undefined,
-      limit: undefined,
+      q: undefined,
     },
   },
   {
@@ -40,19 +39,51 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
     data: {
       workspace_token: "wrkspc_123",
       account_id: undefined,
+      account_name: undefined,
       provider: "aws",
-      page: undefined,
-      limit: undefined,
+      q: undefined,
     },
+  },
+  {
+    name: "q provided",
+    data: {
+      workspace_token: "wrkspc_123",
+      account_id: undefined,
+      account_name: undefined,
+      provider: undefined,
+      q: "prod",
+    },
+  },
+  {
+    name: "account_name provided",
+    data: {
+      workspace_token: "wrkspc_123",
+      account_id: undefined,
+      account_name: "Production Account",
+      provider: undefined,
+      q: undefined,
+    },
+  },
+  {
+    name: "invalid provider rejected",
+    data: {
+      workspace_token: "wrkspc_123",
+      account_id: undefined,
+      account_name: undefined,
+      // @ts-expect-error intentionally invalid provider for schema validation
+      provider: "not-a-provider",
+      q: undefined,
+    },
+    expectedIssues: [`Invalid option: expected one of ${VANTAGE_PROVIDERS.map((p) => `"${p}"`).join("|")}`],
   },
   {
     name: "all arguments provided",
     data: {
       workspace_token: "wrkspc_123",
       account_id: "acct_123",
+      account_name: "Production Account",
       provider: "aws",
-      page: 2,
-      limit: 50,
+      q: "prod",
     },
   },
 ];
@@ -74,18 +105,6 @@ const successData: GetCostProviderAccountsResponse = {
   ],
 };
 
-const successDataWithNextPage: GetCostProviderAccountsResponse = {
-  ...successData,
-  links: {
-    next: "https://api.vantage.sh/v2/cost_provider_accounts?page=3",
-  },
-};
-
-// The API type for /v2/cost_provider_accounts doesn't include page/limit yet,
-// but they are passed through via ...args at runtime. We cast params to satisfy
-// the test framework's strict typing while matching actual runtime behavior.
-const defaultPaginationParams = { page: 1, limit: DEFAULT_LIMIT } as Record<string, unknown>;
-
 const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
   {
     name: "successful call without filters",
@@ -95,8 +114,9 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
         params: {
           workspace_token: "wrkspc_123",
           account_id: undefined,
+          account_name: undefined,
           provider: undefined,
-          ...defaultPaginationParams,
+          q: undefined,
         },
         method: "GET",
         result: {
@@ -109,9 +129,9 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
       const res = await callExpectingSuccess({
         workspace_token: "wrkspc_123",
         account_id: undefined,
+        account_name: undefined,
         provider: undefined,
-        page: undefined,
-        limit: undefined,
+        q: undefined,
       });
       expect(res).toEqual({
         cost_provider_accounts: successData.cost_provider_accounts,
@@ -130,8 +150,9 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
         params: {
           workspace_token: "wrkspc_123",
           account_id: "acct_123",
+          account_name: undefined,
           provider: undefined,
-          ...defaultPaginationParams,
+          q: undefined,
         },
         method: "GET",
         result: {
@@ -144,9 +165,9 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
       const res = await callExpectingSuccess({
         workspace_token: "wrkspc_123",
         account_id: "acct_123",
+        account_name: undefined,
         provider: undefined,
-        page: undefined,
-        limit: undefined,
+        q: undefined,
       });
       expect(res).toEqual({
         cost_provider_accounts: successData.cost_provider_accounts,
@@ -165,8 +186,9 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
         params: {
           workspace_token: "wrkspc_123",
           account_id: undefined,
+          account_name: undefined,
           provider: "aws",
-          ...defaultPaginationParams,
+          q: undefined,
         },
         method: "GET",
         result: {
@@ -179,9 +201,9 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
       const res = await callExpectingSuccess({
         workspace_token: "wrkspc_123",
         account_id: undefined,
+        account_name: undefined,
         provider: "aws",
-        page: undefined,
-        limit: undefined,
+        q: undefined,
       });
       expect(res).toEqual({
         cost_provider_accounts: successData.cost_provider_accounts,
@@ -193,20 +215,21 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
     },
   },
   {
-    name: "successful call with pagination params and next page",
+    name: "successful call with q search",
     apiCallHandler: requestsInOrder([
       {
         endpoint: "/v2/cost_provider_accounts",
         params: {
           workspace_token: "wrkspc_123",
           account_id: undefined,
+          account_name: undefined,
           provider: undefined,
-          ...({ page: 2, limit: 50 } as Record<string, unknown>),
+          q: "prod",
         },
         method: "GET",
         result: {
           ok: true,
-          data: successDataWithNextPage,
+          data: successData,
         },
       },
     ]),
@@ -214,15 +237,15 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
       const res = await callExpectingSuccess({
         workspace_token: "wrkspc_123",
         account_id: undefined,
+        account_name: undefined,
         provider: undefined,
-        page: 2,
-        limit: 50,
+        q: "prod",
       });
       expect(res).toEqual({
-        cost_provider_accounts: successDataWithNextPage.cost_provider_accounts,
+        cost_provider_accounts: successData.cost_provider_accounts,
         pagination: {
-          hasNextPage: true,
-          nextPage: 3,
+          hasNextPage: false,
+          nextPage: 0,
         },
       });
     },
@@ -235,8 +258,9 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
         params: {
           workspace_token: "wrkspc_123",
           account_id: undefined,
+          account_name: undefined,
           provider: undefined,
-          ...defaultPaginationParams,
+          q: undefined,
         },
         method: "GET",
         result: {
@@ -249,9 +273,9 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
       const err = await callExpectingMCPUserError({
         workspace_token: "wrkspc_123",
         account_id: undefined,
+        account_name: undefined,
         provider: undefined,
-        page: undefined,
-        limit: undefined,
+        q: undefined,
       });
       expect(err.exception).toEqual({
         errors: [{ message: "Invalid token" }],

--- a/test/tools/cost-providers/get-cost-provider-accounts.test.ts
+++ b/test/tools/cost-providers/get-cost-provider-accounts.test.ts
@@ -133,13 +133,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
         provider: undefined,
         q: undefined,
       });
-      expect(res).toEqual({
-        cost_provider_accounts: successData.cost_provider_accounts,
-        pagination: {
-          hasNextPage: false,
-          nextPage: 0,
-        },
-      });
+      expect(res).toEqual(successData);
     },
   },
   {
@@ -169,13 +163,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
         provider: undefined,
         q: undefined,
       });
-      expect(res).toEqual({
-        cost_provider_accounts: successData.cost_provider_accounts,
-        pagination: {
-          hasNextPage: false,
-          nextPage: 0,
-        },
-      });
+      expect(res).toEqual(successData);
     },
   },
   {
@@ -205,13 +193,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
         provider: "aws",
         q: undefined,
       });
-      expect(res).toEqual({
-        cost_provider_accounts: successData.cost_provider_accounts,
-        pagination: {
-          hasNextPage: false,
-          nextPage: 0,
-        },
-      });
+      expect(res).toEqual(successData);
     },
   },
   {
@@ -241,13 +223,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
         provider: undefined,
         q: "prod",
       });
-      expect(res).toEqual({
-        cost_provider_accounts: successData.cost_provider_accounts,
-        pagination: {
-          hasNextPage: false,
-          nextPage: 0,
-        },
-      });
+      expect(res).toEqual(successData);
     },
   },
   {


### PR DESCRIPTION
## What Changed

* Adding filtering to `get-cost-provider-accounts`
* Added an eval against GPT 5.6-luna to test functionality
* Fixed up some eval harness stuff that was uncovered

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The MCP tool’s args and response shape change (no pagination wrapper, new/removed params), which can break existing agent workflows; eval-only harness changes are low risk.
> 
> **Overview**
> **`get-cost-provider-accounts`** is aligned with the updated Vantage client (**2.22.0**): **`page`/`limit` and client-side pagination wrapping are removed**, the handler returns the API payload as-is, and filters add **`account_name`**, title search **`q`**, and a **`provider`** enum from `VANTAGE_PROVIDERS`. The tool description is shortened accordingly.
> 
> The **tool-selection eval harness** gets two fixes uncovered while adding coverage for this tool: AI SDK tools use **`strict: false`** so OpenAI’s Responses API does not inject placeholder values into omitted optional args (which broke arg scoring), and **`buildToolCases`** sets **`disableVarExpansion: true`** so promptfoo does not explode `expected`/`distractors` arrays into extra cases. Eval CLI validation now reminds users to pass flags after **`npm run eval --`**.
> 
> A new **`get-cost-provider-accounts`** eval case (with cost-provider distractors) and a **gpt-5.6-luna** baseline result JSON are committed; unit tests cover the schema and harness changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43ad78f80fbcbfda1c0c2e246f0ca6aebcbc8856. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->