### PR TITLE
Upgrade `@cloudflare/workers-oauth-provider` to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "vantage-mcp-server",
       "dependencies": {
-        "@cloudflare/workers-oauth-provider": "^0.0.11",
+        "@cloudflare/workers-oauth-provider": "^0.10.3",
         "@modelcontextprotocol/sdk": "1.29.0",
         "@sentry/cloudflare": "10.30.0",
         "@vantage-sh/vantage-client": "2.22.0",
@@ -2051,9 +2051,9 @@
       }
     },
     "node_modules/@cloudflare/workers-oauth-provider": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-oauth-provider/-/workers-oauth-provider-0.0.11.tgz",
-      "integrity": "sha512-uarVcE1y/lf0y6iMFTwpJe8u6kpDP9CRZQTsGfCFonCEmH9n9b8k4ZmFpxI5g4XfoS7s9YHO0XcSRH8fgsjHWA==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-oauth-provider/-/workers-oauth-provider-0.10.3.tgz",
+      "integrity": "sha512-25ufMONJir9PllqVpK4GwOOoSFgpYm3+bM6NBedj7ufMCIfNf5jk4OI0LPuTJBaJgLl2lGCLqFqEPJXcSuPopQ==",
       "license": "MIT"
     },
     "node_modules/@cloudflare/workers-types": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "print-version": "tsx src/tools/bin/print-version.ts"
   },
   "dependencies": {
-    "@cloudflare/workers-oauth-provider": "^0.0.11",
+    "@cloudflare/workers-oauth-provider": "^0.10.3",
     "@modelcontextprotocol/sdk": "1.29.0",
     "@sentry/cloudflare": "10.30.0",
     "@vantage-sh/vantage-client": "2.22.0",

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -3,11 +3,12 @@ Note that this code started from the examples at
 https://github.com/cloudflare/ai/tree/0150b265a4510123b545b4f988511bf0b63c6641/demos/remote-mcp-auth0
 */
 import { env } from "cloudflare:workers";
-import type {
-  AuthRequest,
-  OAuthHelpers,
-  TokenExchangeCallbackOptions,
-  TokenExchangeCallbackResult,
+import {
+  AuthorizationError,
+  type AuthRequest,
+  type OAuthHelpers,
+  type TokenExchangeCallbackOptions,
+  type TokenExchangeCallbackResult,
 } from "@cloudflare/workers-oauth-provider";
 import axios from "axios";
 import type { Context } from "hono";
@@ -21,8 +22,9 @@ export type UserProps = {
   claims: JWTPayload;
   tokenSet: {
     accessToken: string;
-    idToken: string;
-    refreshToken: string;
+    accessTokenTTL?: number;
+    idToken?: string;
+    refreshToken?: string;
   };
 };
 
@@ -63,9 +65,28 @@ export async function getOidcConfig({
  * Then it shows a consent screen before redirecting to Auth0.
  */
 export async function authorize(c: Context<{ Bindings: AppEnv & { OAUTH_PROVIDER: OAuthHelpers } }>) {
-  const mcpClientAuthRequest = await c.env.OAUTH_PROVIDER.parseAuthRequest(c.req.raw);
-  if (!mcpClientAuthRequest.clientId) {
-    return c.text("Invalid request", 400);
+  let mcpClientAuthRequest: AuthRequest;
+  try {
+    mcpClientAuthRequest = await c.env.OAUTH_PROVIDER.parseAuthRequest(c.req.raw);
+  } catch (error) {
+    if (!(error instanceof AuthorizationError)) {
+      throw error;
+    }
+
+    if (!error.redirectUri) {
+      return c.text(error.description, 400);
+    }
+
+    const redirectUri = new URL(error.redirectUri);
+    redirectUri.searchParams.set("error", error.code);
+    redirectUri.searchParams.set("error_description", error.description);
+    if (error.state) {
+      redirectUri.searchParams.set("state", error.state);
+    }
+    if (error.issuer) {
+      redirectUri.searchParams.set("iss", error.issuer);
+    }
+    return c.redirect(redirectUri.toString());
   }
 
   const client = await c.env.OAUTH_PROVIDER.lookupClient(mcpClientAuthRequest.clientId);
@@ -163,6 +184,9 @@ export async function confirmConsent(c: Context<{ Bindings: AppEnv & { OAUTH_PRO
     redirectUri.searchParams.set("error_description", "User denied the request");
     if (auth0AuthRequest.mcpAuthRequest.state) {
       redirectUri.searchParams.set("state", auth0AuthRequest.mcpAuthRequest.state);
+    }
+    if (auth0AuthRequest.mcpAuthRequest.issuer) {
+      redirectUri.searchParams.set("iss", auth0AuthRequest.mcpAuthRequest.issuer);
     }
 
     // Clear the transaction cookie
@@ -295,8 +319,9 @@ export async function callback(c: Context<{ Bindings: AppEnv & { OAUTH_PROVIDER:
         idToken: result.id_token,
         refreshToken: result.refresh_token,
       },
-    } as UserProps,
+    } satisfies UserProps,
     request: auth0AuthRequest.mcpAuthRequest,
+    revokeExistingGrants: false,
     scope: auth0AuthRequest.mcpAuthRequest.scope,
     userId: claims.sub!,
   });

--- a/src/cf-worker.ts
+++ b/src/cf-worker.ts
@@ -115,7 +115,7 @@ export class VantageMCP extends McpAgent<Env, Record<string, never>, UserProps> 
 }
 
 // Initialize the Hono app with the routes for the OAuth Provider.
-const app = new Hono<{ Bindings: Env & { OAUTH_PROVIDER: OAuthHelpers } }>();
+const app = new Hono<{ Bindings: AppEnv & { OAUTH_PROVIDER: OAuthHelpers } }>();
 
 app.get("/authorize", authorize);
 app.post("/authorize/consent", confirmConsent);
@@ -139,25 +139,48 @@ function hasVantageHeaders(request: Request): boolean {
   return false;
 }
 
-function createMcpServer(request: Request, sse: boolean): HeaderAuthProvider | OAuthProvider {
+function createMcpServer(request: Request, sse: boolean): HeaderAuthProvider<AppEnv> | OAuthProvider<AppEnv> {
+  const apiHandler = (sse ? VantageMCP.mount("/sse") : VantageMCP.serve("/mcp")) as unknown as {
+    fetch(request: Request, env: AppEnv, ctx: ExecutionContext): Response | Promise<Response>;
+  };
+
   if (hasVantageHeaders(request) || hasValidAuthHeader(request)) {
     // Vantage headers or token is passed through headers, use HeaderAuthProvider
     // Can be used when programmatically accessing the server
-    return new HeaderAuthProvider({
-      apiHandler: sse ? VantageMCP.mount("/sse") : VantageMCP.serve("/mcp"),
+    return new HeaderAuthProvider<AppEnv>({
+      apiHandler,
       apiRoute: sse ? "/sse" : "/mcp",
-      // @ts-expect-error
       defaultHandler: app,
     });
   } else {
     // OAuth mode - use the full OAuth provider setup
-    return new OAuthProvider({
-      apiHandler: sse ? VantageMCP.mount("/sse") : VantageMCP.serve("/mcp"),
+    return new OAuthProvider<AppEnv>({
+      allowPlainPKCE: true,
+      apiHandler,
       apiRoute: sse ? "/sse" : "/mcp",
       authorizeEndpoint: "/authorize",
+      clientRegistrationTTL: undefined,
       clientRegistrationEndpoint: "/register",
-      // @ts-expect-error
       defaultHandler: app,
+      onError: ({ code, description, headers, internal, status }) => {
+        const tags = {
+          oauth_error_code: code,
+          oauth_error_status: status,
+          oauth_error_category: internal?.category,
+          oauth_error_reason: internal?.reason,
+        };
+        logger.withTags(tags).error("OAuth error response", description);
+        Sentry.captureMessage("OAuth error response", {
+          level: "error",
+          tags,
+          extra: {
+            description,
+            headers,
+            internal,
+          },
+        });
+      },
+      refreshTokenTTL: undefined,
       tokenEndpoint: "/token",
       tokenExchangeCallback,
     });

--- a/src/header-auth-provider.ts
+++ b/src/header-auth-provider.ts
@@ -1,24 +1,24 @@
 import type { ExecutionContext } from "@cloudflare/workers-types";
 
-type HandlerWithFetch = {
-  fetch(request: Request, env?: unknown, ctx?: ExecutionContext): Promise<Response>;
+type HandlerWithFetch<Env> = {
+  fetch(request: Request, env: Env, ctx: ExecutionContext): Response | Promise<Response>;
 };
 
 // These options mimic the OAuthProviderOptions from @cloudflare/workers-oauth-provider
-export type HeaderAuthProviderOptions = {
+export type HeaderAuthProviderOptions<Env> = {
   apiRoute: string | string[];
-  defaultHandler: HandlerWithFetch;
-  apiHandler: HandlerWithFetch;
+  defaultHandler: HandlerWithFetch<Env>;
+  apiHandler: HandlerWithFetch<Env>;
 };
 
-export class HeaderAuthProvider {
-  private options: HeaderAuthProviderOptions;
+export class HeaderAuthProvider<Env> {
+  private options: HeaderAuthProviderOptions<Env>;
 
-  constructor(options: HeaderAuthProviderOptions) {
+  constructor(options: HeaderAuthProviderOptions<Env>) {
     this.options = options;
   }
 
-  async fetch(request: Request, env: unknown, ctx: ExecutionContext): Promise<Response> {
+  async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
     const url = new URL(request.url);
 
     if (this.matchesApiRoute(url)) {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -5,6 +5,10 @@ export type LogTagHints = {
   mcp_client_version?: string;
   endpoint?: string;
   method?: string;
+  oauth_error_category?: string;
+  oauth_error_code?: string;
+  oauth_error_reason?: string;
+  oauth_error_status?: number;
   ok?: boolean;
 };
 


### PR DESCRIPTION
## What Changed

Working on upgrading `@cloudflare/workers-oauth-provider` so that we can eventually get the MCP server updated to the latest spec. This is first step

## Testing Done

None yet, I will provide a detailed test report when I get to this

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> This is a large jump in the OAuth/MCP auth library with changes to authorization error handling, PKCE, token TTLs, and grant revocation behavior—all security-critical login paths that the PR author notes are not yet tested.
> 
> **Overview**
> Upgrades **`@cloudflare/workers-oauth-provider`** from `0.0.11` to `0.10.3` as groundwork for aligning the hosted MCP server with newer MCP/OAuth expectations.
> 
> **Auth flow (`auth.ts`)** now treats **`AuthorizationError`** from `parseAuthRequest` as a proper OAuth redirect (error, `error_description`, `state`, and **`iss`** when present) instead of a generic 400. User-denied consent redirects include **`iss`** as well. **`UserProps`** reflects optional id/refresh tokens and optional **`accessTokenTTL`**; **`completeAuthorization`** passes **`revokeExistingGrants: false`** and uses **`satisfies UserProps`**.
> 
> **Worker wiring (`cf-worker.ts`)** types **`OAuthProvider`** and **`HeaderAuthProvider`** with **`AppEnv`**, removes `@ts-expect-error` on handlers, and configures the new provider options: **`allowPlainPKCE`**, explicit **`clientRegistrationTTL` / `refreshTokenTTL`**, and an **`onError`** hook that logs tagged OAuth failures and reports them to Sentry. **`header-auth-provider.ts`** mirrors the generic env typing on `fetch` handlers.
> 
> **Logging** adds structured tags for OAuth error code, status, category, and reason.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7507e84f20d9c4a061b8f263babae960481ade5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->