### PR TITLE
Add the rest of the teams tools and evals

### DIFF
--- a/.agents/skills/writing-evals/SKILL.md
+++ b/.agents/skills/writing-evals/SKILL.md
@@ -26,14 +26,19 @@ If the user wants evals but says the required key is not configured, author the 
 
 | Command                                                                                                                | Purpose                                                         |
 | ---------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
-| `npm run eval -- --tool <name> --model gpt-5.6-sol-high`                                                               | Run one tool against one approved model after explicit approval |
+| `npm run eval -- --tool <name> --model gpt-5.6-sol-high`                                                               | Run one exact tool against one approved model after explicit approval |
+| `npm run eval -- --tool <name> --tool <name> --model gpt-5.6-sol-high`                                                 | Run an explicit set of exact tools                              |
+| `npm run eval -- --resource <name> --model gpt-5.6-sol-high`                                                           | Run every eval case in one resource directory                   |
+| `npm run eval -- --tool <name> --dry-run`                                                                              | Preview the exact resolved scope without model calls            |
 | `npm run eval:all -- --model gpt-5.6-sol-high`                                                                         | Deliberately refresh every case against one model               |
 | `npm run eval -- --list-models`                                                                                        | Print the approved model × effort catalog                       |
 | `npm run eval -- --tool <name> --filter-failing evals/results/<model>/<resource>/<tool>.json --model gpt-5.6-sol-high` | Re-run failures only                                            |
 | `npm run eval:site`                                                                                                    | Merge stored JSON → `evals/site/index.html`                     |
 | `npm run eval:view`                                                                                                    | promptfoo's local viewer                                        |
 
-`--model` is required. The slug is an approved model id, optionally plus an effort suffix (`gpt-5.6-sol-high`). Models that do not expose effort (today: `claude-haiku-4-5`) take the bare id. Effort is optional even when the model supports it — `gpt-5.6-sol` uses the provider default. Dotted forms like `gpt-5.6.sol-high` are accepted and stored as `gpt-5.6-sol-high`. The catalog lives in `evals/_lib/models.ts`.
+`--tool` is an exact selector and may be repeated. `--resource` selects every case under the matching `evals/cases/<resource>/` directory, may be repeated, and accepts an optional trailing slash. The selectors can be combined and are resolved as a deduplicated union before Promptfoo starts. Use `--dry-run` to print that resolved scope without selecting a model or making model calls.
+
+`--model` is required except for `--dry-run`. The slug is an approved model id, optionally plus an effort suffix (`gpt-5.6-sol-high`). Models that do not expose effort (today: `claude-haiku-4-5`) take the bare id. Effort is optional even when the model supports it — `gpt-5.6-sol` uses the provider default. Dotted forms like `gpt-5.6.sol-high` are accepted and stored as `gpt-5.6-sol-high`. The catalog lives in `evals/_lib/models.ts`.
 
 promptfoo loads the ignored `.env` file; set `ANTHROPIC_API_KEY` or `OPENAI_API_KEY` there for the selected model's provider before the first run. Do not infer permission to run from the presence of a key. Every eval invocation makes fresh model calls; promptfoo's response cache is disabled. An unfiltered run replaces the selected result JSON. A run using a partial promptfoo filter merges rerun cells into the retained baseline and preserves cells the filter omitted.
 
@@ -52,8 +57,9 @@ evals/
 
 - **Adding a tool:** after the user opts in to evals, write `evals/cases/<resource>/<tool>.eval.ts`. Unless the user explicitly asked for execution and confirmed the required API key is configured, stop there and provide `npm run eval -- --tool <tool> --model <approved-model>` as the next-step command. When explicitly authorized, the run writes `evals/results/<model>/<resource>/<tool>.json` and leaves every other tool's files untouched; then run `npm run eval:site` and commit the new JSON.
 - **Editing an existing tool:** update the case file only when the user opts in to eval work. Re-run that tool only when the user explicitly asks and confirms credential setup; its per-tool JSON is replaced.
+- **Refreshing one resource:** use `npm run eval -- --resource <resource> --model <approved-model>` only after the user explicitly authorizes the model-backed run. This replaces the per-tool result JSON for every selected case in that resource and leaves other resources untouched.
 - **Filtered rerun:** partial filters such as `--filter-failing` and `--filter-metadata` replace matching cells by provider and case identity while preserving every stored cell the filter omitted.
-- **Full-model refresh:** the normal `eval` command rejects a missing `--tool`. Use `npm run eval:all -- --model <model>` only when you intentionally want to refresh every case for that model.
+- **Full-model refresh:** the normal `eval` command rejects a missing `--tool` or `--resource` selector. Use `npm run eval:all -- --model <model>` only when you intentionally want to refresh every case for that model.
 - **Merge conflicts** on a JSON file: take one side, re-run that tool, commit the result.
 - **Browsing results:** `npm run eval:site && open evals/site/index.html`. GitHub Pages at <https://vantage-sh.github.io/vantage-mcp-server/> regenerates HTML from committed JSON on every push to `main` that touches `evals/results/`. No model API keys in CI.
 
@@ -63,6 +69,7 @@ evals/
 evals/
   _lib/
     evalArgs.ts           # CLI parsing + targeted/full-run safety guard
+    evalScope.ts          # exact tool/resource case discovery and selection
     models.ts             # approved models × effort levels; --model slug parser
     distractors.ts        # registered-tool sampler + optional named distractors
     buildAiSdkTools.ts    # reads from the live registerTool registry → AI SDK tool() defs
@@ -114,7 +121,7 @@ export default function generateTests() {
 }
 ```
 
-`buildToolCases` tags every case with `metadata.tool` and `metadata.resource` so `--tool` / `--filter-metadata tool=` works and results land under `evals/results/<model>/<resource>/`.
+`buildToolCases` tags every case with `metadata.tool` and `metadata.resource` so results land under `evals/results/<model>/<resource>/` and optional Promptfoo metadata filters can narrow an already-resolved scope. The wrapper resolves `--tool` and `--resource` exactly before Promptfoo loads the selected case files.
 
 The scorer requires **exactly one** tool call with the expected name and args. Missing calls, extra calls, and multiple expected calls fail the cell. The v1 eval matrix does not cover abstention, negative, or multi-tool prompts.
 

--- a/evals/_lib/evalArgs.ts
+++ b/evals/_lib/evalArgs.ts
@@ -1,10 +1,12 @@
 export type ParsedEvalArgs = {
   all: boolean;
+  dryRun: boolean;
   help: boolean;
   listModels: boolean;
-  tool?: string;
   model?: string;
   passthrough: string[];
+  resources: string[];
+  tools: string[];
 };
 
 const PARTIAL_RESULT_FILTERS = [
@@ -29,25 +31,45 @@ export function hasPartialResultFilter(args: readonly string[]): boolean {
 export function parseEvalArgs(argv: string[]): ParsedEvalArgs {
   const parsed: ParsedEvalArgs = {
     all: false,
+    dryRun: false,
     help: false,
     listModels: false,
     passthrough: [],
+    resources: [],
+    tools: [],
+  };
+
+  const valueAfter = (index: number, flag: string): string => {
+    const value = argv[index + 1];
+    if (!value || value.startsWith("--")) {
+      throw new Error(`${flag} requires a value.`);
+    }
+    return value;
   };
 
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     if (arg === "--tool") {
-      parsed.tool = argv[i + 1];
+      parsed.tools.push(valueAfter(i, arg));
+      i += 1;
+      continue;
+    }
+    if (arg === "--resource") {
+      parsed.resources.push(valueAfter(i, arg));
       i += 1;
       continue;
     }
     if (arg === "--model") {
-      parsed.model = argv[i + 1];
+      parsed.model = valueAfter(i, arg);
       i += 1;
       continue;
     }
     if (arg === "--all") {
       parsed.all = true;
+      continue;
+    }
+    if (arg === "--dry-run") {
+      parsed.dryRun = true;
       continue;
     }
     if (arg === "--help" || arg === "-h") {
@@ -64,13 +86,14 @@ export function parseEvalArgs(argv: string[]): ParsedEvalArgs {
   return parsed;
 }
 
-export function validateEvalScope(args: Pick<ParsedEvalArgs, "all" | "tool">): string | undefined {
-  if (args.all && args.tool) {
-    return "Choose either --tool <name> or the eval:all command, not both.";
+export function validateEvalScope(args: Pick<ParsedEvalArgs, "all" | "resources" | "tools">): string | undefined {
+  const hasSelectors = args.tools.length > 0 || args.resources.length > 0;
+  if (args.all && hasSelectors) {
+    return "Choose --tool/--resource selectors or the eval:all command, not both.";
   }
-  if (!args.all && !args.tool) {
+  if (!args.all && !hasSelectors) {
     return [
-      "--tool <name> is required.",
+      "At least one --tool <name> or --resource <name> selector is required.",
       "Pass flags after `--` so npm forwards them to the script, e.g. npm run eval -- --tool get-myself --model gpt-5.6-sol-high.",
       "To deliberately refresh every tool, use npm run eval:all -- --model <id[-effort]>.",
     ].join(" ");

--- a/evals/_lib/evalScope.ts
+++ b/evals/_lib/evalScope.ts
@@ -1,0 +1,97 @@
+import { readdirSync } from "node:fs";
+import { join, relative, sep } from "node:path";
+
+const CASE_FILE_SUFFIX = ".eval.ts";
+
+export type EvalCaseFile = {
+  path: string;
+  resource: string;
+  tool: string;
+};
+
+export type EvalScope = {
+  all: boolean;
+  resources: readonly string[];
+  tools: readonly string[];
+};
+
+function normalizeResource(resource: string): string {
+  return resource.trim().replace(/^\/+|\/+$/g, "");
+}
+
+export function discoverEvalCases(casesDir: string): EvalCaseFile[] {
+  function walk(dir: string): EvalCaseFile[] {
+    return readdirSync(dir, { withFileTypes: true })
+      .sort((a, b) => a.name.localeCompare(b.name))
+      .flatMap((entry) => {
+        const fullPath = join(dir, entry.name);
+        if (entry.isDirectory()) {
+          return walk(fullPath);
+        }
+        if (!entry.name.endsWith(CASE_FILE_SUFFIX)) {
+          return [];
+        }
+
+        const relativePath = relative(casesDir, fullPath).split(sep).join("/");
+        const pathParts = relativePath.split("/");
+        if (pathParts.length < 2) {
+          throw new Error(`Eval case must be under a resource directory: ${relativePath}`);
+        }
+
+        return [
+          {
+            path: `file://cases/${relativePath}`,
+            resource: pathParts.slice(0, -1).join("/"),
+            tool: entry.name.slice(0, -CASE_FILE_SUFFIX.length),
+          },
+        ];
+      });
+  }
+
+  return walk(casesDir);
+}
+
+export function selectEvalCases(cases: readonly EvalCaseFile[], scope: EvalScope): EvalCaseFile[] {
+  if (scope.all) {
+    return [...cases];
+  }
+
+  const requestedTools = [...new Set(scope.tools.map((tool) => tool.trim()))];
+  const requestedResources = [...new Set(scope.resources.map(normalizeResource))];
+  const selectedPaths = new Set<string>();
+
+  for (const tool of requestedTools) {
+    const matches = cases.filter((candidate) => candidate.tool === tool);
+    if (matches.length === 0) {
+      throw new Error(`No eval case found for tool: ${tool || "<empty>"}`);
+    }
+    if (matches.length > 1) {
+      throw new Error(`Tool selector is ambiguous across resources: ${tool}`);
+    }
+    selectedPaths.add(matches[0].path);
+  }
+
+  for (const resource of requestedResources) {
+    const matches = cases.filter((candidate) => candidate.resource === resource);
+    if (matches.length === 0) {
+      throw new Error(`No eval cases found for resource: ${resource || "<empty>"}`);
+    }
+    for (const match of matches) {
+      selectedPaths.add(match.path);
+    }
+  }
+
+  return cases.filter((candidate) => selectedPaths.has(candidate.path));
+}
+
+export function parseSelectedCasePaths(raw: string | undefined, fallback: readonly string[]): string[] {
+  if (raw === undefined) {
+    return [...fallback];
+  }
+
+  const parsed = JSON.parse(raw) as unknown;
+  if (!Array.isArray(parsed) || parsed.length === 0 || parsed.some((path) => typeof path !== "string")) {
+    throw new Error("EVAL_CASE_PATHS must be a non-empty JSON array of case paths.");
+  }
+  return parsed;
+}

--- a/evals/_lib/models.ts
+++ b/evals/_lib/models.ts
@@ -117,7 +117,9 @@ export function parseModelSpec(raw: string): ModelHandle {
 
 export function resolveEvalModel(raw: string | undefined): ModelHandle {
   if (raw === undefined || raw.trim().length === 0) {
-    throw new Error("EVAL_MODEL is not set. Run evals with `npm run eval -- --tool <name> --model gpt-5.6-sol-high`.");
+    throw new Error(
+      "EVAL_MODEL is not set. Run evals with `npm run eval -- --tool <name> --model gpt-5.6-sol-high` or select a resource with `--resource <name>`."
+    );
   }
   return parseModelSpec(raw);
 }

--- a/evals/_lib/run-eval.ts
+++ b/evals/_lib/run-eval.ts
@@ -4,6 +4,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { hasPartialResultFilter, parseEvalArgs, validateEvalScope } from "./evalArgs";
 import { finalizeEvalRun } from "./evalRunLifecycle";
+import { discoverEvalCases, selectEvalCases } from "./evalScope";
 import { formatApprovedModels, parseModelSpec } from "./models";
 import { CONFIG_PATH, EVALS_ROOT, readOutputFile, splitOutputIntoToolFiles } from "./resultsStore";
 
@@ -16,11 +17,14 @@ function printHelp(): void {
   console.log(`Run Vantage MCP tool-selection evals.
 
 Usage:
-  npm run eval -- --tool <name> --model <id[-effort]> [promptfoo flags...]
+  npm run eval -- (--tool <name> | --resource <name>)... --model <id[-effort]> [promptfoo flags...]
+  npm run eval -- (--tool <name> | --resource <name>)... --dry-run
   npm run eval:all -- --model <id[-effort]> [promptfoo flags...]
 
-The normal command requires --tool. Use eval:all for an intentional full refresh.
---model is always required. Effort is optional when the model supports it
+--tool selects one exact tool and may be repeated. --resource selects every eval
+case in one exact resource directory and may be repeated. Use eval:all for an
+intentional full refresh. --dry-run prints the resolved scope without model calls.
+--model is required unless --dry-run is used. Effort is optional when the model supports it
 (gpt-5.6-sol uses the provider default; gpt-5.6-sol-high sets high).
 Every invocation makes fresh model calls; committed result JSON is the retained baseline.
 Unfiltered runs replace selected result files. Partial promptfoo filters merge rerun
@@ -28,6 +32,9 @@ cells into those files and preserve cells omitted by the filter.
 
 Examples:
   npm run eval -- --tool get-myself --model gpt-5.6-sol-high
+  npm run eval -- --tool get-team --tool get-teams --model gpt-5.6-sol-high
+  npm run eval -- --resource teams --model gpt-5.6-sol-high
+  npm run eval -- --resource teams/ --dry-run
   npm run eval -- --tool get-myself --model claude-haiku-4-5
   npm run eval -- --tool get-myself --filter-failing evals/results/gpt-5.6-sol-high/current-user/get-myself.json --model gpt-5.6-sol-high
   npm run eval:all -- --model gpt-5.6-sol-high
@@ -56,6 +63,13 @@ async function cleanupTmpOutput(): Promise<void> {
   await unlink(tmpOutputPath).catch(() => undefined);
 }
 
+function printSelectedCases(cases: readonly { resource: string; tool: string }[]): void {
+  console.log(`Selected ${cases.length} tool eval${cases.length === 1 ? "" : "s"}:`);
+  for (const evalCase of cases) {
+    console.log(`  ${evalCase.resource}/${evalCase.tool}`);
+  }
+}
+
 async function main(): Promise<void> {
   const parsed = parseEvalArgs(process.argv.slice(2));
   if (parsed.help) {
@@ -73,7 +87,13 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  const { tool, model, passthrough } = parsed;
+  const selectedCases = selectEvalCases(discoverEvalCases(join(EVALS_ROOT, "cases")), parsed);
+  printSelectedCases(selectedCases);
+  if (parsed.dryRun) {
+    return;
+  }
+
+  const { model, passthrough } = parsed;
   const mergeExistingResults = hasPartialResultFilter(passthrough);
   if (!model) {
     console.error(`Error: --model is required.\n\n${formatApprovedModels()}`);
@@ -92,11 +112,11 @@ async function main(): Promise<void> {
   await cleanupTmpOutput();
 
   const args = ["eval", "-c", CONFIG_PATH, "-o", tmpOutputPath, "--no-cache", ...passthrough];
-  if (tool) {
-    args.push("--filter-metadata", `tool=${tool}`);
-  }
 
-  const code = await runPromptfoo(args, { EVAL_MODEL: selected.id });
+  const code = await runPromptfoo(args, {
+    EVAL_CASE_PATHS: JSON.stringify(selectedCases.map((evalCase) => evalCase.path)),
+    EVAL_MODEL: selected.id,
+  });
   const written = await finalizeEvalRun(
     code,
     async () => {

--- a/evals/cases/teams/add-team-member.eval.ts
+++ b/evals/cases/teams/add-team-member.eval.ts
@@ -1,0 +1,37 @@
+import { buildToolCases } from "../../_lib/buildCases";
+
+const TARGET = "add-team-member";
+
+export default function generateTests() {
+  return buildToolCases({
+    target: TARGET,
+    resource: "teams",
+    distractors: ["remove-team-member", "get-team-members", "update-team", "get-user"],
+    directPrompts: [
+      {
+        input: "Use add-team-member to add pat@example.com to Vantage Team team_abc123 as an integration owner.",
+        expected: [
+          {
+            toolName: TARGET,
+            input: {
+              team_token: "team_abc123",
+              user_email: "pat@example.com",
+              role: "integration_owner",
+            },
+          },
+        ],
+      },
+    ],
+    inferredPrompts: [
+      {
+        input: "Make lee@example.com a viewer on the Vantage Team team_abc123.",
+        expected: [
+          {
+            toolName: TARGET,
+            input: { team_token: "team_abc123", user_email: "lee@example.com", role: "viewer" },
+          },
+        ],
+      },
+    ],
+  });
+}

--- a/evals/cases/teams/create-team.eval.ts
+++ b/evals/cases/teams/create-team.eval.ts
@@ -1,0 +1,34 @@
+import { buildToolCases } from "../../_lib/buildCases";
+
+const TARGET = "create-team";
+
+export default function generateTests() {
+  return buildToolCases({
+    target: TARGET,
+    resource: "teams",
+    distractors: ["update-team", "add-team-member", "create-workspace", "get-teams"],
+    directPrompts: [
+      {
+        input:
+          "Use create-team to create a Vantage Team named Platform Ops in workspace wrkspc_abc123 and give user usr_def456 the editor role.",
+        expected: [
+          {
+            toolName: TARGET,
+            input: {
+              name: "Platform Ops",
+              workspace_tokens: ["wrkspc_abc123"],
+              user_tokens: ["usr_def456"],
+              role: "editor",
+            },
+          },
+        ],
+      },
+    ],
+    inferredPrompts: [
+      {
+        input: "Set up a new Vantage Team called FinOps Enablement.",
+        expected: [{ toolName: TARGET, input: { name: "FinOps Enablement" } }],
+      },
+    ],
+  });
+}

--- a/evals/cases/teams/delete-team.eval.ts
+++ b/evals/cases/teams/delete-team.eval.ts
@@ -1,0 +1,23 @@
+import { buildToolCases } from "../../_lib/buildCases";
+
+const TARGET = "delete-team";
+
+export default function generateTests() {
+  return buildToolCases({
+    target: TARGET,
+    resource: "teams",
+    distractors: ["remove-team-member", "get-team", "update-team", "create-team"],
+    directPrompts: [
+      {
+        input: "Use delete-team to delete Vantage Team team_abc123.",
+        expected: [{ toolName: TARGET, input: { team_token: "team_abc123" } }],
+      },
+    ],
+    inferredPrompts: [
+      {
+        input: "Permanently remove the obsolete Vantage Team team_legacy456.",
+        expected: [{ toolName: TARGET, input: { team_token: "team_legacy456" } }],
+      },
+    ],
+  });
+}

--- a/evals/cases/teams/get-team-members.eval.ts
+++ b/evals/cases/teams/get-team-members.eval.ts
@@ -1,0 +1,23 @@
+import { buildToolCases } from "../../_lib/buildCases";
+
+const TARGET = "get-team-members";
+
+export default function generateTests() {
+  return buildToolCases({
+    target: TARGET,
+    resource: "teams",
+    distractors: ["get-team", "get-teams", "get-users", "add-team-member"],
+    directPrompts: [
+      {
+        input: "Use get-team-members to show page 3 of the members of Vantage Team team_abc123.",
+        expected: [{ toolName: TARGET, input: { team_token: "team_abc123", page: 3 } }],
+      },
+    ],
+    inferredPrompts: [
+      {
+        input: "Who belongs to Vantage Team team_abc123? Show me the second page.",
+        expected: [{ toolName: TARGET, input: { team_token: "team_abc123", page: 2 } }],
+      },
+    ],
+  });
+}

--- a/evals/cases/teams/get-team.eval.ts
+++ b/evals/cases/teams/get-team.eval.ts
@@ -1,0 +1,23 @@
+import { buildToolCases } from "../../_lib/buildCases";
+
+const TARGET = "get-team";
+
+export default function generateTests() {
+  return buildToolCases({
+    target: TARGET,
+    resource: "teams",
+    distractors: ["get-teams", "get-team-members", "update-team", "get-workspace"],
+    directPrompts: [
+      {
+        input: "Use get-team to retrieve Vantage Team team_abc123.",
+        expected: [{ toolName: TARGET, input: { token: "team_abc123" } }],
+      },
+    ],
+    inferredPrompts: [
+      {
+        input: "Show me the details for the Vantage Team with token team_platform789.",
+        expected: [{ toolName: TARGET, input: { token: "team_platform789" } }],
+      },
+    ],
+  });
+}

--- a/evals/cases/teams/get-teams.eval.ts
+++ b/evals/cases/teams/get-teams.eval.ts
@@ -1,0 +1,29 @@
+import { buildToolCases } from "../../_lib/buildCases";
+
+const TARGET = "get-teams";
+
+export default function generateTests() {
+  return buildToolCases({
+    target: TARGET,
+    resource: "teams",
+    distractors: ["get-team", "get-team-members", "get-users", "list-workspaces"],
+    directPrompts: [
+      {
+        input:
+          "Use get-teams to search page 2 for Vantage Teams named Platform that can access workspace wrkspc_abc123.",
+        expected: [
+          {
+            toolName: TARGET,
+            input: { page: 2, q: "Platform", workspace_token: "wrkspc_abc123" },
+          },
+        ],
+      },
+    ],
+    inferredPrompts: [
+      {
+        input: "Which Vantage Teams can access workspace wrkspc_abc123? Show page 3.",
+        expected: [{ toolName: TARGET, input: { page: 3, workspace_token: "wrkspc_abc123" } }],
+      },
+    ],
+  });
+}

--- a/evals/cases/teams/remove-team-member.eval.ts
+++ b/evals/cases/teams/remove-team-member.eval.ts
@@ -1,0 +1,33 @@
+import { buildToolCases } from "../../_lib/buildCases";
+
+const TARGET = "remove-team-member";
+
+export default function generateTests() {
+  return buildToolCases({
+    target: TARGET,
+    resource: "teams",
+    distractors: ["add-team-member", "get-team-members", "delete-team", "update-team"],
+    directPrompts: [
+      {
+        input: "Use remove-team-member to remove user usr_def456 from Vantage Team team_abc123.",
+        expected: [
+          {
+            toolName: TARGET,
+            input: { team_token: "team_abc123", user_token: "usr_def456" },
+          },
+        ],
+      },
+    ],
+    inferredPrompts: [
+      {
+        input: "Take user usr_legacy789 off the Vantage Team team_abc123 without deleting the user.",
+        expected: [
+          {
+            toolName: TARGET,
+            input: { team_token: "team_abc123", user_token: "usr_legacy789" },
+          },
+        ],
+      },
+    ],
+  });
+}

--- a/evals/cases/teams/update-team.eval.ts
+++ b/evals/cases/teams/update-team.eval.ts
@@ -1,0 +1,32 @@
+import { buildToolCases } from "../../_lib/buildCases";
+
+const TARGET = "update-team";
+
+export default function generateTests() {
+  return buildToolCases({
+    target: TARGET,
+    resource: "teams",
+    distractors: ["create-team", "get-team", "add-team-member", "update-workspace"],
+    directPrompts: [
+      {
+        input: "Use update-team to rename team_abc123 to Platform Engineering and clear its default Dashboard.",
+        expected: [
+          {
+            toolName: TARGET,
+            input: {
+              team_token: "team_abc123",
+              name: "Platform Engineering",
+              default_dashboard_token: null,
+            },
+          },
+        ],
+      },
+    ],
+    inferredPrompts: [
+      {
+        input: "The Vantage Team team_abc123 should now be called Cloud Efficiency.",
+        expected: [{ toolName: TARGET, input: { team_token: "team_abc123", name: "Cloud Efficiency" } }],
+      },
+    ],
+  });
+}

--- a/evals/promptfooconfig.ts
+++ b/evals/promptfooconfig.ts
@@ -1,24 +1,14 @@
-import { readdirSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { UnifiedConfig } from "promptfoo";
+import { discoverEvalCases, parseSelectedCasePaths } from "./_lib/evalScope";
 import { resolveEvalModel } from "./_lib/models";
 
 const here = dirname(fileURLToPath(import.meta.url));
 
-function casePaths(dir = join(here, "cases"), prefix = "cases"): string[] {
-  return readdirSync(dir, { withFileTypes: true })
-    .sort((a, b) => a.name.localeCompare(b.name))
-    .flatMap((entry) => {
-      const nextPrefix = `${prefix}/${entry.name}`;
-      if (entry.isDirectory()) {
-        return casePaths(join(dir, entry.name), nextPrefix);
-      }
-      return entry.name.endsWith(".eval.ts") ? [`file://${nextPrefix}`] : [];
-    });
-}
-
 const selected = resolveEvalModel(process.env.EVAL_MODEL);
+const discoveredCasePaths = discoverEvalCases(join(here, "cases")).map((evalCase) => evalCase.path);
+const selectedCasePaths = parseSelectedCasePaths(process.env.EVAL_CASE_PATHS, discoveredCasePaths);
 
 const config: Partial<UnifiedConfig> = {
   description: "Vantage MCP tool-selection evals",
@@ -32,7 +22,7 @@ const config: Partial<UnifiedConfig> = {
       },
     },
   ],
-  tests: casePaths(),
+  tests: selectedCasePaths,
   evaluateOptions: {
     maxConcurrency: 4,
   },

--- a/evals/results/gpt-5.6-luna/teams/add-team-member.json
+++ b/evals/results/gpt-5.6-luna/teams/add-team-member.json
@@ -1,0 +1,841 @@
+{
+  "evalId": null,
+  "results": {
+    "version": 3,
+    "timestamp": "2026-09-03T16:36:52.518Z",
+    "results": [
+      {
+        "cost": 0,
+        "gradingResult": {
+          "pass": true,
+          "score": 1,
+          "reason": "All assertions passed",
+          "namedScores": {},
+          "tokensUsed": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 0
+          },
+          "componentResults": [
+            {
+              "pass": true,
+              "score": 1,
+              "reason": "Expected tool call matched.",
+              "assertion": {
+                "type": "javascript",
+                "value": "file://_lib/assertToolCalls.ts"
+              }
+            }
+          ]
+        },
+        "id": "edf4af69-d660-44db-825e-b20204e7db78",
+        "latencyMs": 3650,
+        "namedScores": {},
+        "prompt": {
+          "raw": "Use add-team-member to add pat@example.com to Vantage Team team_abc123 as an integration owner.",
+          "label": "{{prompt}}",
+          "config": {
+            "disableVarExpansion": true
+          }
+        },
+        "promptId": "effa18501e44aafd9bc42a2f64ffc9b6350f94025520ca2ed382f9bdc4b6e982",
+        "promptIdx": 1,
+        "provider": {
+          "id": "tool-selection:gpt-5.6-luna:mixed",
+          "label": "gpt-5.6-luna · mixed"
+        },
+        "response": {
+          "output": {
+            "toolCalls": [
+              {
+                "toolName": "add-team-member",
+                "input": {
+                  "team_token": "team_abc123",
+                  "user_email": "pat@example.com",
+                  "role": "integration_owner"
+                }
+              }
+            ],
+            "text": ""
+          },
+          "metadata": {
+            "modelId": "gpt-5.6-luna",
+            "mode": "mixed",
+            "target": "add-team-member",
+            "toolNames": [
+              "add-team-member",
+              "remove-team-member",
+              "get-team-members",
+              "update-team",
+              "get-user"
+            ],
+            "toolCalls": [
+              {
+                "toolName": "add-team-member",
+                "input": {
+                  "team_token": "team_abc123",
+                  "user_email": "pat@example.com",
+                  "role": "integration_owner"
+                }
+              }
+            ]
+          }
+        },
+        "score": 1,
+        "success": true,
+        "testCase": {
+          "description": "add-team-member · direct · Use add-team-member to add pat@example.com to Vantage Team team_abc123 as an integration owner.",
+          "vars": {
+            "prompt": "Use add-team-member to add pat@example.com to Vantage Team team_abc123 as an integration owner.",
+            "target": "add-team-member",
+            "expected": [
+              {
+                "toolName": "add-team-member",
+                "input": {
+                  "team_token": "team_abc123",
+                  "user_email": "pat@example.com",
+                  "role": "integration_owner"
+                }
+              }
+            ],
+            "distractors": [
+              "remove-team-member",
+              "get-team-members",
+              "update-team",
+              "get-user"
+            ]
+          },
+          "options": {
+            "disableVarExpansion": true
+          },
+          "metadata": {
+            "tool": "add-team-member",
+            "resource": "teams",
+            "phrasing": "direct"
+          },
+          "assert": [
+            {
+              "type": "javascript",
+              "value": "file://_lib/assertToolCalls.ts"
+            }
+          ]
+        },
+        "testIdx": 0,
+        "tokenUsage": {
+          "prompt": 0,
+          "completion": 0,
+          "cached": 0,
+          "total": 0,
+          "numRequests": 1,
+          "completionDetails": {
+            "reasoning": 0,
+            "acceptedPrediction": 0,
+            "rejectedPrediction": 0,
+            "cacheReadInputTokens": 0,
+            "cacheCreationInputTokens": 0
+          },
+          "assertions": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 1,
+            "completionDetails": {
+              "reasoning": 0,
+              "acceptedPrediction": 0,
+              "rejectedPrediction": 0,
+              "cacheReadInputTokens": 0,
+              "cacheCreationInputTokens": 0
+            }
+          }
+        },
+        "vars": {
+          "prompt": "Use add-team-member to add pat@example.com to Vantage Team team_abc123 as an integration owner.",
+          "target": "add-team-member",
+          "expected": [
+            {
+              "toolName": "add-team-member",
+              "input": {
+                "team_token": "team_abc123",
+                "user_email": "pat@example.com",
+                "role": "integration_owner"
+              }
+            }
+          ],
+          "distractors": [
+            "remove-team-member",
+            "get-team-members",
+            "update-team",
+            "get-user"
+          ]
+        },
+        "metadata": {
+          "tool": "add-team-member",
+          "resource": "teams",
+          "phrasing": "direct",
+          "modelId": "gpt-5.6-luna",
+          "mode": "mixed",
+          "target": "add-team-member",
+          "toolNames": [
+            "add-team-member",
+            "remove-team-member",
+            "get-team-members",
+            "update-team",
+            "get-user"
+          ],
+          "toolCalls": [
+            {
+              "toolName": "add-team-member",
+              "input": {
+                "team_token": "team_abc123",
+                "user_email": "pat@example.com",
+                "role": "integration_owner"
+              }
+            }
+          ],
+          "_promptfooFileMetadata": {}
+        },
+        "failureReason": 0
+      },
+      {
+        "cost": 0,
+        "gradingResult": {
+          "pass": true,
+          "score": 1,
+          "reason": "All assertions passed",
+          "namedScores": {},
+          "tokensUsed": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 0
+          },
+          "componentResults": [
+            {
+              "pass": true,
+              "score": 1,
+              "reason": "Expected tool call matched.",
+              "assertion": {
+                "type": "javascript",
+                "value": "file://_lib/assertToolCalls.ts"
+              }
+            }
+          ]
+        },
+        "id": "ff5c6e1b-5ad5-470e-8d29-6c18182bc184",
+        "latencyMs": 3725,
+        "namedScores": {},
+        "prompt": {
+          "raw": "Use add-team-member to add pat@example.com to Vantage Team team_abc123 as an integration owner.",
+          "label": "{{prompt}}",
+          "config": {
+            "disableVarExpansion": true
+          }
+        },
+        "promptId": "effa18501e44aafd9bc42a2f64ffc9b6350f94025520ca2ed382f9bdc4b6e982",
+        "promptIdx": 0,
+        "provider": {
+          "id": "tool-selection:gpt-5.6-luna:isolated",
+          "label": "gpt-5.6-luna · isolated"
+        },
+        "response": {
+          "output": {
+            "toolCalls": [
+              {
+                "toolName": "add-team-member",
+                "input": {
+                  "team_token": "team_abc123",
+                  "user_email": "pat@example.com",
+                  "role": "integration_owner"
+                }
+              }
+            ],
+            "text": ""
+          },
+          "metadata": {
+            "modelId": "gpt-5.6-luna",
+            "mode": "isolated",
+            "target": "add-team-member",
+            "toolNames": [
+              "add-team-member"
+            ],
+            "toolCalls": [
+              {
+                "toolName": "add-team-member",
+                "input": {
+                  "team_token": "team_abc123",
+                  "user_email": "pat@example.com",
+                  "role": "integration_owner"
+                }
+              }
+            ]
+          }
+        },
+        "score": 1,
+        "success": true,
+        "testCase": {
+          "description": "add-team-member · direct · Use add-team-member to add pat@example.com to Vantage Team team_abc123 as an integration owner.",
+          "vars": {
+            "prompt": "Use add-team-member to add pat@example.com to Vantage Team team_abc123 as an integration owner.",
+            "target": "add-team-member",
+            "expected": [
+              {
+                "toolName": "add-team-member",
+                "input": {
+                  "team_token": "team_abc123",
+                  "user_email": "pat@example.com",
+                  "role": "integration_owner"
+                }
+              }
+            ],
+            "distractors": [
+              "remove-team-member",
+              "get-team-members",
+              "update-team",
+              "get-user"
+            ]
+          },
+          "options": {
+            "disableVarExpansion": true
+          },
+          "metadata": {
+            "tool": "add-team-member",
+            "resource": "teams",
+            "phrasing": "direct"
+          },
+          "assert": [
+            {
+              "type": "javascript",
+              "value": "file://_lib/assertToolCalls.ts"
+            }
+          ]
+        },
+        "testIdx": 0,
+        "tokenUsage": {
+          "prompt": 0,
+          "completion": 0,
+          "cached": 0,
+          "total": 0,
+          "numRequests": 1,
+          "completionDetails": {
+            "reasoning": 0,
+            "acceptedPrediction": 0,
+            "rejectedPrediction": 0,
+            "cacheReadInputTokens": 0,
+            "cacheCreationInputTokens": 0
+          },
+          "assertions": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 1,
+            "completionDetails": {
+              "reasoning": 0,
+              "acceptedPrediction": 0,
+              "rejectedPrediction": 0,
+              "cacheReadInputTokens": 0,
+              "cacheCreationInputTokens": 0
+            }
+          }
+        },
+        "vars": {
+          "prompt": "Use add-team-member to add pat@example.com to Vantage Team team_abc123 as an integration owner.",
+          "target": "add-team-member",
+          "expected": [
+            {
+              "toolName": "add-team-member",
+              "input": {
+                "team_token": "team_abc123",
+                "user_email": "pat@example.com",
+                "role": "integration_owner"
+              }
+            }
+          ],
+          "distractors": [
+            "remove-team-member",
+            "get-team-members",
+            "update-team",
+            "get-user"
+          ]
+        },
+        "metadata": {
+          "tool": "add-team-member",
+          "resource": "teams",
+          "phrasing": "direct",
+          "modelId": "gpt-5.6-luna",
+          "mode": "isolated",
+          "target": "add-team-member",
+          "toolNames": [
+            "add-team-member"
+          ],
+          "toolCalls": [
+            {
+              "toolName": "add-team-member",
+              "input": {
+                "team_token": "team_abc123",
+                "user_email": "pat@example.com",
+                "role": "integration_owner"
+              }
+            }
+          ],
+          "_promptfooFileMetadata": {}
+        },
+        "failureReason": 0
+      },
+      {
+        "cost": 0,
+        "gradingResult": {
+          "pass": true,
+          "score": 1,
+          "reason": "All assertions passed",
+          "namedScores": {},
+          "tokensUsed": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 0
+          },
+          "componentResults": [
+            {
+              "pass": true,
+              "score": 1,
+              "reason": "Expected tool call matched.",
+              "assertion": {
+                "type": "javascript",
+                "value": "file://_lib/assertToolCalls.ts"
+              }
+            }
+          ]
+        },
+        "id": "0cd8ca5f-6287-4ea3-bc2f-66b7fff927dd",
+        "latencyMs": 2831,
+        "namedScores": {},
+        "prompt": {
+          "raw": "Make lee@example.com a viewer on the Vantage Team team_abc123.",
+          "label": "{{prompt}}",
+          "config": {
+            "disableVarExpansion": true
+          }
+        },
+        "promptId": "effa18501e44aafd9bc42a2f64ffc9b6350f94025520ca2ed382f9bdc4b6e982",
+        "promptIdx": 1,
+        "provider": {
+          "id": "tool-selection:gpt-5.6-luna:mixed",
+          "label": "gpt-5.6-luna · mixed"
+        },
+        "response": {
+          "output": {
+            "toolCalls": [
+              {
+                "toolName": "add-team-member",
+                "input": {
+                  "team_token": "team_abc123",
+                  "user_email": "lee@example.com",
+                  "role": "viewer"
+                }
+              }
+            ],
+            "text": ""
+          },
+          "metadata": {
+            "modelId": "gpt-5.6-luna",
+            "mode": "mixed",
+            "target": "add-team-member",
+            "toolNames": [
+              "add-team-member",
+              "remove-team-member",
+              "get-team-members",
+              "update-team",
+              "get-user"
+            ],
+            "toolCalls": [
+              {
+                "toolName": "add-team-member",
+                "input": {
+                  "team_token": "team_abc123",
+                  "user_email": "lee@example.com",
+                  "role": "viewer"
+                }
+              }
+            ]
+          }
+        },
+        "score": 1,
+        "success": true,
+        "testCase": {
+          "description": "add-team-member · inferred · Make lee@example.com a viewer on the Vantage Team team_abc123.",
+          "vars": {
+            "prompt": "Make lee@example.com a viewer on the Vantage Team team_abc123.",
+            "target": "add-team-member",
+            "expected": [
+              {
+                "toolName": "add-team-member",
+                "input": {
+                  "team_token": "team_abc123",
+                  "user_email": "lee@example.com",
+                  "role": "viewer"
+                }
+              }
+            ],
+            "distractors": [
+              "remove-team-member",
+              "get-team-members",
+              "update-team",
+              "get-user"
+            ]
+          },
+          "options": {
+            "disableVarExpansion": true
+          },
+          "metadata": {
+            "tool": "add-team-member",
+            "resource": "teams",
+            "phrasing": "inferred"
+          },
+          "assert": [
+            {
+              "type": "javascript",
+              "value": "file://_lib/assertToolCalls.ts"
+            }
+          ]
+        },
+        "testIdx": 1,
+        "tokenUsage": {
+          "prompt": 0,
+          "completion": 0,
+          "cached": 0,
+          "total": 0,
+          "numRequests": 1,
+          "completionDetails": {
+            "reasoning": 0,
+            "acceptedPrediction": 0,
+            "rejectedPrediction": 0,
+            "cacheReadInputTokens": 0,
+            "cacheCreationInputTokens": 0
+          },
+          "assertions": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 1,
+            "completionDetails": {
+              "reasoning": 0,
+              "acceptedPrediction": 0,
+              "rejectedPrediction": 0,
+              "cacheReadInputTokens": 0,
+              "cacheCreationInputTokens": 0
+            }
+          }
+        },
+        "vars": {
+          "prompt": "Make lee@example.com a viewer on the Vantage Team team_abc123.",
+          "target": "add-team-member",
+          "expected": [
+            {
+              "toolName": "add-team-member",
+              "input": {
+                "team_token": "team_abc123",
+                "user_email": "lee@example.com",
+                "role": "viewer"
+              }
+            }
+          ],
+          "distractors": [
+            "remove-team-member",
+            "get-team-members",
+            "update-team",
+            "get-user"
+          ]
+        },
+        "metadata": {
+          "tool": "add-team-member",
+          "resource": "teams",
+          "phrasing": "inferred",
+          "modelId": "gpt-5.6-luna",
+          "mode": "mixed",
+          "target": "add-team-member",
+          "toolNames": [
+            "add-team-member",
+            "remove-team-member",
+            "get-team-members",
+            "update-team",
+            "get-user"
+          ],
+          "toolCalls": [
+            {
+              "toolName": "add-team-member",
+              "input": {
+                "team_token": "team_abc123",
+                "user_email": "lee@example.com",
+                "role": "viewer"
+              }
+            }
+          ],
+          "_promptfooFileMetadata": {}
+        },
+        "failureReason": 0
+      },
+      {
+        "cost": 0,
+        "gradingResult": {
+          "pass": true,
+          "score": 1,
+          "reason": "All assertions passed",
+          "namedScores": {},
+          "tokensUsed": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 0
+          },
+          "componentResults": [
+            {
+              "pass": true,
+              "score": 1,
+              "reason": "Expected tool call matched.",
+              "assertion": {
+                "type": "javascript",
+                "value": "file://_lib/assertToolCalls.ts"
+              }
+            }
+          ]
+        },
+        "id": "915fc4e5-c223-4f0c-9ef9-3223da9973ad",
+        "latencyMs": 2923,
+        "namedScores": {},
+        "prompt": {
+          "raw": "Make lee@example.com a viewer on the Vantage Team team_abc123.",
+          "label": "{{prompt}}",
+          "config": {
+            "disableVarExpansion": true
+          }
+        },
+        "promptId": "effa18501e44aafd9bc42a2f64ffc9b6350f94025520ca2ed382f9bdc4b6e982",
+        "promptIdx": 0,
+        "provider": {
+          "id": "tool-selection:gpt-5.6-luna:isolated",
+          "label": "gpt-5.6-luna · isolated"
+        },
+        "response": {
+          "output": {
+            "toolCalls": [
+              {
+                "toolName": "add-team-member",
+                "input": {
+                  "team_token": "team_abc123",
+                  "user_email": "lee@example.com",
+                  "role": "viewer"
+                }
+              }
+            ],
+            "text": ""
+          },
+          "metadata": {
+            "modelId": "gpt-5.6-luna",
+            "mode": "isolated",
+            "target": "add-team-member",
+            "toolNames": [
+              "add-team-member"
+            ],
+            "toolCalls": [
+              {
+                "toolName": "add-team-member",
+                "input": {
+                  "team_token": "team_abc123",
+                  "user_email": "lee@example.com",
+                  "role": "viewer"
+                }
+              }
+            ]
+          }
+        },
+        "score": 1,
+        "success": true,
+        "testCase": {
+          "description": "add-team-member · inferred · Make lee@example.com a viewer on the Vantage Team team_abc123.",
+          "vars": {
+            "prompt": "Make lee@example.com a viewer on the Vantage Team team_abc123.",
+            "target": "add-team-member",
+            "expected": [
+              {
+                "toolName": "add-team-member",
+                "input": {
+                  "team_token": "team_abc123",
+                  "user_email": "lee@example.com",
+                  "role": "viewer"
+                }
+              }
+            ],
+            "distractors": [
+              "remove-team-member",
+              "get-team-members",
+              "update-team",
+              "get-user"
+            ]
+          },
+          "options": {
+            "disableVarExpansion": true
+          },
+          "metadata": {
+            "tool": "add-team-member",
+            "resource": "teams",
+            "phrasing": "inferred"
+          },
+          "assert": [
+            {
+              "type": "javascript",
+              "value": "file://_lib/assertToolCalls.ts"
+            }
+          ]
+        },
+        "testIdx": 1,
+        "tokenUsage": {
+          "prompt": 0,
+          "completion": 0,
+          "cached": 0,
+          "total": 0,
+          "numRequests": 1,
+          "completionDetails": {
+            "reasoning": 0,
+            "acceptedPrediction": 0,
+            "rejectedPrediction": 0,
+            "cacheReadInputTokens": 0,
+            "cacheCreationInputTokens": 0
+          },
+          "assertions": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 1,
+            "completionDetails": {
+              "reasoning": 0,
+              "acceptedPrediction": 0,
+              "rejectedPrediction": 0,
+              "cacheReadInputTokens": 0,
+              "cacheCreationInputTokens": 0
+            }
+          }
+        },
+        "vars": {
+          "prompt": "Make lee@example.com a viewer on the Vantage Team team_abc123.",
+          "target": "add-team-member",
+          "expected": [
+            {
+              "toolName": "add-team-member",
+              "input": {
+                "team_token": "team_abc123",
+                "user_email": "lee@example.com",
+                "role": "viewer"
+              }
+            }
+          ],
+          "distractors": [
+            "remove-team-member",
+            "get-team-members",
+            "update-team",
+            "get-user"
+          ]
+        },
+        "metadata": {
+          "tool": "add-team-member",
+          "resource": "teams",
+          "phrasing": "inferred",
+          "modelId": "gpt-5.6-luna",
+          "mode": "isolated",
+          "target": "add-team-member",
+          "toolNames": [
+            "add-team-member"
+          ],
+          "toolCalls": [
+            {
+              "toolName": "add-team-member",
+              "input": {
+                "team_token": "team_abc123",
+                "user_email": "lee@example.com",
+                "role": "viewer"
+              }
+            }
+          ],
+          "_promptfooFileMetadata": {}
+        },
+        "failureReason": 0
+      }
+    ],
+    "prompts": [],
+    "stats": {
+      "successes": 4,
+      "failures": 0,
+      "errors": 0,
+      "tokenUsage": {
+        "prompt": 0,
+        "completion": 0,
+        "cached": 0,
+        "total": 0,
+        "numRequests": 4,
+        "completionDetails": {
+          "reasoning": 0,
+          "acceptedPrediction": 0,
+          "rejectedPrediction": 0
+        }
+      }
+    }
+  },
+  "config": {
+    "tags": {},
+    "description": "Vantage MCP tool-selection evals",
+    "prompts": [
+      "{{prompt}}"
+    ],
+    "providers": [
+      {
+        "id": "file://_lib/provider.ts",
+        "label": "gpt-5.6-luna · isolated",
+        "config": {
+          "modelId": "gpt-5.6-luna",
+          "mode": "isolated"
+        }
+      },
+      {
+        "id": "file://_lib/provider.ts",
+        "label": "gpt-5.6-luna · mixed",
+        "config": {
+          "modelId": "gpt-5.6-luna",
+          "mode": "mixed"
+        }
+      }
+    ],
+    "tests": [
+      "file://cases/cost-providers/get-cost-provider-accounts.eval.ts",
+      "file://cases/current-user/get-myself.eval.ts",
+      "file://cases/teams/add-team-member.eval.ts",
+      "file://cases/teams/create-team.eval.ts",
+      "file://cases/teams/delete-team.eval.ts",
+      "file://cases/teams/get-team-members.eval.ts",
+      "file://cases/teams/remove-team-member.eval.ts",
+      "file://cases/teams/update-team.eval.ts"
+    ],
+    "env": {},
+    "extensions": [],
+    "metadata": {},
+    "evaluateOptions": {
+      "maxConcurrency": 4
+    }
+  },
+  "shareableUrl": null,
+  "metadata": {
+    "promptfooVersion": "0.122.0",
+    "nodeVersion": "v23.11.0",
+    "platform": "darwin",
+    "arch": "arm64",
+    "exportedAt": "2026-09-03T16:36:52.200Z",
+    "evaluationCreatedAt": "2026-09-03T16:36:48.386Z"
+  }
+}

--- a/evals/results/gpt-5.6-luna/teams/create-team.json
+++ b/evals/results/gpt-5.6-luna/teams/create-team.json
@@ -1,0 +1,871 @@
+{
+  "evalId": null,
+  "results": {
+    "version": 3,
+    "timestamp": "2026-09-03T16:53:47.682Z",
+    "results": [
+      {
+        "cost": 0,
+        "gradingResult": {
+          "pass": true,
+          "score": 1,
+          "reason": "All assertions passed",
+          "namedScores": {},
+          "tokensUsed": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 0
+          },
+          "componentResults": [
+            {
+              "pass": true,
+              "score": 1,
+              "reason": "Expected tool call matched.",
+              "assertion": {
+                "type": "javascript",
+                "value": "file://_lib/assertToolCalls.ts"
+              }
+            }
+          ]
+        },
+        "id": "b1c38eb9-716e-48f0-b424-39c881a1709d",
+        "latencyMs": 2493,
+        "namedScores": {},
+        "prompt": {
+          "raw": "Use create-team to create a Vantage Team named Platform Ops in workspace wrkspc_abc123 and give user usr_def456 the editor role.",
+          "label": "{{prompt}}",
+          "config": {
+            "disableVarExpansion": true
+          }
+        },
+        "promptId": "effa18501e44aafd9bc42a2f64ffc9b6350f94025520ca2ed382f9bdc4b6e982",
+        "promptIdx": 1,
+        "provider": {
+          "id": "tool-selection:gpt-5.6-luna:mixed",
+          "label": "gpt-5.6-luna · mixed"
+        },
+        "response": {
+          "output": {
+            "toolCalls": [
+              {
+                "toolName": "create-team",
+                "input": {
+                  "name": "Platform Ops",
+                  "workspace_tokens": [
+                    "wrkspc_abc123"
+                  ],
+                  "user_tokens": [
+                    "usr_def456"
+                  ],
+                  "role": "editor"
+                }
+              }
+            ],
+            "text": ""
+          },
+          "metadata": {
+            "modelId": "gpt-5.6-luna",
+            "mode": "mixed",
+            "target": "create-team",
+            "toolNames": [
+              "create-team",
+              "update-team",
+              "add-team-member",
+              "create-workspace",
+              "get-teams"
+            ],
+            "toolCalls": [
+              {
+                "toolName": "create-team",
+                "input": {
+                  "name": "Platform Ops",
+                  "workspace_tokens": [
+                    "wrkspc_abc123"
+                  ],
+                  "user_tokens": [
+                    "usr_def456"
+                  ],
+                  "role": "editor"
+                }
+              }
+            ]
+          }
+        },
+        "score": 1,
+        "success": true,
+        "testCase": {
+          "description": "create-team · direct · Use create-team to create a Vantage Team named Platform Ops in workspace wrkspc_abc123 and give user usr_def456 the editor role.",
+          "vars": {
+            "prompt": "Use create-team to create a Vantage Team named Platform Ops in workspace wrkspc_abc123 and give user usr_def456 the editor role.",
+            "target": "create-team",
+            "expected": [
+              {
+                "toolName": "create-team",
+                "input": {
+                  "name": "Platform Ops",
+                  "workspace_tokens": [
+                    "wrkspc_abc123"
+                  ],
+                  "user_tokens": [
+                    "usr_def456"
+                  ],
+                  "role": "editor"
+                }
+              }
+            ],
+            "distractors": [
+              "update-team",
+              "add-team-member",
+              "create-workspace",
+              "get-teams"
+            ]
+          },
+          "options": {
+            "disableVarExpansion": true
+          },
+          "metadata": {
+            "tool": "create-team",
+            "resource": "teams",
+            "phrasing": "direct"
+          },
+          "assert": [
+            {
+              "type": "javascript",
+              "value": "file://_lib/assertToolCalls.ts"
+            }
+          ]
+        },
+        "testIdx": 0,
+        "tokenUsage": {
+          "prompt": 0,
+          "completion": 0,
+          "cached": 0,
+          "total": 0,
+          "numRequests": 1,
+          "completionDetails": {
+            "reasoning": 0,
+            "acceptedPrediction": 0,
+            "rejectedPrediction": 0,
+            "cacheReadInputTokens": 0,
+            "cacheCreationInputTokens": 0
+          },
+          "assertions": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 1,
+            "completionDetails": {
+              "reasoning": 0,
+              "acceptedPrediction": 0,
+              "rejectedPrediction": 0,
+              "cacheReadInputTokens": 0,
+              "cacheCreationInputTokens": 0
+            }
+          }
+        },
+        "vars": {
+          "prompt": "Use create-team to create a Vantage Team named Platform Ops in workspace wrkspc_abc123 and give user usr_def456 the editor role.",
+          "target": "create-team",
+          "expected": [
+            {
+              "toolName": "create-team",
+              "input": {
+                "name": "Platform Ops",
+                "workspace_tokens": [
+                  "wrkspc_abc123"
+                ],
+                "user_tokens": [
+                  "usr_def456"
+                ],
+                "role": "editor"
+              }
+            }
+          ],
+          "distractors": [
+            "update-team",
+            "add-team-member",
+            "create-workspace",
+            "get-teams"
+          ]
+        },
+        "metadata": {
+          "tool": "create-team",
+          "resource": "teams",
+          "phrasing": "direct",
+          "modelId": "gpt-5.6-luna",
+          "mode": "mixed",
+          "target": "create-team",
+          "toolNames": [
+            "create-team",
+            "update-team",
+            "add-team-member",
+            "create-workspace",
+            "get-teams"
+          ],
+          "toolCalls": [
+            {
+              "toolName": "create-team",
+              "input": {
+                "name": "Platform Ops",
+                "workspace_tokens": [
+                  "wrkspc_abc123"
+                ],
+                "user_tokens": [
+                  "usr_def456"
+                ],
+                "role": "editor"
+              }
+            }
+          ],
+          "_promptfooFileMetadata": {}
+        },
+        "failureReason": 0
+      },
+      {
+        "cost": 0,
+        "gradingResult": {
+          "pass": true,
+          "score": 1,
+          "reason": "All assertions passed",
+          "namedScores": {},
+          "tokensUsed": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 0
+          },
+          "componentResults": [
+            {
+              "pass": true,
+              "score": 1,
+              "reason": "Expected tool call matched.",
+              "assertion": {
+                "type": "javascript",
+                "value": "file://_lib/assertToolCalls.ts"
+              }
+            }
+          ]
+        },
+        "id": "068d51fc-9bc1-43f7-8baf-dfcf45ac0212",
+        "latencyMs": 2669,
+        "namedScores": {},
+        "prompt": {
+          "raw": "Use create-team to create a Vantage Team named Platform Ops in workspace wrkspc_abc123 and give user usr_def456 the editor role.",
+          "label": "{{prompt}}",
+          "config": {
+            "disableVarExpansion": true
+          }
+        },
+        "promptId": "effa18501e44aafd9bc42a2f64ffc9b6350f94025520ca2ed382f9bdc4b6e982",
+        "promptIdx": 0,
+        "provider": {
+          "id": "tool-selection:gpt-5.6-luna:isolated",
+          "label": "gpt-5.6-luna · isolated"
+        },
+        "response": {
+          "output": {
+            "toolCalls": [
+              {
+                "toolName": "create-team",
+                "input": {
+                  "name": "Platform Ops",
+                  "workspace_tokens": [
+                    "wrkspc_abc123"
+                  ],
+                  "user_tokens": [
+                    "usr_def456"
+                  ],
+                  "role": "editor"
+                }
+              }
+            ],
+            "text": ""
+          },
+          "metadata": {
+            "modelId": "gpt-5.6-luna",
+            "mode": "isolated",
+            "target": "create-team",
+            "toolNames": [
+              "create-team"
+            ],
+            "toolCalls": [
+              {
+                "toolName": "create-team",
+                "input": {
+                  "name": "Platform Ops",
+                  "workspace_tokens": [
+                    "wrkspc_abc123"
+                  ],
+                  "user_tokens": [
+                    "usr_def456"
+                  ],
+                  "role": "editor"
+                }
+              }
+            ]
+          }
+        },
+        "score": 1,
+        "success": true,
+        "testCase": {
+          "description": "create-team · direct · Use create-team to create a Vantage Team named Platform Ops in workspace wrkspc_abc123 and give user usr_def456 the editor role.",
+          "vars": {
+            "prompt": "Use create-team to create a Vantage Team named Platform Ops in workspace wrkspc_abc123 and give user usr_def456 the editor role.",
+            "target": "create-team",
+            "expected": [
+              {
+                "toolName": "create-team",
+                "input": {
+                  "name": "Platform Ops",
+                  "workspace_tokens": [
+                    "wrkspc_abc123"
+                  ],
+                  "user_tokens": [
+                    "usr_def456"
+                  ],
+                  "role": "editor"
+                }
+              }
+            ],
+            "distractors": [
+              "update-team",
+              "add-team-member",
+              "create-workspace",
+              "get-teams"
+            ]
+          },
+          "options": {
+            "disableVarExpansion": true
+          },
+          "metadata": {
+            "tool": "create-team",
+            "resource": "teams",
+            "phrasing": "direct"
+          },
+          "assert": [
+            {
+              "type": "javascript",
+              "value": "file://_lib/assertToolCalls.ts"
+            }
+          ]
+        },
+        "testIdx": 0,
+        "tokenUsage": {
+          "prompt": 0,
+          "completion": 0,
+          "cached": 0,
+          "total": 0,
+          "numRequests": 1,
+          "completionDetails": {
+            "reasoning": 0,
+            "acceptedPrediction": 0,
+            "rejectedPrediction": 0,
+            "cacheReadInputTokens": 0,
+            "cacheCreationInputTokens": 0
+          },
+          "assertions": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 1,
+            "completionDetails": {
+              "reasoning": 0,
+              "acceptedPrediction": 0,
+              "rejectedPrediction": 0,
+              "cacheReadInputTokens": 0,
+              "cacheCreationInputTokens": 0
+            }
+          }
+        },
+        "vars": {
+          "prompt": "Use create-team to create a Vantage Team named Platform Ops in workspace wrkspc_abc123 and give user usr_def456 the editor role.",
+          "target": "create-team",
+          "expected": [
+            {
+              "toolName": "create-team",
+              "input": {
+                "name": "Platform Ops",
+                "workspace_tokens": [
+                  "wrkspc_abc123"
+                ],
+                "user_tokens": [
+                  "usr_def456"
+                ],
+                "role": "editor"
+              }
+            }
+          ],
+          "distractors": [
+            "update-team",
+            "add-team-member",
+            "create-workspace",
+            "get-teams"
+          ]
+        },
+        "metadata": {
+          "tool": "create-team",
+          "resource": "teams",
+          "phrasing": "direct",
+          "modelId": "gpt-5.6-luna",
+          "mode": "isolated",
+          "target": "create-team",
+          "toolNames": [
+            "create-team"
+          ],
+          "toolCalls": [
+            {
+              "toolName": "create-team",
+              "input": {
+                "name": "Platform Ops",
+                "workspace_tokens": [
+                  "wrkspc_abc123"
+                ],
+                "user_tokens": [
+                  "usr_def456"
+                ],
+                "role": "editor"
+              }
+            }
+          ],
+          "_promptfooFileMetadata": {}
+        },
+        "failureReason": 0
+      },
+      {
+        "cost": 0,
+        "gradingResult": {
+          "pass": true,
+          "score": 1,
+          "reason": "All assertions passed",
+          "namedScores": {},
+          "tokensUsed": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 0
+          },
+          "componentResults": [
+            {
+              "pass": true,
+              "score": 1,
+              "reason": "Expected tool call matched.",
+              "assertion": {
+                "type": "javascript",
+                "value": "file://_lib/assertToolCalls.ts"
+              }
+            }
+          ]
+        },
+        "id": "736d77ac-6507-428d-99d3-4cb0145cf06e",
+        "latencyMs": 2483,
+        "namedScores": {},
+        "prompt": {
+          "raw": "Set up a new Vantage Team called FinOps Enablement.",
+          "label": "{{prompt}}",
+          "config": {
+            "disableVarExpansion": true
+          }
+        },
+        "promptId": "effa18501e44aafd9bc42a2f64ffc9b6350f94025520ca2ed382f9bdc4b6e982",
+        "promptIdx": 0,
+        "provider": {
+          "id": "tool-selection:gpt-5.6-luna:isolated",
+          "label": "gpt-5.6-luna · isolated"
+        },
+        "response": {
+          "output": {
+            "toolCalls": [
+              {
+                "toolName": "create-team",
+                "input": {
+                  "name": "FinOps Enablement"
+                }
+              }
+            ],
+            "text": ""
+          },
+          "metadata": {
+            "modelId": "gpt-5.6-luna",
+            "mode": "isolated",
+            "target": "create-team",
+            "toolNames": [
+              "create-team"
+            ],
+            "toolCalls": [
+              {
+                "toolName": "create-team",
+                "input": {
+                  "name": "FinOps Enablement"
+                }
+              }
+            ]
+          }
+        },
+        "score": 1,
+        "success": true,
+        "testCase": {
+          "description": "create-team · inferred · Set up a new Vantage Team called FinOps Enablement.",
+          "vars": {
+            "prompt": "Set up a new Vantage Team called FinOps Enablement.",
+            "target": "create-team",
+            "expected": [
+              {
+                "toolName": "create-team",
+                "input": {
+                  "name": "FinOps Enablement"
+                }
+              }
+            ],
+            "distractors": [
+              "update-team",
+              "add-team-member",
+              "create-workspace",
+              "get-teams"
+            ]
+          },
+          "options": {
+            "disableVarExpansion": true
+          },
+          "metadata": {
+            "tool": "create-team",
+            "resource": "teams",
+            "phrasing": "inferred"
+          },
+          "assert": [
+            {
+              "type": "javascript",
+              "value": "file://_lib/assertToolCalls.ts"
+            }
+          ]
+        },
+        "testIdx": 1,
+        "tokenUsage": {
+          "prompt": 0,
+          "completion": 0,
+          "cached": 0,
+          "total": 0,
+          "numRequests": 1,
+          "completionDetails": {
+            "reasoning": 0,
+            "acceptedPrediction": 0,
+            "rejectedPrediction": 0,
+            "cacheReadInputTokens": 0,
+            "cacheCreationInputTokens": 0
+          },
+          "assertions": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 1,
+            "completionDetails": {
+              "reasoning": 0,
+              "acceptedPrediction": 0,
+              "rejectedPrediction": 0,
+              "cacheReadInputTokens": 0,
+              "cacheCreationInputTokens": 0
+            }
+          }
+        },
+        "vars": {
+          "prompt": "Set up a new Vantage Team called FinOps Enablement.",
+          "target": "create-team",
+          "expected": [
+            {
+              "toolName": "create-team",
+              "input": {
+                "name": "FinOps Enablement"
+              }
+            }
+          ],
+          "distractors": [
+            "update-team",
+            "add-team-member",
+            "create-workspace",
+            "get-teams"
+          ]
+        },
+        "metadata": {
+          "tool": "create-team",
+          "resource": "teams",
+          "phrasing": "inferred",
+          "modelId": "gpt-5.6-luna",
+          "mode": "isolated",
+          "target": "create-team",
+          "toolNames": [
+            "create-team"
+          ],
+          "toolCalls": [
+            {
+              "toolName": "create-team",
+              "input": {
+                "name": "FinOps Enablement"
+              }
+            }
+          ],
+          "_promptfooFileMetadata": {}
+        },
+        "failureReason": 0
+      },
+      {
+        "cost": 0,
+        "gradingResult": {
+          "pass": true,
+          "score": 1,
+          "reason": "All assertions passed",
+          "namedScores": {},
+          "tokensUsed": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 0
+          },
+          "componentResults": [
+            {
+              "pass": true,
+              "score": 1,
+              "reason": "Expected tool call matched.",
+              "assertion": {
+                "type": "javascript",
+                "value": "file://_lib/assertToolCalls.ts"
+              }
+            }
+          ]
+        },
+        "id": "3f796400-97e9-45e9-9966-e6218b529b0d",
+        "latencyMs": 2843,
+        "namedScores": {},
+        "prompt": {
+          "raw": "Set up a new Vantage Team called FinOps Enablement.",
+          "label": "{{prompt}}",
+          "config": {
+            "disableVarExpansion": true
+          }
+        },
+        "promptId": "effa18501e44aafd9bc42a2f64ffc9b6350f94025520ca2ed382f9bdc4b6e982",
+        "promptIdx": 1,
+        "provider": {
+          "id": "tool-selection:gpt-5.6-luna:mixed",
+          "label": "gpt-5.6-luna · mixed"
+        },
+        "response": {
+          "output": {
+            "toolCalls": [
+              {
+                "toolName": "create-team",
+                "input": {
+                  "name": "FinOps Enablement"
+                }
+              }
+            ],
+            "text": ""
+          },
+          "metadata": {
+            "modelId": "gpt-5.6-luna",
+            "mode": "mixed",
+            "target": "create-team",
+            "toolNames": [
+              "create-team",
+              "update-team",
+              "add-team-member",
+              "create-workspace",
+              "get-teams"
+            ],
+            "toolCalls": [
+              {
+                "toolName": "create-team",
+                "input": {
+                  "name": "FinOps Enablement"
+                }
+              }
+            ]
+          }
+        },
+        "score": 1,
+        "success": true,
+        "testCase": {
+          "description": "create-team · inferred · Set up a new Vantage Team called FinOps Enablement.",
+          "vars": {
+            "prompt": "Set up a new Vantage Team called FinOps Enablement.",
+            "target": "create-team",
+            "expected": [
+              {
+                "toolName": "create-team",
+                "input": {
+                  "name": "FinOps Enablement"
+                }
+              }
+            ],
+            "distractors": [
+              "update-team",
+              "add-team-member",
+              "create-workspace",
+              "get-teams"
+            ]
+          },
+          "options": {
+            "disableVarExpansion": true
+          },
+          "metadata": {
+            "tool": "create-team",
+            "resource": "teams",
+            "phrasing": "inferred"
+          },
+          "assert": [
+            {
+              "type": "javascript",
+              "value": "file://_lib/assertToolCalls.ts"
+            }
+          ]
+        },
+        "testIdx": 1,
+        "tokenUsage": {
+          "prompt": 0,
+          "completion": 0,
+          "cached": 0,
+          "total": 0,
+          "numRequests": 1,
+          "completionDetails": {
+            "reasoning": 0,
+            "acceptedPrediction": 0,
+            "rejectedPrediction": 0,
+            "cacheReadInputTokens": 0,
+            "cacheCreationInputTokens": 0
+          },
+          "assertions": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 1,
+            "completionDetails": {
+              "reasoning": 0,
+              "acceptedPrediction": 0,
+              "rejectedPrediction": 0,
+              "cacheReadInputTokens": 0,
+              "cacheCreationInputTokens": 0
+            }
+          }
+        },
+        "vars": {
+          "prompt": "Set up a new Vantage Team called FinOps Enablement.",
+          "target": "create-team",
+          "expected": [
+            {
+              "toolName": "create-team",
+              "input": {
+                "name": "FinOps Enablement"
+              }
+            }
+          ],
+          "distractors": [
+            "update-team",
+            "add-team-member",
+            "create-workspace",
+            "get-teams"
+          ]
+        },
+        "metadata": {
+          "tool": "create-team",
+          "resource": "teams",
+          "phrasing": "inferred",
+          "modelId": "gpt-5.6-luna",
+          "mode": "mixed",
+          "target": "create-team",
+          "toolNames": [
+            "create-team",
+            "update-team",
+            "add-team-member",
+            "create-workspace",
+            "get-teams"
+          ],
+          "toolCalls": [
+            {
+              "toolName": "create-team",
+              "input": {
+                "name": "FinOps Enablement"
+              }
+            }
+          ],
+          "_promptfooFileMetadata": {}
+        },
+        "failureReason": 0
+      }
+    ],
+    "prompts": [],
+    "stats": {
+      "successes": 4,
+      "failures": 0,
+      "errors": 0,
+      "tokenUsage": {
+        "prompt": 0,
+        "completion": 0,
+        "cached": 0,
+        "total": 0,
+        "numRequests": 4,
+        "completionDetails": {
+          "reasoning": 0,
+          "acceptedPrediction": 0,
+          "rejectedPrediction": 0
+        }
+      }
+    }
+  },
+  "config": {
+    "tags": {},
+    "description": "Vantage MCP tool-selection evals",
+    "prompts": [
+      "{{prompt}}"
+    ],
+    "providers": [
+      {
+        "id": "file://_lib/provider.ts",
+        "label": "gpt-5.6-luna · isolated",
+        "config": {
+          "modelId": "gpt-5.6-luna",
+          "mode": "isolated"
+        }
+      },
+      {
+        "id": "file://_lib/provider.ts",
+        "label": "gpt-5.6-luna · mixed",
+        "config": {
+          "modelId": "gpt-5.6-luna",
+          "mode": "mixed"
+        }
+      }
+    ],
+    "tests": [
+      "file://cases/cost-providers/get-cost-provider-accounts.eval.ts",
+      "file://cases/current-user/get-myself.eval.ts",
+      "file://cases/teams/add-team-member.eval.ts",
+      "file://cases/teams/create-team.eval.ts",
+      "file://cases/teams/delete-team.eval.ts",
+      "file://cases/teams/get-team-members.eval.ts",
+      "file://cases/teams/remove-team-member.eval.ts",
+      "file://cases/teams/update-team.eval.ts"
+    ],
+    "env": {},
+    "extensions": [],
+    "metadata": {},
+    "evaluateOptions": {
+      "maxConcurrency": 4
+    }
+  },
+  "shareableUrl": null,
+  "metadata": {
+    "promptfooVersion": "0.122.0",
+    "nodeVersion": "v23.11.0",
+    "platform": "darwin",
+    "arch": "arm64",
+    "exportedAt": "2026-09-03T16:53:47.356Z",
+    "evaluationCreatedAt": "2026-09-03T16:53:44.415Z"
+  }
+}

--- a/evals/results/gpt-5.6-luna/teams/delete-team.json
+++ b/evals/results/gpt-5.6-luna/teams/delete-team.json
@@ -1,0 +1,801 @@
+{
+  "evalId": null,
+  "results": {
+    "version": 3,
+    "timestamp": "2026-09-03T16:54:21.446Z",
+    "results": [
+      {
+        "cost": 0,
+        "gradingResult": {
+          "pass": true,
+          "score": 1,
+          "reason": "All assertions passed",
+          "namedScores": {},
+          "tokensUsed": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 0
+          },
+          "componentResults": [
+            {
+              "pass": true,
+              "score": 1,
+              "reason": "Expected tool call matched.",
+              "assertion": {
+                "type": "javascript",
+                "value": "file://_lib/assertToolCalls.ts"
+              }
+            }
+          ]
+        },
+        "id": "299d3e13-7b0e-4b1c-a035-7edd16f0a81e",
+        "latencyMs": 1462,
+        "namedScores": {},
+        "prompt": {
+          "raw": "Use delete-team to delete Vantage Team team_abc123.",
+          "label": "{{prompt}}",
+          "config": {
+            "disableVarExpansion": true
+          }
+        },
+        "promptId": "effa18501e44aafd9bc42a2f64ffc9b6350f94025520ca2ed382f9bdc4b6e982",
+        "promptIdx": 0,
+        "provider": {
+          "id": "tool-selection:gpt-5.6-luna:isolated",
+          "label": "gpt-5.6-luna · isolated"
+        },
+        "response": {
+          "output": {
+            "toolCalls": [
+              {
+                "toolName": "delete-team",
+                "input": {
+                  "team_token": "team_abc123"
+                }
+              }
+            ],
+            "text": ""
+          },
+          "metadata": {
+            "modelId": "gpt-5.6-luna",
+            "mode": "isolated",
+            "target": "delete-team",
+            "toolNames": [
+              "delete-team"
+            ],
+            "toolCalls": [
+              {
+                "toolName": "delete-team",
+                "input": {
+                  "team_token": "team_abc123"
+                }
+              }
+            ]
+          }
+        },
+        "score": 1,
+        "success": true,
+        "testCase": {
+          "description": "delete-team · direct · Use delete-team to delete Vantage Team team_abc123.",
+          "vars": {
+            "prompt": "Use delete-team to delete Vantage Team team_abc123.",
+            "target": "delete-team",
+            "expected": [
+              {
+                "toolName": "delete-team",
+                "input": {
+                  "team_token": "team_abc123"
+                }
+              }
+            ],
+            "distractors": [
+              "remove-team-member",
+              "get-team",
+              "update-team",
+              "create-team"
+            ]
+          },
+          "options": {
+            "disableVarExpansion": true
+          },
+          "metadata": {
+            "tool": "delete-team",
+            "resource": "teams",
+            "phrasing": "direct"
+          },
+          "assert": [
+            {
+              "type": "javascript",
+              "value": "file://_lib/assertToolCalls.ts"
+            }
+          ]
+        },
+        "testIdx": 0,
+        "tokenUsage": {
+          "prompt": 0,
+          "completion": 0,
+          "cached": 0,
+          "total": 0,
+          "numRequests": 1,
+          "completionDetails": {
+            "reasoning": 0,
+            "acceptedPrediction": 0,
+            "rejectedPrediction": 0,
+            "cacheReadInputTokens": 0,
+            "cacheCreationInputTokens": 0
+          },
+          "assertions": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 1,
+            "completionDetails": {
+              "reasoning": 0,
+              "acceptedPrediction": 0,
+              "rejectedPrediction": 0,
+              "cacheReadInputTokens": 0,
+              "cacheCreationInputTokens": 0
+            }
+          }
+        },
+        "vars": {
+          "prompt": "Use delete-team to delete Vantage Team team_abc123.",
+          "target": "delete-team",
+          "expected": [
+            {
+              "toolName": "delete-team",
+              "input": {
+                "team_token": "team_abc123"
+              }
+            }
+          ],
+          "distractors": [
+            "remove-team-member",
+            "get-team",
+            "update-team",
+            "create-team"
+          ]
+        },
+        "metadata": {
+          "tool": "delete-team",
+          "resource": "teams",
+          "phrasing": "direct",
+          "modelId": "gpt-5.6-luna",
+          "mode": "isolated",
+          "target": "delete-team",
+          "toolNames": [
+            "delete-team"
+          ],
+          "toolCalls": [
+            {
+              "toolName": "delete-team",
+              "input": {
+                "team_token": "team_abc123"
+              }
+            }
+          ],
+          "_promptfooFileMetadata": {}
+        },
+        "failureReason": 0
+      },
+      {
+        "cost": 0,
+        "gradingResult": {
+          "pass": true,
+          "score": 1,
+          "reason": "All assertions passed",
+          "namedScores": {},
+          "tokensUsed": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 0
+          },
+          "componentResults": [
+            {
+              "pass": true,
+              "score": 1,
+              "reason": "Expected tool call matched.",
+              "assertion": {
+                "type": "javascript",
+                "value": "file://_lib/assertToolCalls.ts"
+              }
+            }
+          ]
+        },
+        "id": "c7eb8f2c-c850-4fcf-87dc-14356763dba7",
+        "latencyMs": 2340,
+        "namedScores": {},
+        "prompt": {
+          "raw": "Use delete-team to delete Vantage Team team_abc123.",
+          "label": "{{prompt}}",
+          "config": {
+            "disableVarExpansion": true
+          }
+        },
+        "promptId": "effa18501e44aafd9bc42a2f64ffc9b6350f94025520ca2ed382f9bdc4b6e982",
+        "promptIdx": 1,
+        "provider": {
+          "id": "tool-selection:gpt-5.6-luna:mixed",
+          "label": "gpt-5.6-luna · mixed"
+        },
+        "response": {
+          "output": {
+            "toolCalls": [
+              {
+                "toolName": "delete-team",
+                "input": {
+                  "team_token": "team_abc123"
+                }
+              }
+            ],
+            "text": ""
+          },
+          "metadata": {
+            "modelId": "gpt-5.6-luna",
+            "mode": "mixed",
+            "target": "delete-team",
+            "toolNames": [
+              "delete-team",
+              "remove-team-member",
+              "get-team",
+              "update-team",
+              "create-team"
+            ],
+            "toolCalls": [
+              {
+                "toolName": "delete-team",
+                "input": {
+                  "team_token": "team_abc123"
+                }
+              }
+            ]
+          }
+        },
+        "score": 1,
+        "success": true,
+        "testCase": {
+          "description": "delete-team · direct · Use delete-team to delete Vantage Team team_abc123.",
+          "vars": {
+            "prompt": "Use delete-team to delete Vantage Team team_abc123.",
+            "target": "delete-team",
+            "expected": [
+              {
+                "toolName": "delete-team",
+                "input": {
+                  "team_token": "team_abc123"
+                }
+              }
+            ],
+            "distractors": [
+              "remove-team-member",
+              "get-team",
+              "update-team",
+              "create-team"
+            ]
+          },
+          "options": {
+            "disableVarExpansion": true
+          },
+          "metadata": {
+            "tool": "delete-team",
+            "resource": "teams",
+            "phrasing": "direct"
+          },
+          "assert": [
+            {
+              "type": "javascript",
+              "value": "file://_lib/assertToolCalls.ts"
+            }
+          ]
+        },
+        "testIdx": 0,
+        "tokenUsage": {
+          "prompt": 0,
+          "completion": 0,
+          "cached": 0,
+          "total": 0,
+          "numRequests": 1,
+          "completionDetails": {
+            "reasoning": 0,
+            "acceptedPrediction": 0,
+            "rejectedPrediction": 0,
+            "cacheReadInputTokens": 0,
+            "cacheCreationInputTokens": 0
+          },
+          "assertions": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 1,
+            "completionDetails": {
+              "reasoning": 0,
+              "acceptedPrediction": 0,
+              "rejectedPrediction": 0,
+              "cacheReadInputTokens": 0,
+              "cacheCreationInputTokens": 0
+            }
+          }
+        },
+        "vars": {
+          "prompt": "Use delete-team to delete Vantage Team team_abc123.",
+          "target": "delete-team",
+          "expected": [
+            {
+              "toolName": "delete-team",
+              "input": {
+                "team_token": "team_abc123"
+              }
+            }
+          ],
+          "distractors": [
+            "remove-team-member",
+            "get-team",
+            "update-team",
+            "create-team"
+          ]
+        },
+        "metadata": {
+          "tool": "delete-team",
+          "resource": "teams",
+          "phrasing": "direct",
+          "modelId": "gpt-5.6-luna",
+          "mode": "mixed",
+          "target": "delete-team",
+          "toolNames": [
+            "delete-team",
+            "remove-team-member",
+            "get-team",
+            "update-team",
+            "create-team"
+          ],
+          "toolCalls": [
+            {
+              "toolName": "delete-team",
+              "input": {
+                "team_token": "team_abc123"
+              }
+            }
+          ],
+          "_promptfooFileMetadata": {}
+        },
+        "failureReason": 0
+      },
+      {
+        "cost": 0,
+        "gradingResult": {
+          "pass": true,
+          "score": 1,
+          "reason": "All assertions passed",
+          "namedScores": {},
+          "tokensUsed": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 0
+          },
+          "componentResults": [
+            {
+              "pass": true,
+              "score": 1,
+              "reason": "Expected tool call matched.",
+              "assertion": {
+                "type": "javascript",
+                "value": "file://_lib/assertToolCalls.ts"
+              }
+            }
+          ]
+        },
+        "id": "b2ff4e0c-61e6-4313-a81d-9d1ad3d621cf",
+        "latencyMs": 1823,
+        "namedScores": {},
+        "prompt": {
+          "raw": "Permanently remove the obsolete Vantage Team team_legacy456.",
+          "label": "{{prompt}}",
+          "config": {
+            "disableVarExpansion": true
+          }
+        },
+        "promptId": "effa18501e44aafd9bc42a2f64ffc9b6350f94025520ca2ed382f9bdc4b6e982",
+        "promptIdx": 0,
+        "provider": {
+          "id": "tool-selection:gpt-5.6-luna:isolated",
+          "label": "gpt-5.6-luna · isolated"
+        },
+        "response": {
+          "output": {
+            "toolCalls": [
+              {
+                "toolName": "delete-team",
+                "input": {
+                  "team_token": "team_legacy456"
+                }
+              }
+            ],
+            "text": ""
+          },
+          "metadata": {
+            "modelId": "gpt-5.6-luna",
+            "mode": "isolated",
+            "target": "delete-team",
+            "toolNames": [
+              "delete-team"
+            ],
+            "toolCalls": [
+              {
+                "toolName": "delete-team",
+                "input": {
+                  "team_token": "team_legacy456"
+                }
+              }
+            ]
+          }
+        },
+        "score": 1,
+        "success": true,
+        "testCase": {
+          "description": "delete-team · inferred · Permanently remove the obsolete Vantage Team team_legacy456.",
+          "vars": {
+            "prompt": "Permanently remove the obsolete Vantage Team team_legacy456.",
+            "target": "delete-team",
+            "expected": [
+              {
+                "toolName": "delete-team",
+                "input": {
+                  "team_token": "team_legacy456"
+                }
+              }
+            ],
+            "distractors": [
+              "remove-team-member",
+              "get-team",
+              "update-team",
+              "create-team"
+            ]
+          },
+          "options": {
+            "disableVarExpansion": true
+          },
+          "metadata": {
+            "tool": "delete-team",
+            "resource": "teams",
+            "phrasing": "inferred"
+          },
+          "assert": [
+            {
+              "type": "javascript",
+              "value": "file://_lib/assertToolCalls.ts"
+            }
+          ]
+        },
+        "testIdx": 1,
+        "tokenUsage": {
+          "prompt": 0,
+          "completion": 0,
+          "cached": 0,
+          "total": 0,
+          "numRequests": 1,
+          "completionDetails": {
+            "reasoning": 0,
+            "acceptedPrediction": 0,
+            "rejectedPrediction": 0,
+            "cacheReadInputTokens": 0,
+            "cacheCreationInputTokens": 0
+          },
+          "assertions": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 1,
+            "completionDetails": {
+              "reasoning": 0,
+              "acceptedPrediction": 0,
+              "rejectedPrediction": 0,
+              "cacheReadInputTokens": 0,
+              "cacheCreationInputTokens": 0
+            }
+          }
+        },
+        "vars": {
+          "prompt": "Permanently remove the obsolete Vantage Team team_legacy456.",
+          "target": "delete-team",
+          "expected": [
+            {
+              "toolName": "delete-team",
+              "input": {
+                "team_token": "team_legacy456"
+              }
+            }
+          ],
+          "distractors": [
+            "remove-team-member",
+            "get-team",
+            "update-team",
+            "create-team"
+          ]
+        },
+        "metadata": {
+          "tool": "delete-team",
+          "resource": "teams",
+          "phrasing": "inferred",
+          "modelId": "gpt-5.6-luna",
+          "mode": "isolated",
+          "target": "delete-team",
+          "toolNames": [
+            "delete-team"
+          ],
+          "toolCalls": [
+            {
+              "toolName": "delete-team",
+              "input": {
+                "team_token": "team_legacy456"
+              }
+            }
+          ],
+          "_promptfooFileMetadata": {}
+        },
+        "failureReason": 0
+      },
+      {
+        "cost": 0,
+        "gradingResult": {
+          "pass": true,
+          "score": 1,
+          "reason": "All assertions passed",
+          "namedScores": {},
+          "tokensUsed": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 0
+          },
+          "componentResults": [
+            {
+              "pass": true,
+              "score": 1,
+              "reason": "Expected tool call matched.",
+              "assertion": {
+                "type": "javascript",
+                "value": "file://_lib/assertToolCalls.ts"
+              }
+            }
+          ]
+        },
+        "id": "56cd3ee8-943c-46ff-8437-55656c9b827b",
+        "latencyMs": 6753,
+        "namedScores": {},
+        "prompt": {
+          "raw": "Permanently remove the obsolete Vantage Team team_legacy456.",
+          "label": "{{prompt}}",
+          "config": {
+            "disableVarExpansion": true
+          }
+        },
+        "promptId": "effa18501e44aafd9bc42a2f64ffc9b6350f94025520ca2ed382f9bdc4b6e982",
+        "promptIdx": 1,
+        "provider": {
+          "id": "tool-selection:gpt-5.6-luna:mixed",
+          "label": "gpt-5.6-luna · mixed"
+        },
+        "response": {
+          "output": {
+            "toolCalls": [
+              {
+                "toolName": "delete-team",
+                "input": {
+                  "team_token": "team_legacy456"
+                }
+              }
+            ],
+            "text": ""
+          },
+          "metadata": {
+            "modelId": "gpt-5.6-luna",
+            "mode": "mixed",
+            "target": "delete-team",
+            "toolNames": [
+              "delete-team",
+              "remove-team-member",
+              "get-team",
+              "update-team",
+              "create-team"
+            ],
+            "toolCalls": [
+              {
+                "toolName": "delete-team",
+                "input": {
+                  "team_token": "team_legacy456"
+                }
+              }
+            ]
+          }
+        },
+        "score": 1,
+        "success": true,
+        "testCase": {
+          "description": "delete-team · inferred · Permanently remove the obsolete Vantage Team team_legacy456.",
+          "vars": {
+            "prompt": "Permanently remove the obsolete Vantage Team team_legacy456.",
+            "target": "delete-team",
+            "expected": [
+              {
+                "toolName": "delete-team",
+                "input": {
+                  "team_token": "team_legacy456"
+                }
+              }
+            ],
+            "distractors": [
+              "remove-team-member",
+              "get-team",
+              "update-team",
+              "create-team"
+            ]
+          },
+          "options": {
+            "disableVarExpansion": true
+          },
+          "metadata": {
+            "tool": "delete-team",
+            "resource": "teams",
+            "phrasing": "inferred"
+          },
+          "assert": [
+            {
+              "type": "javascript",
+              "value": "file://_lib/assertToolCalls.ts"
+            }
+          ]
+        },
+        "testIdx": 1,
+        "tokenUsage": {
+          "prompt": 0,
+          "completion": 0,
+          "cached": 0,
+          "total": 0,
+          "numRequests": 1,
+          "completionDetails": {
+            "reasoning": 0,
+            "acceptedPrediction": 0,
+            "rejectedPrediction": 0,
+            "cacheReadInputTokens": 0,
+            "cacheCreationInputTokens": 0
+          },
+          "assertions": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 1,
+            "completionDetails": {
+              "reasoning": 0,
+              "acceptedPrediction": 0,
+              "rejectedPrediction": 0,
+              "cacheReadInputTokens": 0,
+              "cacheCreationInputTokens": 0
+            }
+          }
+        },
+        "vars": {
+          "prompt": "Permanently remove the obsolete Vantage Team team_legacy456.",
+          "target": "delete-team",
+          "expected": [
+            {
+              "toolName": "delete-team",
+              "input": {
+                "team_token": "team_legacy456"
+              }
+            }
+          ],
+          "distractors": [
+            "remove-team-member",
+            "get-team",
+            "update-team",
+            "create-team"
+          ]
+        },
+        "metadata": {
+          "tool": "delete-team",
+          "resource": "teams",
+          "phrasing": "inferred",
+          "modelId": "gpt-5.6-luna",
+          "mode": "mixed",
+          "target": "delete-team",
+          "toolNames": [
+            "delete-team",
+            "remove-team-member",
+            "get-team",
+            "update-team",
+            "create-team"
+          ],
+          "toolCalls": [
+            {
+              "toolName": "delete-team",
+              "input": {
+                "team_token": "team_legacy456"
+              }
+            }
+          ],
+          "_promptfooFileMetadata": {}
+        },
+        "failureReason": 0
+      }
+    ],
+    "prompts": [],
+    "stats": {
+      "successes": 4,
+      "failures": 0,
+      "errors": 0,
+      "tokenUsage": {
+        "prompt": 0,
+        "completion": 0,
+        "cached": 0,
+        "total": 0,
+        "numRequests": 4,
+        "completionDetails": {
+          "reasoning": 0,
+          "acceptedPrediction": 0,
+          "rejectedPrediction": 0
+        }
+      }
+    }
+  },
+  "config": {
+    "tags": {},
+    "description": "Vantage MCP tool-selection evals",
+    "prompts": [
+      "{{prompt}}"
+    ],
+    "providers": [
+      {
+        "id": "file://_lib/provider.ts",
+        "label": "gpt-5.6-luna · isolated",
+        "config": {
+          "modelId": "gpt-5.6-luna",
+          "mode": "isolated"
+        }
+      },
+      {
+        "id": "file://_lib/provider.ts",
+        "label": "gpt-5.6-luna · mixed",
+        "config": {
+          "modelId": "gpt-5.6-luna",
+          "mode": "mixed"
+        }
+      }
+    ],
+    "tests": [
+      "file://cases/cost-providers/get-cost-provider-accounts.eval.ts",
+      "file://cases/current-user/get-myself.eval.ts",
+      "file://cases/teams/add-team-member.eval.ts",
+      "file://cases/teams/create-team.eval.ts",
+      "file://cases/teams/delete-team.eval.ts",
+      "file://cases/teams/get-team-members.eval.ts",
+      "file://cases/teams/remove-team-member.eval.ts",
+      "file://cases/teams/update-team.eval.ts"
+    ],
+    "env": {},
+    "extensions": [],
+    "metadata": {},
+    "evaluateOptions": {
+      "maxConcurrency": 4
+    }
+  },
+  "shareableUrl": null,
+  "metadata": {
+    "promptfooVersion": "0.122.0",
+    "nodeVersion": "v23.11.0",
+    "platform": "darwin",
+    "arch": "arm64",
+    "exportedAt": "2026-09-03T16:54:21.140Z",
+    "evaluationCreatedAt": "2026-09-03T16:54:14.313Z"
+  }
+}

--- a/evals/results/gpt-5.6-luna/teams/get-team-members.json
+++ b/evals/results/gpt-5.6-luna/teams/get-team-members.json
@@ -1,0 +1,823 @@
+{
+  "evalId": null,
+  "results": {
+    "version": 3,
+    "timestamp": "2026-09-03T18:34:09.208Z",
+    "results": [
+      {
+        "cost": 0,
+        "gradingResult": {
+          "pass": true,
+          "score": 1,
+          "reason": "All assertions passed",
+          "namedScores": {},
+          "tokensUsed": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 0
+          },
+          "componentResults": [
+            {
+              "pass": true,
+              "score": 1,
+              "reason": "Expected tool call matched.",
+              "assertion": {
+                "type": "javascript",
+                "value": "file://_lib/assertToolCalls.ts"
+              }
+            }
+          ]
+        },
+        "id": "e97a3f4c-0523-4bf8-8ea9-04aee926b868",
+        "latencyMs": 2289,
+        "namedScores": {},
+        "prompt": {
+          "raw": "Use get-team-members to show page 3 of the members of Vantage Team team_abc123.",
+          "label": "{{prompt}}",
+          "config": {
+            "disableVarExpansion": true
+          }
+        },
+        "promptId": "effa18501e44aafd9bc42a2f64ffc9b6350f94025520ca2ed382f9bdc4b6e982",
+        "promptIdx": 1,
+        "provider": {
+          "id": "tool-selection:gpt-5.6-luna:mixed",
+          "label": "gpt-5.6-luna · mixed"
+        },
+        "response": {
+          "output": {
+            "toolCalls": [
+              {
+                "toolName": "get-team-members",
+                "input": {
+                  "team_token": "team_abc123",
+                  "page": 3
+                }
+              }
+            ],
+            "text": ""
+          },
+          "metadata": {
+            "modelId": "gpt-5.6-luna",
+            "mode": "mixed",
+            "target": "get-team-members",
+            "toolNames": [
+              "get-team-members",
+              "get-team",
+              "get-teams",
+              "get-users",
+              "add-team-member"
+            ],
+            "toolCalls": [
+              {
+                "toolName": "get-team-members",
+                "input": {
+                  "team_token": "team_abc123",
+                  "page": 3
+                }
+              }
+            ]
+          }
+        },
+        "score": 1,
+        "success": true,
+        "testCase": {
+          "description": "get-team-members · direct · Use get-team-members to show page 3 of the members of Vantage Team team_abc123.",
+          "vars": {
+            "prompt": "Use get-team-members to show page 3 of the members of Vantage Team team_abc123.",
+            "target": "get-team-members",
+            "expected": [
+              {
+                "toolName": "get-team-members",
+                "input": {
+                  "team_token": "team_abc123",
+                  "page": 3
+                }
+              }
+            ],
+            "distractors": [
+              "get-team",
+              "get-teams",
+              "get-users",
+              "add-team-member"
+            ]
+          },
+          "options": {
+            "disableVarExpansion": true
+          },
+          "metadata": {
+            "tool": "get-team-members",
+            "resource": "teams",
+            "phrasing": "direct"
+          },
+          "assert": [
+            {
+              "type": "javascript",
+              "value": "file://_lib/assertToolCalls.ts"
+            }
+          ]
+        },
+        "testIdx": 0,
+        "tokenUsage": {
+          "prompt": 0,
+          "completion": 0,
+          "cached": 0,
+          "total": 0,
+          "numRequests": 1,
+          "completionDetails": {
+            "reasoning": 0,
+            "acceptedPrediction": 0,
+            "rejectedPrediction": 0,
+            "cacheReadInputTokens": 0,
+            "cacheCreationInputTokens": 0
+          },
+          "assertions": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 1,
+            "completionDetails": {
+              "reasoning": 0,
+              "acceptedPrediction": 0,
+              "rejectedPrediction": 0,
+              "cacheReadInputTokens": 0,
+              "cacheCreationInputTokens": 0
+            }
+          }
+        },
+        "vars": {
+          "prompt": "Use get-team-members to show page 3 of the members of Vantage Team team_abc123.",
+          "target": "get-team-members",
+          "expected": [
+            {
+              "toolName": "get-team-members",
+              "input": {
+                "team_token": "team_abc123",
+                "page": 3
+              }
+            }
+          ],
+          "distractors": [
+            "get-team",
+            "get-teams",
+            "get-users",
+            "add-team-member"
+          ]
+        },
+        "metadata": {
+          "tool": "get-team-members",
+          "resource": "teams",
+          "phrasing": "direct",
+          "modelId": "gpt-5.6-luna",
+          "mode": "mixed",
+          "target": "get-team-members",
+          "toolNames": [
+            "get-team-members",
+            "get-team",
+            "get-teams",
+            "get-users",
+            "add-team-member"
+          ],
+          "toolCalls": [
+            {
+              "toolName": "get-team-members",
+              "input": {
+                "team_token": "team_abc123",
+                "page": 3
+              }
+            }
+          ],
+          "_promptfooFileMetadata": {}
+        },
+        "failureReason": 0
+      },
+      {
+        "cost": 0,
+        "gradingResult": {
+          "pass": true,
+          "score": 1,
+          "reason": "All assertions passed",
+          "namedScores": {},
+          "tokensUsed": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 0
+          },
+          "componentResults": [
+            {
+              "pass": true,
+              "score": 1,
+              "reason": "Expected tool call matched.",
+              "assertion": {
+                "type": "javascript",
+                "value": "file://_lib/assertToolCalls.ts"
+              }
+            }
+          ]
+        },
+        "id": "7dcec3b7-b69e-4eca-954a-1b1ccbcb3eb5",
+        "latencyMs": 2324,
+        "namedScores": {},
+        "prompt": {
+          "raw": "Use get-team-members to show page 3 of the members of Vantage Team team_abc123.",
+          "label": "{{prompt}}",
+          "config": {
+            "disableVarExpansion": true
+          }
+        },
+        "promptId": "effa18501e44aafd9bc42a2f64ffc9b6350f94025520ca2ed382f9bdc4b6e982",
+        "promptIdx": 0,
+        "provider": {
+          "id": "tool-selection:gpt-5.6-luna:isolated",
+          "label": "gpt-5.6-luna · isolated"
+        },
+        "response": {
+          "output": {
+            "toolCalls": [
+              {
+                "toolName": "get-team-members",
+                "input": {
+                  "team_token": "team_abc123",
+                  "page": 3
+                }
+              }
+            ],
+            "text": ""
+          },
+          "metadata": {
+            "modelId": "gpt-5.6-luna",
+            "mode": "isolated",
+            "target": "get-team-members",
+            "toolNames": [
+              "get-team-members"
+            ],
+            "toolCalls": [
+              {
+                "toolName": "get-team-members",
+                "input": {
+                  "team_token": "team_abc123",
+                  "page": 3
+                }
+              }
+            ]
+          }
+        },
+        "score": 1,
+        "success": true,
+        "testCase": {
+          "description": "get-team-members · direct · Use get-team-members to show page 3 of the members of Vantage Team team_abc123.",
+          "vars": {
+            "prompt": "Use get-team-members to show page 3 of the members of Vantage Team team_abc123.",
+            "target": "get-team-members",
+            "expected": [
+              {
+                "toolName": "get-team-members",
+                "input": {
+                  "team_token": "team_abc123",
+                  "page": 3
+                }
+              }
+            ],
+            "distractors": [
+              "get-team",
+              "get-teams",
+              "get-users",
+              "add-team-member"
+            ]
+          },
+          "options": {
+            "disableVarExpansion": true
+          },
+          "metadata": {
+            "tool": "get-team-members",
+            "resource": "teams",
+            "phrasing": "direct"
+          },
+          "assert": [
+            {
+              "type": "javascript",
+              "value": "file://_lib/assertToolCalls.ts"
+            }
+          ]
+        },
+        "testIdx": 0,
+        "tokenUsage": {
+          "prompt": 0,
+          "completion": 0,
+          "cached": 0,
+          "total": 0,
+          "numRequests": 1,
+          "completionDetails": {
+            "reasoning": 0,
+            "acceptedPrediction": 0,
+            "rejectedPrediction": 0,
+            "cacheReadInputTokens": 0,
+            "cacheCreationInputTokens": 0
+          },
+          "assertions": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 1,
+            "completionDetails": {
+              "reasoning": 0,
+              "acceptedPrediction": 0,
+              "rejectedPrediction": 0,
+              "cacheReadInputTokens": 0,
+              "cacheCreationInputTokens": 0
+            }
+          }
+        },
+        "vars": {
+          "prompt": "Use get-team-members to show page 3 of the members of Vantage Team team_abc123.",
+          "target": "get-team-members",
+          "expected": [
+            {
+              "toolName": "get-team-members",
+              "input": {
+                "team_token": "team_abc123",
+                "page": 3
+              }
+            }
+          ],
+          "distractors": [
+            "get-team",
+            "get-teams",
+            "get-users",
+            "add-team-member"
+          ]
+        },
+        "metadata": {
+          "tool": "get-team-members",
+          "resource": "teams",
+          "phrasing": "direct",
+          "modelId": "gpt-5.6-luna",
+          "mode": "isolated",
+          "target": "get-team-members",
+          "toolNames": [
+            "get-team-members"
+          ],
+          "toolCalls": [
+            {
+              "toolName": "get-team-members",
+              "input": {
+                "team_token": "team_abc123",
+                "page": 3
+              }
+            }
+          ],
+          "_promptfooFileMetadata": {}
+        },
+        "failureReason": 0
+      },
+      {
+        "cost": 0,
+        "gradingResult": {
+          "pass": true,
+          "score": 1,
+          "reason": "All assertions passed",
+          "namedScores": {},
+          "tokensUsed": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 0
+          },
+          "componentResults": [
+            {
+              "pass": true,
+              "score": 1,
+              "reason": "Expected tool call matched.",
+              "assertion": {
+                "type": "javascript",
+                "value": "file://_lib/assertToolCalls.ts"
+              }
+            }
+          ]
+        },
+        "id": "317e6c9b-08f1-4fe8-a18c-18d443e81a91",
+        "latencyMs": 2451,
+        "namedScores": {},
+        "prompt": {
+          "raw": "Who belongs to Vantage Team team_abc123? Show me the second page.",
+          "label": "{{prompt}}",
+          "config": {
+            "disableVarExpansion": true
+          }
+        },
+        "promptId": "effa18501e44aafd9bc42a2f64ffc9b6350f94025520ca2ed382f9bdc4b6e982",
+        "promptIdx": 0,
+        "provider": {
+          "id": "tool-selection:gpt-5.6-luna:isolated",
+          "label": "gpt-5.6-luna · isolated"
+        },
+        "response": {
+          "output": {
+            "toolCalls": [
+              {
+                "toolName": "get-team-members",
+                "input": {
+                  "team_token": "team_abc123",
+                  "page": 2
+                }
+              }
+            ],
+            "text": ""
+          },
+          "metadata": {
+            "modelId": "gpt-5.6-luna",
+            "mode": "isolated",
+            "target": "get-team-members",
+            "toolNames": [
+              "get-team-members"
+            ],
+            "toolCalls": [
+              {
+                "toolName": "get-team-members",
+                "input": {
+                  "team_token": "team_abc123",
+                  "page": 2
+                }
+              }
+            ]
+          }
+        },
+        "score": 1,
+        "success": true,
+        "testCase": {
+          "description": "get-team-members · inferred · Who belongs to Vantage Team team_abc123? Show me the second page.",
+          "vars": {
+            "prompt": "Who belongs to Vantage Team team_abc123? Show me the second page.",
+            "target": "get-team-members",
+            "expected": [
+              {
+                "toolName": "get-team-members",
+                "input": {
+                  "team_token": "team_abc123",
+                  "page": 2
+                }
+              }
+            ],
+            "distractors": [
+              "get-team",
+              "get-teams",
+              "get-users",
+              "add-team-member"
+            ]
+          },
+          "options": {
+            "disableVarExpansion": true
+          },
+          "metadata": {
+            "tool": "get-team-members",
+            "resource": "teams",
+            "phrasing": "inferred"
+          },
+          "assert": [
+            {
+              "type": "javascript",
+              "value": "file://_lib/assertToolCalls.ts"
+            }
+          ]
+        },
+        "testIdx": 1,
+        "tokenUsage": {
+          "prompt": 0,
+          "completion": 0,
+          "cached": 0,
+          "total": 0,
+          "numRequests": 1,
+          "completionDetails": {
+            "reasoning": 0,
+            "acceptedPrediction": 0,
+            "rejectedPrediction": 0,
+            "cacheReadInputTokens": 0,
+            "cacheCreationInputTokens": 0
+          },
+          "assertions": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 1,
+            "completionDetails": {
+              "reasoning": 0,
+              "acceptedPrediction": 0,
+              "rejectedPrediction": 0,
+              "cacheReadInputTokens": 0,
+              "cacheCreationInputTokens": 0
+            }
+          }
+        },
+        "vars": {
+          "prompt": "Who belongs to Vantage Team team_abc123? Show me the second page.",
+          "target": "get-team-members",
+          "expected": [
+            {
+              "toolName": "get-team-members",
+              "input": {
+                "team_token": "team_abc123",
+                "page": 2
+              }
+            }
+          ],
+          "distractors": [
+            "get-team",
+            "get-teams",
+            "get-users",
+            "add-team-member"
+          ]
+        },
+        "metadata": {
+          "tool": "get-team-members",
+          "resource": "teams",
+          "phrasing": "inferred",
+          "modelId": "gpt-5.6-luna",
+          "mode": "isolated",
+          "target": "get-team-members",
+          "toolNames": [
+            "get-team-members"
+          ],
+          "toolCalls": [
+            {
+              "toolName": "get-team-members",
+              "input": {
+                "team_token": "team_abc123",
+                "page": 2
+              }
+            }
+          ],
+          "_promptfooFileMetadata": {}
+        },
+        "failureReason": 0
+      },
+      {
+        "cost": 0,
+        "gradingResult": {
+          "pass": true,
+          "score": 1,
+          "reason": "All assertions passed",
+          "namedScores": {},
+          "tokensUsed": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 0
+          },
+          "componentResults": [
+            {
+              "pass": true,
+              "score": 1,
+              "reason": "Expected tool call matched.",
+              "assertion": {
+                "type": "javascript",
+                "value": "file://_lib/assertToolCalls.ts"
+              }
+            }
+          ]
+        },
+        "id": "7d46a483-d920-4fe3-be42-e54bab510065",
+        "latencyMs": 3021,
+        "namedScores": {},
+        "prompt": {
+          "raw": "Who belongs to Vantage Team team_abc123? Show me the second page.",
+          "label": "{{prompt}}",
+          "config": {
+            "disableVarExpansion": true
+          }
+        },
+        "promptId": "effa18501e44aafd9bc42a2f64ffc9b6350f94025520ca2ed382f9bdc4b6e982",
+        "promptIdx": 1,
+        "provider": {
+          "id": "tool-selection:gpt-5.6-luna:mixed",
+          "label": "gpt-5.6-luna · mixed"
+        },
+        "response": {
+          "output": {
+            "toolCalls": [
+              {
+                "toolName": "get-team-members",
+                "input": {
+                  "team_token": "team_abc123",
+                  "page": 2
+                }
+              }
+            ],
+            "text": ""
+          },
+          "metadata": {
+            "modelId": "gpt-5.6-luna",
+            "mode": "mixed",
+            "target": "get-team-members",
+            "toolNames": [
+              "get-team-members",
+              "get-team",
+              "get-teams",
+              "get-users",
+              "add-team-member"
+            ],
+            "toolCalls": [
+              {
+                "toolName": "get-team-members",
+                "input": {
+                  "team_token": "team_abc123",
+                  "page": 2
+                }
+              }
+            ]
+          }
+        },
+        "score": 1,
+        "success": true,
+        "testCase": {
+          "description": "get-team-members · inferred · Who belongs to Vantage Team team_abc123? Show me the second page.",
+          "vars": {
+            "prompt": "Who belongs to Vantage Team team_abc123? Show me the second page.",
+            "target": "get-team-members",
+            "expected": [
+              {
+                "toolName": "get-team-members",
+                "input": {
+                  "team_token": "team_abc123",
+                  "page": 2
+                }
+              }
+            ],
+            "distractors": [
+              "get-team",
+              "get-teams",
+              "get-users",
+              "add-team-member"
+            ]
+          },
+          "options": {
+            "disableVarExpansion": true
+          },
+          "metadata": {
+            "tool": "get-team-members",
+            "resource": "teams",
+            "phrasing": "inferred"
+          },
+          "assert": [
+            {
+              "type": "javascript",
+              "value": "file://_lib/assertToolCalls.ts"
+            }
+          ]
+        },
+        "testIdx": 1,
+        "tokenUsage": {
+          "prompt": 0,
+          "completion": 0,
+          "cached": 0,
+          "total": 0,
+          "numRequests": 1,
+          "completionDetails": {
+            "reasoning": 0,
+            "acceptedPrediction": 0,
+            "rejectedPrediction": 0,
+            "cacheReadInputTokens": 0,
+            "cacheCreationInputTokens": 0
+          },
+          "assertions": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 1,
+            "completionDetails": {
+              "reasoning": 0,
+              "acceptedPrediction": 0,
+              "rejectedPrediction": 0,
+              "cacheReadInputTokens": 0,
+              "cacheCreationInputTokens": 0
+            }
+          }
+        },
+        "vars": {
+          "prompt": "Who belongs to Vantage Team team_abc123? Show me the second page.",
+          "target": "get-team-members",
+          "expected": [
+            {
+              "toolName": "get-team-members",
+              "input": {
+                "team_token": "team_abc123",
+                "page": 2
+              }
+            }
+          ],
+          "distractors": [
+            "get-team",
+            "get-teams",
+            "get-users",
+            "add-team-member"
+          ]
+        },
+        "metadata": {
+          "tool": "get-team-members",
+          "resource": "teams",
+          "phrasing": "inferred",
+          "modelId": "gpt-5.6-luna",
+          "mode": "mixed",
+          "target": "get-team-members",
+          "toolNames": [
+            "get-team-members",
+            "get-team",
+            "get-teams",
+            "get-users",
+            "add-team-member"
+          ],
+          "toolCalls": [
+            {
+              "toolName": "get-team-members",
+              "input": {
+                "team_token": "team_abc123",
+                "page": 2
+              }
+            }
+          ],
+          "_promptfooFileMetadata": {}
+        },
+        "failureReason": 0
+      }
+    ],
+    "prompts": [],
+    "stats": {
+      "successes": 4,
+      "failures": 0,
+      "errors": 0,
+      "tokenUsage": {
+        "prompt": 0,
+        "completion": 0,
+        "cached": 0,
+        "total": 0,
+        "numRequests": 4,
+        "completionDetails": {
+          "reasoning": 0,
+          "acceptedPrediction": 0,
+          "rejectedPrediction": 0
+        }
+      }
+    }
+  },
+  "config": {
+    "tags": {},
+    "description": "Vantage MCP tool-selection evals",
+    "prompts": [
+      "{{prompt}}"
+    ],
+    "providers": [
+      {
+        "id": "file://_lib/provider.ts",
+        "label": "gpt-5.6-luna · isolated",
+        "config": {
+          "modelId": "gpt-5.6-luna",
+          "mode": "isolated"
+        }
+      },
+      {
+        "id": "file://_lib/provider.ts",
+        "label": "gpt-5.6-luna · mixed",
+        "config": {
+          "modelId": "gpt-5.6-luna",
+          "mode": "mixed"
+        }
+      }
+    ],
+    "tests": [
+      "file://cases/cost-providers/get-cost-provider-accounts.eval.ts",
+      "file://cases/current-user/get-myself.eval.ts",
+      "file://cases/teams/add-team-member.eval.ts",
+      "file://cases/teams/create-team.eval.ts",
+      "file://cases/teams/delete-team.eval.ts",
+      "file://cases/teams/get-team-members.eval.ts",
+      "file://cases/teams/get-team.eval.ts",
+      "file://cases/teams/get-teams.eval.ts",
+      "file://cases/teams/remove-team-member.eval.ts",
+      "file://cases/teams/update-team.eval.ts"
+    ],
+    "env": {},
+    "extensions": [],
+    "metadata": {},
+    "evaluateOptions": {
+      "maxConcurrency": 4
+    }
+  },
+  "shareableUrl": null,
+  "metadata": {
+    "promptfooVersion": "0.122.0",
+    "nodeVersion": "v23.11.0",
+    "platform": "darwin",
+    "arch": "arm64",
+    "exportedAt": "2026-09-03T18:34:08.896Z",
+    "evaluationCreatedAt": "2026-09-03T18:34:02.765Z"
+  }
+}

--- a/evals/results/gpt-5.6-luna/teams/get-team.json
+++ b/evals/results/gpt-5.6-luna/teams/get-team.json
@@ -1,0 +1,803 @@
+{
+  "evalId": null,
+  "results": {
+    "version": 3,
+    "timestamp": "2026-09-03T18:34:09.210Z",
+    "results": [
+      {
+        "cost": 0,
+        "gradingResult": {
+          "pass": true,
+          "score": 1,
+          "reason": "All assertions passed",
+          "namedScores": {},
+          "tokensUsed": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 0
+          },
+          "componentResults": [
+            {
+              "pass": true,
+              "score": 1,
+              "reason": "Expected tool call matched.",
+              "assertion": {
+                "type": "javascript",
+                "value": "file://_lib/assertToolCalls.ts"
+              }
+            }
+          ]
+        },
+        "id": "d81985e9-b78b-4de0-a3c9-81e3d6654ff5",
+        "latencyMs": 1226,
+        "namedScores": {},
+        "prompt": {
+          "raw": "Use get-team to retrieve Vantage Team team_abc123.",
+          "label": "{{prompt}}",
+          "config": {
+            "disableVarExpansion": true
+          }
+        },
+        "promptId": "effa18501e44aafd9bc42a2f64ffc9b6350f94025520ca2ed382f9bdc4b6e982",
+        "promptIdx": 1,
+        "provider": {
+          "id": "tool-selection:gpt-5.6-luna:mixed",
+          "label": "gpt-5.6-luna · mixed"
+        },
+        "response": {
+          "output": {
+            "toolCalls": [
+              {
+                "toolName": "get-team",
+                "input": {
+                  "token": "team_abc123"
+                }
+              }
+            ],
+            "text": ""
+          },
+          "metadata": {
+            "modelId": "gpt-5.6-luna",
+            "mode": "mixed",
+            "target": "get-team",
+            "toolNames": [
+              "get-team",
+              "get-teams",
+              "get-team-members",
+              "update-team",
+              "get-workspace"
+            ],
+            "toolCalls": [
+              {
+                "toolName": "get-team",
+                "input": {
+                  "token": "team_abc123"
+                }
+              }
+            ]
+          }
+        },
+        "score": 1,
+        "success": true,
+        "testCase": {
+          "description": "get-team · direct · Use get-team to retrieve Vantage Team team_abc123.",
+          "vars": {
+            "prompt": "Use get-team to retrieve Vantage Team team_abc123.",
+            "target": "get-team",
+            "expected": [
+              {
+                "toolName": "get-team",
+                "input": {
+                  "token": "[REDACTED]"
+                }
+              }
+            ],
+            "distractors": [
+              "get-teams",
+              "get-team-members",
+              "update-team",
+              "get-workspace"
+            ]
+          },
+          "options": {
+            "disableVarExpansion": true
+          },
+          "metadata": {
+            "tool": "get-team",
+            "resource": "teams",
+            "phrasing": "direct"
+          },
+          "assert": [
+            {
+              "type": "javascript",
+              "value": "file://_lib/assertToolCalls.ts"
+            }
+          ]
+        },
+        "testIdx": 2,
+        "tokenUsage": {
+          "prompt": 0,
+          "completion": 0,
+          "cached": 0,
+          "total": 0,
+          "numRequests": 1,
+          "completionDetails": {
+            "reasoning": 0,
+            "acceptedPrediction": 0,
+            "rejectedPrediction": 0,
+            "cacheReadInputTokens": 0,
+            "cacheCreationInputTokens": 0
+          },
+          "assertions": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 1,
+            "completionDetails": {
+              "reasoning": 0,
+              "acceptedPrediction": 0,
+              "rejectedPrediction": 0,
+              "cacheReadInputTokens": 0,
+              "cacheCreationInputTokens": 0
+            }
+          }
+        },
+        "vars": {
+          "prompt": "Use get-team to retrieve Vantage Team team_abc123.",
+          "target": "get-team",
+          "expected": [
+            {
+              "toolName": "get-team",
+              "input": {
+                "token": "[REDACTED]"
+              }
+            }
+          ],
+          "distractors": [
+            "get-teams",
+            "get-team-members",
+            "update-team",
+            "get-workspace"
+          ]
+        },
+        "metadata": {
+          "tool": "get-team",
+          "resource": "teams",
+          "phrasing": "direct",
+          "modelId": "gpt-5.6-luna",
+          "mode": "mixed",
+          "target": "get-team",
+          "toolNames": [
+            "get-team",
+            "get-teams",
+            "get-team-members",
+            "update-team",
+            "get-workspace"
+          ],
+          "toolCalls": [
+            {
+              "toolName": "get-team",
+              "input": {
+                "token": "team_abc123"
+              }
+            }
+          ],
+          "_promptfooFileMetadata": {}
+        },
+        "failureReason": 0
+      },
+      {
+        "cost": 0,
+        "gradingResult": {
+          "pass": true,
+          "score": 1,
+          "reason": "All assertions passed",
+          "namedScores": {},
+          "tokensUsed": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 0
+          },
+          "componentResults": [
+            {
+              "pass": true,
+              "score": 1,
+              "reason": "Expected tool call matched.",
+              "assertion": {
+                "type": "javascript",
+                "value": "file://_lib/assertToolCalls.ts"
+              }
+            }
+          ]
+        },
+        "id": "89273432-29b6-4230-868f-8e4963b6bfb8",
+        "latencyMs": 1311,
+        "namedScores": {},
+        "prompt": {
+          "raw": "Use get-team to retrieve Vantage Team team_abc123.",
+          "label": "{{prompt}}",
+          "config": {
+            "disableVarExpansion": true
+          }
+        },
+        "promptId": "effa18501e44aafd9bc42a2f64ffc9b6350f94025520ca2ed382f9bdc4b6e982",
+        "promptIdx": 0,
+        "provider": {
+          "id": "tool-selection:gpt-5.6-luna:isolated",
+          "label": "gpt-5.6-luna · isolated"
+        },
+        "response": {
+          "output": {
+            "toolCalls": [
+              {
+                "toolName": "get-team",
+                "input": {
+                  "token": "team_abc123"
+                }
+              }
+            ],
+            "text": ""
+          },
+          "metadata": {
+            "modelId": "gpt-5.6-luna",
+            "mode": "isolated",
+            "target": "get-team",
+            "toolNames": [
+              "get-team"
+            ],
+            "toolCalls": [
+              {
+                "toolName": "get-team",
+                "input": {
+                  "token": "team_abc123"
+                }
+              }
+            ]
+          }
+        },
+        "score": 1,
+        "success": true,
+        "testCase": {
+          "description": "get-team · direct · Use get-team to retrieve Vantage Team team_abc123.",
+          "vars": {
+            "prompt": "Use get-team to retrieve Vantage Team team_abc123.",
+            "target": "get-team",
+            "expected": [
+              {
+                "toolName": "get-team",
+                "input": {
+                  "token": "[REDACTED]"
+                }
+              }
+            ],
+            "distractors": [
+              "get-teams",
+              "get-team-members",
+              "update-team",
+              "get-workspace"
+            ]
+          },
+          "options": {
+            "disableVarExpansion": true
+          },
+          "metadata": {
+            "tool": "get-team",
+            "resource": "teams",
+            "phrasing": "direct"
+          },
+          "assert": [
+            {
+              "type": "javascript",
+              "value": "file://_lib/assertToolCalls.ts"
+            }
+          ]
+        },
+        "testIdx": 2,
+        "tokenUsage": {
+          "prompt": 0,
+          "completion": 0,
+          "cached": 0,
+          "total": 0,
+          "numRequests": 1,
+          "completionDetails": {
+            "reasoning": 0,
+            "acceptedPrediction": 0,
+            "rejectedPrediction": 0,
+            "cacheReadInputTokens": 0,
+            "cacheCreationInputTokens": 0
+          },
+          "assertions": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 1,
+            "completionDetails": {
+              "reasoning": 0,
+              "acceptedPrediction": 0,
+              "rejectedPrediction": 0,
+              "cacheReadInputTokens": 0,
+              "cacheCreationInputTokens": 0
+            }
+          }
+        },
+        "vars": {
+          "prompt": "Use get-team to retrieve Vantage Team team_abc123.",
+          "target": "get-team",
+          "expected": [
+            {
+              "toolName": "get-team",
+              "input": {
+                "token": "[REDACTED]"
+              }
+            }
+          ],
+          "distractors": [
+            "get-teams",
+            "get-team-members",
+            "update-team",
+            "get-workspace"
+          ]
+        },
+        "metadata": {
+          "tool": "get-team",
+          "resource": "teams",
+          "phrasing": "direct",
+          "modelId": "gpt-5.6-luna",
+          "mode": "isolated",
+          "target": "get-team",
+          "toolNames": [
+            "get-team"
+          ],
+          "toolCalls": [
+            {
+              "toolName": "get-team",
+              "input": {
+                "token": "team_abc123"
+              }
+            }
+          ],
+          "_promptfooFileMetadata": {}
+        },
+        "failureReason": 0
+      },
+      {
+        "cost": 0,
+        "gradingResult": {
+          "pass": true,
+          "score": 1,
+          "reason": "All assertions passed",
+          "namedScores": {},
+          "tokensUsed": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 0
+          },
+          "componentResults": [
+            {
+              "pass": true,
+              "score": 1,
+              "reason": "Expected tool call matched.",
+              "assertion": {
+                "type": "javascript",
+                "value": "file://_lib/assertToolCalls.ts"
+              }
+            }
+          ]
+        },
+        "id": "0b22ac50-e84d-403f-8dc8-5279d3597549",
+        "latencyMs": 1360,
+        "namedScores": {},
+        "prompt": {
+          "raw": "Show me the details for the Vantage Team with token team_platform789.",
+          "label": "{{prompt}}",
+          "config": {
+            "disableVarExpansion": true
+          }
+        },
+        "promptId": "effa18501e44aafd9bc42a2f64ffc9b6350f94025520ca2ed382f9bdc4b6e982",
+        "promptIdx": 0,
+        "provider": {
+          "id": "tool-selection:gpt-5.6-luna:isolated",
+          "label": "gpt-5.6-luna · isolated"
+        },
+        "response": {
+          "output": {
+            "toolCalls": [
+              {
+                "toolName": "get-team",
+                "input": {
+                  "token": "team_platform789"
+                }
+              }
+            ],
+            "text": ""
+          },
+          "metadata": {
+            "modelId": "gpt-5.6-luna",
+            "mode": "isolated",
+            "target": "get-team",
+            "toolNames": [
+              "get-team"
+            ],
+            "toolCalls": [
+              {
+                "toolName": "get-team",
+                "input": {
+                  "token": "team_platform789"
+                }
+              }
+            ]
+          }
+        },
+        "score": 1,
+        "success": true,
+        "testCase": {
+          "description": "get-team · inferred · Show me the details for the Vantage Team with token team_platform789.",
+          "vars": {
+            "prompt": "Show me the details for the Vantage Team with token team_platform789.",
+            "target": "get-team",
+            "expected": [
+              {
+                "toolName": "get-team",
+                "input": {
+                  "token": "[REDACTED]"
+                }
+              }
+            ],
+            "distractors": [
+              "get-teams",
+              "get-team-members",
+              "update-team",
+              "get-workspace"
+            ]
+          },
+          "options": {
+            "disableVarExpansion": true
+          },
+          "metadata": {
+            "tool": "get-team",
+            "resource": "teams",
+            "phrasing": "inferred"
+          },
+          "assert": [
+            {
+              "type": "javascript",
+              "value": "file://_lib/assertToolCalls.ts"
+            }
+          ]
+        },
+        "testIdx": 3,
+        "tokenUsage": {
+          "prompt": 0,
+          "completion": 0,
+          "cached": 0,
+          "total": 0,
+          "numRequests": 1,
+          "completionDetails": {
+            "reasoning": 0,
+            "acceptedPrediction": 0,
+            "rejectedPrediction": 0,
+            "cacheReadInputTokens": 0,
+            "cacheCreationInputTokens": 0
+          },
+          "assertions": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 1,
+            "completionDetails": {
+              "reasoning": 0,
+              "acceptedPrediction": 0,
+              "rejectedPrediction": 0,
+              "cacheReadInputTokens": 0,
+              "cacheCreationInputTokens": 0
+            }
+          }
+        },
+        "vars": {
+          "prompt": "Show me the details for the Vantage Team with token team_platform789.",
+          "target": "get-team",
+          "expected": [
+            {
+              "toolName": "get-team",
+              "input": {
+                "token": "[REDACTED]"
+              }
+            }
+          ],
+          "distractors": [
+            "get-teams",
+            "get-team-members",
+            "update-team",
+            "get-workspace"
+          ]
+        },
+        "metadata": {
+          "tool": "get-team",
+          "resource": "teams",
+          "phrasing": "inferred",
+          "modelId": "gpt-5.6-luna",
+          "mode": "isolated",
+          "target": "get-team",
+          "toolNames": [
+            "get-team"
+          ],
+          "toolCalls": [
+            {
+              "toolName": "get-team",
+              "input": {
+                "token": "team_platform789"
+              }
+            }
+          ],
+          "_promptfooFileMetadata": {}
+        },
+        "failureReason": 0
+      },
+      {
+        "cost": 0,
+        "gradingResult": {
+          "pass": true,
+          "score": 1,
+          "reason": "All assertions passed",
+          "namedScores": {},
+          "tokensUsed": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 0
+          },
+          "componentResults": [
+            {
+              "pass": true,
+              "score": 1,
+              "reason": "Expected tool call matched.",
+              "assertion": {
+                "type": "javascript",
+                "value": "file://_lib/assertToolCalls.ts"
+              }
+            }
+          ]
+        },
+        "id": "790bb8eb-2dbb-40e9-beeb-b965af6295cf",
+        "latencyMs": 1102,
+        "namedScores": {},
+        "prompt": {
+          "raw": "Show me the details for the Vantage Team with token team_platform789.",
+          "label": "{{prompt}}",
+          "config": {
+            "disableVarExpansion": true
+          }
+        },
+        "promptId": "effa18501e44aafd9bc42a2f64ffc9b6350f94025520ca2ed382f9bdc4b6e982",
+        "promptIdx": 1,
+        "provider": {
+          "id": "tool-selection:gpt-5.6-luna:mixed",
+          "label": "gpt-5.6-luna · mixed"
+        },
+        "response": {
+          "output": {
+            "toolCalls": [
+              {
+                "toolName": "get-team",
+                "input": {
+                  "token": "team_platform789"
+                }
+              }
+            ],
+            "text": ""
+          },
+          "metadata": {
+            "modelId": "gpt-5.6-luna",
+            "mode": "mixed",
+            "target": "get-team",
+            "toolNames": [
+              "get-team",
+              "get-teams",
+              "get-team-members",
+              "update-team",
+              "get-workspace"
+            ],
+            "toolCalls": [
+              {
+                "toolName": "get-team",
+                "input": {
+                  "token": "team_platform789"
+                }
+              }
+            ]
+          }
+        },
+        "score": 1,
+        "success": true,
+        "testCase": {
+          "description": "get-team · inferred · Show me the details for the Vantage Team with token team_platform789.",
+          "vars": {
+            "prompt": "Show me the details for the Vantage Team with token team_platform789.",
+            "target": "get-team",
+            "expected": [
+              {
+                "toolName": "get-team",
+                "input": {
+                  "token": "[REDACTED]"
+                }
+              }
+            ],
+            "distractors": [
+              "get-teams",
+              "get-team-members",
+              "update-team",
+              "get-workspace"
+            ]
+          },
+          "options": {
+            "disableVarExpansion": true
+          },
+          "metadata": {
+            "tool": "get-team",
+            "resource": "teams",
+            "phrasing": "inferred"
+          },
+          "assert": [
+            {
+              "type": "javascript",
+              "value": "file://_lib/assertToolCalls.ts"
+            }
+          ]
+        },
+        "testIdx": 3,
+        "tokenUsage": {
+          "prompt": 0,
+          "completion": 0,
+          "cached": 0,
+          "total": 0,
+          "numRequests": 1,
+          "completionDetails": {
+            "reasoning": 0,
+            "acceptedPrediction": 0,
+            "rejectedPrediction": 0,
+            "cacheReadInputTokens": 0,
+            "cacheCreationInputTokens": 0
+          },
+          "assertions": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 1,
+            "completionDetails": {
+              "reasoning": 0,
+              "acceptedPrediction": 0,
+              "rejectedPrediction": 0,
+              "cacheReadInputTokens": 0,
+              "cacheCreationInputTokens": 0
+            }
+          }
+        },
+        "vars": {
+          "prompt": "Show me the details for the Vantage Team with token team_platform789.",
+          "target": "get-team",
+          "expected": [
+            {
+              "toolName": "get-team",
+              "input": {
+                "token": "[REDACTED]"
+              }
+            }
+          ],
+          "distractors": [
+            "get-teams",
+            "get-team-members",
+            "update-team",
+            "get-workspace"
+          ]
+        },
+        "metadata": {
+          "tool": "get-team",
+          "resource": "teams",
+          "phrasing": "inferred",
+          "modelId": "gpt-5.6-luna",
+          "mode": "mixed",
+          "target": "get-team",
+          "toolNames": [
+            "get-team",
+            "get-teams",
+            "get-team-members",
+            "update-team",
+            "get-workspace"
+          ],
+          "toolCalls": [
+            {
+              "toolName": "get-team",
+              "input": {
+                "token": "team_platform789"
+              }
+            }
+          ],
+          "_promptfooFileMetadata": {}
+        },
+        "failureReason": 0
+      }
+    ],
+    "prompts": [],
+    "stats": {
+      "successes": 4,
+      "failures": 0,
+      "errors": 0,
+      "tokenUsage": {
+        "prompt": 0,
+        "completion": 0,
+        "cached": 0,
+        "total": 0,
+        "numRequests": 4,
+        "completionDetails": {
+          "reasoning": 0,
+          "acceptedPrediction": 0,
+          "rejectedPrediction": 0
+        }
+      }
+    }
+  },
+  "config": {
+    "tags": {},
+    "description": "Vantage MCP tool-selection evals",
+    "prompts": [
+      "{{prompt}}"
+    ],
+    "providers": [
+      {
+        "id": "file://_lib/provider.ts",
+        "label": "gpt-5.6-luna · isolated",
+        "config": {
+          "modelId": "gpt-5.6-luna",
+          "mode": "isolated"
+        }
+      },
+      {
+        "id": "file://_lib/provider.ts",
+        "label": "gpt-5.6-luna · mixed",
+        "config": {
+          "modelId": "gpt-5.6-luna",
+          "mode": "mixed"
+        }
+      }
+    ],
+    "tests": [
+      "file://cases/cost-providers/get-cost-provider-accounts.eval.ts",
+      "file://cases/current-user/get-myself.eval.ts",
+      "file://cases/teams/add-team-member.eval.ts",
+      "file://cases/teams/create-team.eval.ts",
+      "file://cases/teams/delete-team.eval.ts",
+      "file://cases/teams/get-team-members.eval.ts",
+      "file://cases/teams/get-team.eval.ts",
+      "file://cases/teams/get-teams.eval.ts",
+      "file://cases/teams/remove-team-member.eval.ts",
+      "file://cases/teams/update-team.eval.ts"
+    ],
+    "env": {},
+    "extensions": [],
+    "metadata": {},
+    "evaluateOptions": {
+      "maxConcurrency": 4
+    }
+  },
+  "shareableUrl": null,
+  "metadata": {
+    "promptfooVersion": "0.122.0",
+    "nodeVersion": "v23.11.0",
+    "platform": "darwin",
+    "arch": "arm64",
+    "exportedAt": "2026-09-03T18:34:08.896Z",
+    "evaluationCreatedAt": "2026-09-03T18:34:02.765Z"
+  }
+}

--- a/evals/results/gpt-5.6-luna/teams/get-teams.json
+++ b/evals/results/gpt-5.6-luna/teams/get-teams.json
@@ -1,0 +1,833 @@
+{
+  "evalId": null,
+  "results": {
+    "version": 3,
+    "timestamp": "2026-09-03T18:34:09.211Z",
+    "results": [
+      {
+        "cost": 0,
+        "gradingResult": {
+          "pass": true,
+          "score": 1,
+          "reason": "All assertions passed",
+          "namedScores": {},
+          "tokensUsed": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 0
+          },
+          "componentResults": [
+            {
+              "pass": true,
+              "score": 1,
+              "reason": "Expected tool call matched.",
+              "assertion": {
+                "type": "javascript",
+                "value": "file://_lib/assertToolCalls.ts"
+              }
+            }
+          ]
+        },
+        "id": "5fbc98a2-c341-4c62-887b-b77c57eea9f2",
+        "latencyMs": 1263,
+        "namedScores": {},
+        "prompt": {
+          "raw": "Use get-teams to search page 2 for Vantage Teams named Platform that can access workspace wrkspc_abc123.",
+          "label": "{{prompt}}",
+          "config": {
+            "disableVarExpansion": true
+          }
+        },
+        "promptId": "effa18501e44aafd9bc42a2f64ffc9b6350f94025520ca2ed382f9bdc4b6e982",
+        "promptIdx": 0,
+        "provider": {
+          "id": "tool-selection:gpt-5.6-luna:isolated",
+          "label": "gpt-5.6-luna · isolated"
+        },
+        "response": {
+          "output": {
+            "toolCalls": [
+              {
+                "toolName": "get-teams",
+                "input": {
+                  "page": 2,
+                  "q": "Platform",
+                  "workspace_token": "wrkspc_abc123"
+                }
+              }
+            ],
+            "text": ""
+          },
+          "metadata": {
+            "modelId": "gpt-5.6-luna",
+            "mode": "isolated",
+            "target": "get-teams",
+            "toolNames": [
+              "get-teams"
+            ],
+            "toolCalls": [
+              {
+                "toolName": "get-teams",
+                "input": {
+                  "page": 2,
+                  "q": "Platform",
+                  "workspace_token": "wrkspc_abc123"
+                }
+              }
+            ]
+          }
+        },
+        "score": 1,
+        "success": true,
+        "testCase": {
+          "description": "get-teams · direct · Use get-teams to search page 2 for Vantage Teams named Platform that can access workspace wrkspc_abc123.",
+          "vars": {
+            "prompt": "Use get-teams to search page 2 for Vantage Teams named Platform that can access workspace wrkspc_abc123.",
+            "target": "get-teams",
+            "expected": [
+              {
+                "toolName": "get-teams",
+                "input": {
+                  "page": 2,
+                  "q": "Platform",
+                  "workspace_token": "wrkspc_abc123"
+                }
+              }
+            ],
+            "distractors": [
+              "get-team",
+              "get-team-members",
+              "get-users",
+              "list-workspaces"
+            ]
+          },
+          "options": {
+            "disableVarExpansion": true
+          },
+          "metadata": {
+            "tool": "get-teams",
+            "resource": "teams",
+            "phrasing": "direct"
+          },
+          "assert": [
+            {
+              "type": "javascript",
+              "value": "file://_lib/assertToolCalls.ts"
+            }
+          ]
+        },
+        "testIdx": 4,
+        "tokenUsage": {
+          "prompt": 0,
+          "completion": 0,
+          "cached": 0,
+          "total": 0,
+          "numRequests": 1,
+          "completionDetails": {
+            "reasoning": 0,
+            "acceptedPrediction": 0,
+            "rejectedPrediction": 0,
+            "cacheReadInputTokens": 0,
+            "cacheCreationInputTokens": 0
+          },
+          "assertions": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 1,
+            "completionDetails": {
+              "reasoning": 0,
+              "acceptedPrediction": 0,
+              "rejectedPrediction": 0,
+              "cacheReadInputTokens": 0,
+              "cacheCreationInputTokens": 0
+            }
+          }
+        },
+        "vars": {
+          "prompt": "Use get-teams to search page 2 for Vantage Teams named Platform that can access workspace wrkspc_abc123.",
+          "target": "get-teams",
+          "expected": [
+            {
+              "toolName": "get-teams",
+              "input": {
+                "page": 2,
+                "q": "Platform",
+                "workspace_token": "wrkspc_abc123"
+              }
+            }
+          ],
+          "distractors": [
+            "get-team",
+            "get-team-members",
+            "get-users",
+            "list-workspaces"
+          ]
+        },
+        "metadata": {
+          "tool": "get-teams",
+          "resource": "teams",
+          "phrasing": "direct",
+          "modelId": "gpt-5.6-luna",
+          "mode": "isolated",
+          "target": "get-teams",
+          "toolNames": [
+            "get-teams"
+          ],
+          "toolCalls": [
+            {
+              "toolName": "get-teams",
+              "input": {
+                "page": 2,
+                "q": "Platform",
+                "workspace_token": "wrkspc_abc123"
+              }
+            }
+          ],
+          "_promptfooFileMetadata": {}
+        },
+        "failureReason": 0
+      },
+      {
+        "cost": 0,
+        "gradingResult": {
+          "pass": true,
+          "score": 1,
+          "reason": "All assertions passed",
+          "namedScores": {},
+          "tokensUsed": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 0
+          },
+          "componentResults": [
+            {
+              "pass": true,
+              "score": 1,
+              "reason": "Expected tool call matched.",
+              "assertion": {
+                "type": "javascript",
+                "value": "file://_lib/assertToolCalls.ts"
+              }
+            }
+          ]
+        },
+        "id": "80b4f8c1-3703-4680-b810-4e623087f7d7",
+        "latencyMs": 1375,
+        "namedScores": {},
+        "prompt": {
+          "raw": "Use get-teams to search page 2 for Vantage Teams named Platform that can access workspace wrkspc_abc123.",
+          "label": "{{prompt}}",
+          "config": {
+            "disableVarExpansion": true
+          }
+        },
+        "promptId": "effa18501e44aafd9bc42a2f64ffc9b6350f94025520ca2ed382f9bdc4b6e982",
+        "promptIdx": 1,
+        "provider": {
+          "id": "tool-selection:gpt-5.6-luna:mixed",
+          "label": "gpt-5.6-luna · mixed"
+        },
+        "response": {
+          "output": {
+            "toolCalls": [
+              {
+                "toolName": "get-teams",
+                "input": {
+                  "page": 2,
+                  "q": "Platform",
+                  "workspace_token": "wrkspc_abc123"
+                }
+              }
+            ],
+            "text": ""
+          },
+          "metadata": {
+            "modelId": "gpt-5.6-luna",
+            "mode": "mixed",
+            "target": "get-teams",
+            "toolNames": [
+              "get-teams",
+              "get-team",
+              "get-team-members",
+              "get-users",
+              "list-workspaces"
+            ],
+            "toolCalls": [
+              {
+                "toolName": "get-teams",
+                "input": {
+                  "page": 2,
+                  "q": "Platform",
+                  "workspace_token": "wrkspc_abc123"
+                }
+              }
+            ]
+          }
+        },
+        "score": 1,
+        "success": true,
+        "testCase": {
+          "description": "get-teams · direct · Use get-teams to search page 2 for Vantage Teams named Platform that can access workspace wrkspc_abc123.",
+          "vars": {
+            "prompt": "Use get-teams to search page 2 for Vantage Teams named Platform that can access workspace wrkspc_abc123.",
+            "target": "get-teams",
+            "expected": [
+              {
+                "toolName": "get-teams",
+                "input": {
+                  "page": 2,
+                  "q": "Platform",
+                  "workspace_token": "wrkspc_abc123"
+                }
+              }
+            ],
+            "distractors": [
+              "get-team",
+              "get-team-members",
+              "get-users",
+              "list-workspaces"
+            ]
+          },
+          "options": {
+            "disableVarExpansion": true
+          },
+          "metadata": {
+            "tool": "get-teams",
+            "resource": "teams",
+            "phrasing": "direct"
+          },
+          "assert": [
+            {
+              "type": "javascript",
+              "value": "file://_lib/assertToolCalls.ts"
+            }
+          ]
+        },
+        "testIdx": 4,
+        "tokenUsage": {
+          "prompt": 0,
+          "completion": 0,
+          "cached": 0,
+          "total": 0,
+          "numRequests": 1,
+          "completionDetails": {
+            "reasoning": 0,
+            "acceptedPrediction": 0,
+            "rejectedPrediction": 0,
+            "cacheReadInputTokens": 0,
+            "cacheCreationInputTokens": 0
+          },
+          "assertions": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 1,
+            "completionDetails": {
+              "reasoning": 0,
+              "acceptedPrediction": 0,
+              "rejectedPrediction": 0,
+              "cacheReadInputTokens": 0,
+              "cacheCreationInputTokens": 0
+            }
+          }
+        },
+        "vars": {
+          "prompt": "Use get-teams to search page 2 for Vantage Teams named Platform that can access workspace wrkspc_abc123.",
+          "target": "get-teams",
+          "expected": [
+            {
+              "toolName": "get-teams",
+              "input": {
+                "page": 2,
+                "q": "Platform",
+                "workspace_token": "wrkspc_abc123"
+              }
+            }
+          ],
+          "distractors": [
+            "get-team",
+            "get-team-members",
+            "get-users",
+            "list-workspaces"
+          ]
+        },
+        "metadata": {
+          "tool": "get-teams",
+          "resource": "teams",
+          "phrasing": "direct",
+          "modelId": "gpt-5.6-luna",
+          "mode": "mixed",
+          "target": "get-teams",
+          "toolNames": [
+            "get-teams",
+            "get-team",
+            "get-team-members",
+            "get-users",
+            "list-workspaces"
+          ],
+          "toolCalls": [
+            {
+              "toolName": "get-teams",
+              "input": {
+                "page": 2,
+                "q": "Platform",
+                "workspace_token": "wrkspc_abc123"
+              }
+            }
+          ],
+          "_promptfooFileMetadata": {}
+        },
+        "failureReason": 0
+      },
+      {
+        "cost": 0,
+        "gradingResult": {
+          "pass": true,
+          "score": 1,
+          "reason": "All assertions passed",
+          "namedScores": {},
+          "tokensUsed": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 0
+          },
+          "componentResults": [
+            {
+              "pass": true,
+              "score": 1,
+              "reason": "Expected tool call matched.",
+              "assertion": {
+                "type": "javascript",
+                "value": "file://_lib/assertToolCalls.ts"
+              }
+            }
+          ]
+        },
+        "id": "41d03229-613f-45f8-8c54-16fa0d0f1461",
+        "latencyMs": 1401,
+        "namedScores": {},
+        "prompt": {
+          "raw": "Which Vantage Teams can access workspace wrkspc_abc123? Show page 3.",
+          "label": "{{prompt}}",
+          "config": {
+            "disableVarExpansion": true
+          }
+        },
+        "promptId": "effa18501e44aafd9bc42a2f64ffc9b6350f94025520ca2ed382f9bdc4b6e982",
+        "promptIdx": 0,
+        "provider": {
+          "id": "tool-selection:gpt-5.6-luna:isolated",
+          "label": "gpt-5.6-luna · isolated"
+        },
+        "response": {
+          "output": {
+            "toolCalls": [
+              {
+                "toolName": "get-teams",
+                "input": {
+                  "page": 3,
+                  "workspace_token": "wrkspc_abc123"
+                }
+              }
+            ],
+            "text": ""
+          },
+          "metadata": {
+            "modelId": "gpt-5.6-luna",
+            "mode": "isolated",
+            "target": "get-teams",
+            "toolNames": [
+              "get-teams"
+            ],
+            "toolCalls": [
+              {
+                "toolName": "get-teams",
+                "input": {
+                  "page": 3,
+                  "workspace_token": "wrkspc_abc123"
+                }
+              }
+            ]
+          }
+        },
+        "score": 1,
+        "success": true,
+        "testCase": {
+          "description": "get-teams · inferred · Which Vantage Teams can access workspace wrkspc_abc123? Show page 3.",
+          "vars": {
+            "prompt": "Which Vantage Teams can access workspace wrkspc_abc123? Show page 3.",
+            "target": "get-teams",
+            "expected": [
+              {
+                "toolName": "get-teams",
+                "input": {
+                  "page": 3,
+                  "workspace_token": "wrkspc_abc123"
+                }
+              }
+            ],
+            "distractors": [
+              "get-team",
+              "get-team-members",
+              "get-users",
+              "list-workspaces"
+            ]
+          },
+          "options": {
+            "disableVarExpansion": true
+          },
+          "metadata": {
+            "tool": "get-teams",
+            "resource": "teams",
+            "phrasing": "inferred"
+          },
+          "assert": [
+            {
+              "type": "javascript",
+              "value": "file://_lib/assertToolCalls.ts"
+            }
+          ]
+        },
+        "testIdx": 5,
+        "tokenUsage": {
+          "prompt": 0,
+          "completion": 0,
+          "cached": 0,
+          "total": 0,
+          "numRequests": 1,
+          "completionDetails": {
+            "reasoning": 0,
+            "acceptedPrediction": 0,
+            "rejectedPrediction": 0,
+            "cacheReadInputTokens": 0,
+            "cacheCreationInputTokens": 0
+          },
+          "assertions": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 1,
+            "completionDetails": {
+              "reasoning": 0,
+              "acceptedPrediction": 0,
+              "rejectedPrediction": 0,
+              "cacheReadInputTokens": 0,
+              "cacheCreationInputTokens": 0
+            }
+          }
+        },
+        "vars": {
+          "prompt": "Which Vantage Teams can access workspace wrkspc_abc123? Show page 3.",
+          "target": "get-teams",
+          "expected": [
+            {
+              "toolName": "get-teams",
+              "input": {
+                "page": 3,
+                "workspace_token": "wrkspc_abc123"
+              }
+            }
+          ],
+          "distractors": [
+            "get-team",
+            "get-team-members",
+            "get-users",
+            "list-workspaces"
+          ]
+        },
+        "metadata": {
+          "tool": "get-teams",
+          "resource": "teams",
+          "phrasing": "inferred",
+          "modelId": "gpt-5.6-luna",
+          "mode": "isolated",
+          "target": "get-teams",
+          "toolNames": [
+            "get-teams"
+          ],
+          "toolCalls": [
+            {
+              "toolName": "get-teams",
+              "input": {
+                "page": 3,
+                "workspace_token": "wrkspc_abc123"
+              }
+            }
+          ],
+          "_promptfooFileMetadata": {}
+        },
+        "failureReason": 0
+      },
+      {
+        "cost": 0,
+        "gradingResult": {
+          "pass": true,
+          "score": 1,
+          "reason": "All assertions passed",
+          "namedScores": {},
+          "tokensUsed": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 0
+          },
+          "componentResults": [
+            {
+              "pass": true,
+              "score": 1,
+              "reason": "Expected tool call matched.",
+              "assertion": {
+                "type": "javascript",
+                "value": "file://_lib/assertToolCalls.ts"
+              }
+            }
+          ]
+        },
+        "id": "24f7bd89-834b-43bb-88d8-81e727617bfc",
+        "latencyMs": 1879,
+        "namedScores": {},
+        "prompt": {
+          "raw": "Which Vantage Teams can access workspace wrkspc_abc123? Show page 3.",
+          "label": "{{prompt}}",
+          "config": {
+            "disableVarExpansion": true
+          }
+        },
+        "promptId": "effa18501e44aafd9bc42a2f64ffc9b6350f94025520ca2ed382f9bdc4b6e982",
+        "promptIdx": 1,
+        "provider": {
+          "id": "tool-selection:gpt-5.6-luna:mixed",
+          "label": "gpt-5.6-luna · mixed"
+        },
+        "response": {
+          "output": {
+            "toolCalls": [
+              {
+                "toolName": "get-teams",
+                "input": {
+                  "page": 3,
+                  "workspace_token": "wrkspc_abc123"
+                }
+              }
+            ],
+            "text": ""
+          },
+          "metadata": {
+            "modelId": "gpt-5.6-luna",
+            "mode": "mixed",
+            "target": "get-teams",
+            "toolNames": [
+              "get-teams",
+              "get-team",
+              "get-team-members",
+              "get-users",
+              "list-workspaces"
+            ],
+            "toolCalls": [
+              {
+                "toolName": "get-teams",
+                "input": {
+                  "page": 3,
+                  "workspace_token": "wrkspc_abc123"
+                }
+              }
+            ]
+          }
+        },
+        "score": 1,
+        "success": true,
+        "testCase": {
+          "description": "get-teams · inferred · Which Vantage Teams can access workspace wrkspc_abc123? Show page 3.",
+          "vars": {
+            "prompt": "Which Vantage Teams can access workspace wrkspc_abc123? Show page 3.",
+            "target": "get-teams",
+            "expected": [
+              {
+                "toolName": "get-teams",
+                "input": {
+                  "page": 3,
+                  "workspace_token": "wrkspc_abc123"
+                }
+              }
+            ],
+            "distractors": [
+              "get-team",
+              "get-team-members",
+              "get-users",
+              "list-workspaces"
+            ]
+          },
+          "options": {
+            "disableVarExpansion": true
+          },
+          "metadata": {
+            "tool": "get-teams",
+            "resource": "teams",
+            "phrasing": "inferred"
+          },
+          "assert": [
+            {
+              "type": "javascript",
+              "value": "file://_lib/assertToolCalls.ts"
+            }
+          ]
+        },
+        "testIdx": 5,
+        "tokenUsage": {
+          "prompt": 0,
+          "completion": 0,
+          "cached": 0,
+          "total": 0,
+          "numRequests": 1,
+          "completionDetails": {
+            "reasoning": 0,
+            "acceptedPrediction": 0,
+            "rejectedPrediction": 0,
+            "cacheReadInputTokens": 0,
+            "cacheCreationInputTokens": 0
+          },
+          "assertions": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 1,
+            "completionDetails": {
+              "reasoning": 0,
+              "acceptedPrediction": 0,
+              "rejectedPrediction": 0,
+              "cacheReadInputTokens": 0,
+              "cacheCreationInputTokens": 0
+            }
+          }
+        },
+        "vars": {
+          "prompt": "Which Vantage Teams can access workspace wrkspc_abc123? Show page 3.",
+          "target": "get-teams",
+          "expected": [
+            {
+              "toolName": "get-teams",
+              "input": {
+                "page": 3,
+                "workspace_token": "wrkspc_abc123"
+              }
+            }
+          ],
+          "distractors": [
+            "get-team",
+            "get-team-members",
+            "get-users",
+            "list-workspaces"
+          ]
+        },
+        "metadata": {
+          "tool": "get-teams",
+          "resource": "teams",
+          "phrasing": "inferred",
+          "modelId": "gpt-5.6-luna",
+          "mode": "mixed",
+          "target": "get-teams",
+          "toolNames": [
+            "get-teams",
+            "get-team",
+            "get-team-members",
+            "get-users",
+            "list-workspaces"
+          ],
+          "toolCalls": [
+            {
+              "toolName": "get-teams",
+              "input": {
+                "page": 3,
+                "workspace_token": "wrkspc_abc123"
+              }
+            }
+          ],
+          "_promptfooFileMetadata": {}
+        },
+        "failureReason": 0
+      }
+    ],
+    "prompts": [],
+    "stats": {
+      "successes": 4,
+      "failures": 0,
+      "errors": 0,
+      "tokenUsage": {
+        "prompt": 0,
+        "completion": 0,
+        "cached": 0,
+        "total": 0,
+        "numRequests": 4,
+        "completionDetails": {
+          "reasoning": 0,
+          "acceptedPrediction": 0,
+          "rejectedPrediction": 0
+        }
+      }
+    }
+  },
+  "config": {
+    "tags": {},
+    "description": "Vantage MCP tool-selection evals",
+    "prompts": [
+      "{{prompt}}"
+    ],
+    "providers": [
+      {
+        "id": "file://_lib/provider.ts",
+        "label": "gpt-5.6-luna · isolated",
+        "config": {
+          "modelId": "gpt-5.6-luna",
+          "mode": "isolated"
+        }
+      },
+      {
+        "id": "file://_lib/provider.ts",
+        "label": "gpt-5.6-luna · mixed",
+        "config": {
+          "modelId": "gpt-5.6-luna",
+          "mode": "mixed"
+        }
+      }
+    ],
+    "tests": [
+      "file://cases/cost-providers/get-cost-provider-accounts.eval.ts",
+      "file://cases/current-user/get-myself.eval.ts",
+      "file://cases/teams/add-team-member.eval.ts",
+      "file://cases/teams/create-team.eval.ts",
+      "file://cases/teams/delete-team.eval.ts",
+      "file://cases/teams/get-team-members.eval.ts",
+      "file://cases/teams/get-team.eval.ts",
+      "file://cases/teams/get-teams.eval.ts",
+      "file://cases/teams/remove-team-member.eval.ts",
+      "file://cases/teams/update-team.eval.ts"
+    ],
+    "env": {},
+    "extensions": [],
+    "metadata": {},
+    "evaluateOptions": {
+      "maxConcurrency": 4
+    }
+  },
+  "shareableUrl": null,
+  "metadata": {
+    "promptfooVersion": "0.122.0",
+    "nodeVersion": "v23.11.0",
+    "platform": "darwin",
+    "arch": "arm64",
+    "exportedAt": "2026-09-03T18:34:08.896Z",
+    "evaluationCreatedAt": "2026-09-03T18:34:02.765Z"
+  }
+}

--- a/evals/results/gpt-5.6-luna/teams/remove-team-member.json
+++ b/evals/results/gpt-5.6-luna/teams/remove-team-member.json
@@ -1,0 +1,821 @@
+{
+  "evalId": null,
+  "results": {
+    "version": 3,
+    "timestamp": "2026-09-03T16:55:01.025Z",
+    "results": [
+      {
+        "cost": 0,
+        "gradingResult": {
+          "pass": true,
+          "score": 1,
+          "reason": "All assertions passed",
+          "namedScores": {},
+          "tokensUsed": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 0
+          },
+          "componentResults": [
+            {
+              "pass": true,
+              "score": 1,
+              "reason": "Expected tool call matched.",
+              "assertion": {
+                "type": "javascript",
+                "value": "file://_lib/assertToolCalls.ts"
+              }
+            }
+          ]
+        },
+        "id": "5a6c9d3a-c6fb-43dc-9321-59d1bac03e74",
+        "latencyMs": 1608,
+        "namedScores": {},
+        "prompt": {
+          "raw": "Use remove-team-member to remove user usr_def456 from Vantage Team team_abc123.",
+          "label": "{{prompt}}",
+          "config": {
+            "disableVarExpansion": true
+          }
+        },
+        "promptId": "effa18501e44aafd9bc42a2f64ffc9b6350f94025520ca2ed382f9bdc4b6e982",
+        "promptIdx": 0,
+        "provider": {
+          "id": "tool-selection:gpt-5.6-luna:isolated",
+          "label": "gpt-5.6-luna · isolated"
+        },
+        "response": {
+          "output": {
+            "toolCalls": [
+              {
+                "toolName": "remove-team-member",
+                "input": {
+                  "team_token": "team_abc123",
+                  "user_token": "usr_def456"
+                }
+              }
+            ],
+            "text": ""
+          },
+          "metadata": {
+            "modelId": "gpt-5.6-luna",
+            "mode": "isolated",
+            "target": "remove-team-member",
+            "toolNames": [
+              "remove-team-member"
+            ],
+            "toolCalls": [
+              {
+                "toolName": "remove-team-member",
+                "input": {
+                  "team_token": "team_abc123",
+                  "user_token": "usr_def456"
+                }
+              }
+            ]
+          }
+        },
+        "score": 1,
+        "success": true,
+        "testCase": {
+          "description": "remove-team-member · direct · Use remove-team-member to remove user usr_def456 from Vantage Team team_abc123.",
+          "vars": {
+            "prompt": "Use remove-team-member to remove user usr_def456 from Vantage Team team_abc123.",
+            "target": "remove-team-member",
+            "expected": [
+              {
+                "toolName": "remove-team-member",
+                "input": {
+                  "team_token": "team_abc123",
+                  "user_token": "usr_def456"
+                }
+              }
+            ],
+            "distractors": [
+              "add-team-member",
+              "get-team-members",
+              "delete-team",
+              "update-team"
+            ]
+          },
+          "options": {
+            "disableVarExpansion": true
+          },
+          "metadata": {
+            "tool": "remove-team-member",
+            "resource": "teams",
+            "phrasing": "direct"
+          },
+          "assert": [
+            {
+              "type": "javascript",
+              "value": "file://_lib/assertToolCalls.ts"
+            }
+          ]
+        },
+        "testIdx": 0,
+        "tokenUsage": {
+          "prompt": 0,
+          "completion": 0,
+          "cached": 0,
+          "total": 0,
+          "numRequests": 1,
+          "completionDetails": {
+            "reasoning": 0,
+            "acceptedPrediction": 0,
+            "rejectedPrediction": 0,
+            "cacheReadInputTokens": 0,
+            "cacheCreationInputTokens": 0
+          },
+          "assertions": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 1,
+            "completionDetails": {
+              "reasoning": 0,
+              "acceptedPrediction": 0,
+              "rejectedPrediction": 0,
+              "cacheReadInputTokens": 0,
+              "cacheCreationInputTokens": 0
+            }
+          }
+        },
+        "vars": {
+          "prompt": "Use remove-team-member to remove user usr_def456 from Vantage Team team_abc123.",
+          "target": "remove-team-member",
+          "expected": [
+            {
+              "toolName": "remove-team-member",
+              "input": {
+                "team_token": "team_abc123",
+                "user_token": "usr_def456"
+              }
+            }
+          ],
+          "distractors": [
+            "add-team-member",
+            "get-team-members",
+            "delete-team",
+            "update-team"
+          ]
+        },
+        "metadata": {
+          "tool": "remove-team-member",
+          "resource": "teams",
+          "phrasing": "direct",
+          "modelId": "gpt-5.6-luna",
+          "mode": "isolated",
+          "target": "remove-team-member",
+          "toolNames": [
+            "remove-team-member"
+          ],
+          "toolCalls": [
+            {
+              "toolName": "remove-team-member",
+              "input": {
+                "team_token": "team_abc123",
+                "user_token": "usr_def456"
+              }
+            }
+          ],
+          "_promptfooFileMetadata": {}
+        },
+        "failureReason": 0
+      },
+      {
+        "cost": 0,
+        "gradingResult": {
+          "pass": true,
+          "score": 1,
+          "reason": "All assertions passed",
+          "namedScores": {},
+          "tokensUsed": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 0
+          },
+          "componentResults": [
+            {
+              "pass": true,
+              "score": 1,
+              "reason": "Expected tool call matched.",
+              "assertion": {
+                "type": "javascript",
+                "value": "file://_lib/assertToolCalls.ts"
+              }
+            }
+          ]
+        },
+        "id": "6c8d10fd-e8ce-49d5-9b93-ba7e9dbf76ae",
+        "latencyMs": 1788,
+        "namedScores": {},
+        "prompt": {
+          "raw": "Use remove-team-member to remove user usr_def456 from Vantage Team team_abc123.",
+          "label": "{{prompt}}",
+          "config": {
+            "disableVarExpansion": true
+          }
+        },
+        "promptId": "effa18501e44aafd9bc42a2f64ffc9b6350f94025520ca2ed382f9bdc4b6e982",
+        "promptIdx": 1,
+        "provider": {
+          "id": "tool-selection:gpt-5.6-luna:mixed",
+          "label": "gpt-5.6-luna · mixed"
+        },
+        "response": {
+          "output": {
+            "toolCalls": [
+              {
+                "toolName": "remove-team-member",
+                "input": {
+                  "team_token": "team_abc123",
+                  "user_token": "usr_def456"
+                }
+              }
+            ],
+            "text": ""
+          },
+          "metadata": {
+            "modelId": "gpt-5.6-luna",
+            "mode": "mixed",
+            "target": "remove-team-member",
+            "toolNames": [
+              "remove-team-member",
+              "add-team-member",
+              "get-team-members",
+              "delete-team",
+              "update-team"
+            ],
+            "toolCalls": [
+              {
+                "toolName": "remove-team-member",
+                "input": {
+                  "team_token": "team_abc123",
+                  "user_token": "usr_def456"
+                }
+              }
+            ]
+          }
+        },
+        "score": 1,
+        "success": true,
+        "testCase": {
+          "description": "remove-team-member · direct · Use remove-team-member to remove user usr_def456 from Vantage Team team_abc123.",
+          "vars": {
+            "prompt": "Use remove-team-member to remove user usr_def456 from Vantage Team team_abc123.",
+            "target": "remove-team-member",
+            "expected": [
+              {
+                "toolName": "remove-team-member",
+                "input": {
+                  "team_token": "team_abc123",
+                  "user_token": "usr_def456"
+                }
+              }
+            ],
+            "distractors": [
+              "add-team-member",
+              "get-team-members",
+              "delete-team",
+              "update-team"
+            ]
+          },
+          "options": {
+            "disableVarExpansion": true
+          },
+          "metadata": {
+            "tool": "remove-team-member",
+            "resource": "teams",
+            "phrasing": "direct"
+          },
+          "assert": [
+            {
+              "type": "javascript",
+              "value": "file://_lib/assertToolCalls.ts"
+            }
+          ]
+        },
+        "testIdx": 0,
+        "tokenUsage": {
+          "prompt": 0,
+          "completion": 0,
+          "cached": 0,
+          "total": 0,
+          "numRequests": 1,
+          "completionDetails": {
+            "reasoning": 0,
+            "acceptedPrediction": 0,
+            "rejectedPrediction": 0,
+            "cacheReadInputTokens": 0,
+            "cacheCreationInputTokens": 0
+          },
+          "assertions": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 1,
+            "completionDetails": {
+              "reasoning": 0,
+              "acceptedPrediction": 0,
+              "rejectedPrediction": 0,
+              "cacheReadInputTokens": 0,
+              "cacheCreationInputTokens": 0
+            }
+          }
+        },
+        "vars": {
+          "prompt": "Use remove-team-member to remove user usr_def456 from Vantage Team team_abc123.",
+          "target": "remove-team-member",
+          "expected": [
+            {
+              "toolName": "remove-team-member",
+              "input": {
+                "team_token": "team_abc123",
+                "user_token": "usr_def456"
+              }
+            }
+          ],
+          "distractors": [
+            "add-team-member",
+            "get-team-members",
+            "delete-team",
+            "update-team"
+          ]
+        },
+        "metadata": {
+          "tool": "remove-team-member",
+          "resource": "teams",
+          "phrasing": "direct",
+          "modelId": "gpt-5.6-luna",
+          "mode": "mixed",
+          "target": "remove-team-member",
+          "toolNames": [
+            "remove-team-member",
+            "add-team-member",
+            "get-team-members",
+            "delete-team",
+            "update-team"
+          ],
+          "toolCalls": [
+            {
+              "toolName": "remove-team-member",
+              "input": {
+                "team_token": "team_abc123",
+                "user_token": "usr_def456"
+              }
+            }
+          ],
+          "_promptfooFileMetadata": {}
+        },
+        "failureReason": 0
+      },
+      {
+        "cost": 0,
+        "gradingResult": {
+          "pass": true,
+          "score": 1,
+          "reason": "All assertions passed",
+          "namedScores": {},
+          "tokensUsed": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 0
+          },
+          "componentResults": [
+            {
+              "pass": true,
+              "score": 1,
+              "reason": "Expected tool call matched.",
+              "assertion": {
+                "type": "javascript",
+                "value": "file://_lib/assertToolCalls.ts"
+              }
+            }
+          ]
+        },
+        "id": "ea6b4714-e879-4b8e-99aa-18033a6c95c9",
+        "latencyMs": 1529,
+        "namedScores": {},
+        "prompt": {
+          "raw": "Take user usr_legacy789 off the Vantage Team team_abc123 without deleting the user.",
+          "label": "{{prompt}}",
+          "config": {
+            "disableVarExpansion": true
+          }
+        },
+        "promptId": "effa18501e44aafd9bc42a2f64ffc9b6350f94025520ca2ed382f9bdc4b6e982",
+        "promptIdx": 0,
+        "provider": {
+          "id": "tool-selection:gpt-5.6-luna:isolated",
+          "label": "gpt-5.6-luna · isolated"
+        },
+        "response": {
+          "output": {
+            "toolCalls": [
+              {
+                "toolName": "remove-team-member",
+                "input": {
+                  "team_token": "team_abc123",
+                  "user_token": "usr_legacy789"
+                }
+              }
+            ],
+            "text": ""
+          },
+          "metadata": {
+            "modelId": "gpt-5.6-luna",
+            "mode": "isolated",
+            "target": "remove-team-member",
+            "toolNames": [
+              "remove-team-member"
+            ],
+            "toolCalls": [
+              {
+                "toolName": "remove-team-member",
+                "input": {
+                  "team_token": "team_abc123",
+                  "user_token": "usr_legacy789"
+                }
+              }
+            ]
+          }
+        },
+        "score": 1,
+        "success": true,
+        "testCase": {
+          "description": "remove-team-member · inferred · Take user usr_legacy789 off the Vantage Team team_abc123 without deleting the user.",
+          "vars": {
+            "prompt": "Take user usr_legacy789 off the Vantage Team team_abc123 without deleting the user.",
+            "target": "remove-team-member",
+            "expected": [
+              {
+                "toolName": "remove-team-member",
+                "input": {
+                  "team_token": "team_abc123",
+                  "user_token": "usr_legacy789"
+                }
+              }
+            ],
+            "distractors": [
+              "add-team-member",
+              "get-team-members",
+              "delete-team",
+              "update-team"
+            ]
+          },
+          "options": {
+            "disableVarExpansion": true
+          },
+          "metadata": {
+            "tool": "remove-team-member",
+            "resource": "teams",
+            "phrasing": "inferred"
+          },
+          "assert": [
+            {
+              "type": "javascript",
+              "value": "file://_lib/assertToolCalls.ts"
+            }
+          ]
+        },
+        "testIdx": 1,
+        "tokenUsage": {
+          "prompt": 0,
+          "completion": 0,
+          "cached": 0,
+          "total": 0,
+          "numRequests": 1,
+          "completionDetails": {
+            "reasoning": 0,
+            "acceptedPrediction": 0,
+            "rejectedPrediction": 0,
+            "cacheReadInputTokens": 0,
+            "cacheCreationInputTokens": 0
+          },
+          "assertions": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 1,
+            "completionDetails": {
+              "reasoning": 0,
+              "acceptedPrediction": 0,
+              "rejectedPrediction": 0,
+              "cacheReadInputTokens": 0,
+              "cacheCreationInputTokens": 0
+            }
+          }
+        },
+        "vars": {
+          "prompt": "Take user usr_legacy789 off the Vantage Team team_abc123 without deleting the user.",
+          "target": "remove-team-member",
+          "expected": [
+            {
+              "toolName": "remove-team-member",
+              "input": {
+                "team_token": "team_abc123",
+                "user_token": "usr_legacy789"
+              }
+            }
+          ],
+          "distractors": [
+            "add-team-member",
+            "get-team-members",
+            "delete-team",
+            "update-team"
+          ]
+        },
+        "metadata": {
+          "tool": "remove-team-member",
+          "resource": "teams",
+          "phrasing": "inferred",
+          "modelId": "gpt-5.6-luna",
+          "mode": "isolated",
+          "target": "remove-team-member",
+          "toolNames": [
+            "remove-team-member"
+          ],
+          "toolCalls": [
+            {
+              "toolName": "remove-team-member",
+              "input": {
+                "team_token": "team_abc123",
+                "user_token": "usr_legacy789"
+              }
+            }
+          ],
+          "_promptfooFileMetadata": {}
+        },
+        "failureReason": 0
+      },
+      {
+        "cost": 0,
+        "gradingResult": {
+          "pass": true,
+          "score": 1,
+          "reason": "All assertions passed",
+          "namedScores": {},
+          "tokensUsed": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 0
+          },
+          "componentResults": [
+            {
+              "pass": true,
+              "score": 1,
+              "reason": "Expected tool call matched.",
+              "assertion": {
+                "type": "javascript",
+                "value": "file://_lib/assertToolCalls.ts"
+              }
+            }
+          ]
+        },
+        "id": "d5ce0891-91dd-4182-8e29-cb14655407ec",
+        "latencyMs": 1785,
+        "namedScores": {},
+        "prompt": {
+          "raw": "Take user usr_legacy789 off the Vantage Team team_abc123 without deleting the user.",
+          "label": "{{prompt}}",
+          "config": {
+            "disableVarExpansion": true
+          }
+        },
+        "promptId": "effa18501e44aafd9bc42a2f64ffc9b6350f94025520ca2ed382f9bdc4b6e982",
+        "promptIdx": 1,
+        "provider": {
+          "id": "tool-selection:gpt-5.6-luna:mixed",
+          "label": "gpt-5.6-luna · mixed"
+        },
+        "response": {
+          "output": {
+            "toolCalls": [
+              {
+                "toolName": "remove-team-member",
+                "input": {
+                  "team_token": "team_abc123",
+                  "user_token": "usr_legacy789"
+                }
+              }
+            ],
+            "text": ""
+          },
+          "metadata": {
+            "modelId": "gpt-5.6-luna",
+            "mode": "mixed",
+            "target": "remove-team-member",
+            "toolNames": [
+              "remove-team-member",
+              "add-team-member",
+              "get-team-members",
+              "delete-team",
+              "update-team"
+            ],
+            "toolCalls": [
+              {
+                "toolName": "remove-team-member",
+                "input": {
+                  "team_token": "team_abc123",
+                  "user_token": "usr_legacy789"
+                }
+              }
+            ]
+          }
+        },
+        "score": 1,
+        "success": true,
+        "testCase": {
+          "description": "remove-team-member · inferred · Take user usr_legacy789 off the Vantage Team team_abc123 without deleting the user.",
+          "vars": {
+            "prompt": "Take user usr_legacy789 off the Vantage Team team_abc123 without deleting the user.",
+            "target": "remove-team-member",
+            "expected": [
+              {
+                "toolName": "remove-team-member",
+                "input": {
+                  "team_token": "team_abc123",
+                  "user_token": "usr_legacy789"
+                }
+              }
+            ],
+            "distractors": [
+              "add-team-member",
+              "get-team-members",
+              "delete-team",
+              "update-team"
+            ]
+          },
+          "options": {
+            "disableVarExpansion": true
+          },
+          "metadata": {
+            "tool": "remove-team-member",
+            "resource": "teams",
+            "phrasing": "inferred"
+          },
+          "assert": [
+            {
+              "type": "javascript",
+              "value": "file://_lib/assertToolCalls.ts"
+            }
+          ]
+        },
+        "testIdx": 1,
+        "tokenUsage": {
+          "prompt": 0,
+          "completion": 0,
+          "cached": 0,
+          "total": 0,
+          "numRequests": 1,
+          "completionDetails": {
+            "reasoning": 0,
+            "acceptedPrediction": 0,
+            "rejectedPrediction": 0,
+            "cacheReadInputTokens": 0,
+            "cacheCreationInputTokens": 0
+          },
+          "assertions": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 1,
+            "completionDetails": {
+              "reasoning": 0,
+              "acceptedPrediction": 0,
+              "rejectedPrediction": 0,
+              "cacheReadInputTokens": 0,
+              "cacheCreationInputTokens": 0
+            }
+          }
+        },
+        "vars": {
+          "prompt": "Take user usr_legacy789 off the Vantage Team team_abc123 without deleting the user.",
+          "target": "remove-team-member",
+          "expected": [
+            {
+              "toolName": "remove-team-member",
+              "input": {
+                "team_token": "team_abc123",
+                "user_token": "usr_legacy789"
+              }
+            }
+          ],
+          "distractors": [
+            "add-team-member",
+            "get-team-members",
+            "delete-team",
+            "update-team"
+          ]
+        },
+        "metadata": {
+          "tool": "remove-team-member",
+          "resource": "teams",
+          "phrasing": "inferred",
+          "modelId": "gpt-5.6-luna",
+          "mode": "mixed",
+          "target": "remove-team-member",
+          "toolNames": [
+            "remove-team-member",
+            "add-team-member",
+            "get-team-members",
+            "delete-team",
+            "update-team"
+          ],
+          "toolCalls": [
+            {
+              "toolName": "remove-team-member",
+              "input": {
+                "team_token": "team_abc123",
+                "user_token": "usr_legacy789"
+              }
+            }
+          ],
+          "_promptfooFileMetadata": {}
+        },
+        "failureReason": 0
+      }
+    ],
+    "prompts": [],
+    "stats": {
+      "successes": 4,
+      "failures": 0,
+      "errors": 0,
+      "tokenUsage": {
+        "prompt": 0,
+        "completion": 0,
+        "cached": 0,
+        "total": 0,
+        "numRequests": 4,
+        "completionDetails": {
+          "reasoning": 0,
+          "acceptedPrediction": 0,
+          "rejectedPrediction": 0
+        }
+      }
+    }
+  },
+  "config": {
+    "tags": {},
+    "description": "Vantage MCP tool-selection evals",
+    "prompts": [
+      "{{prompt}}"
+    ],
+    "providers": [
+      {
+        "id": "file://_lib/provider.ts",
+        "label": "gpt-5.6-luna · isolated",
+        "config": {
+          "modelId": "gpt-5.6-luna",
+          "mode": "isolated"
+        }
+      },
+      {
+        "id": "file://_lib/provider.ts",
+        "label": "gpt-5.6-luna · mixed",
+        "config": {
+          "modelId": "gpt-5.6-luna",
+          "mode": "mixed"
+        }
+      }
+    ],
+    "tests": [
+      "file://cases/cost-providers/get-cost-provider-accounts.eval.ts",
+      "file://cases/current-user/get-myself.eval.ts",
+      "file://cases/teams/add-team-member.eval.ts",
+      "file://cases/teams/create-team.eval.ts",
+      "file://cases/teams/delete-team.eval.ts",
+      "file://cases/teams/get-team-members.eval.ts",
+      "file://cases/teams/remove-team-member.eval.ts",
+      "file://cases/teams/update-team.eval.ts"
+    ],
+    "env": {},
+    "extensions": [],
+    "metadata": {},
+    "evaluateOptions": {
+      "maxConcurrency": 4
+    }
+  },
+  "shareableUrl": null,
+  "metadata": {
+    "promptfooVersion": "0.122.0",
+    "nodeVersion": "v23.11.0",
+    "platform": "darwin",
+    "arch": "arm64",
+    "exportedAt": "2026-09-03T16:55:00.709Z",
+    "evaluationCreatedAt": "2026-09-03T16:54:58.867Z"
+  }
+}

--- a/evals/results/gpt-5.6-luna/teams/update-team.json
+++ b/evals/results/gpt-5.6-luna/teams/update-team.json
@@ -1,0 +1,831 @@
+{
+  "evalId": null,
+  "results": {
+    "version": 3,
+    "timestamp": "2026-09-03T16:55:17.874Z",
+    "results": [
+      {
+        "cost": 0,
+        "gradingResult": {
+          "pass": true,
+          "score": 1,
+          "reason": "All assertions passed",
+          "namedScores": {},
+          "tokensUsed": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 0
+          },
+          "componentResults": [
+            {
+              "pass": true,
+              "score": 1,
+              "reason": "Expected tool call matched.",
+              "assertion": {
+                "type": "javascript",
+                "value": "file://_lib/assertToolCalls.ts"
+              }
+            }
+          ]
+        },
+        "id": "6a5760e9-1642-4dc0-8987-be83a024ae60",
+        "latencyMs": 1830,
+        "namedScores": {},
+        "prompt": {
+          "raw": "Use update-team to rename team_abc123 to Platform Engineering and clear its default Dashboard.",
+          "label": "{{prompt}}",
+          "config": {
+            "disableVarExpansion": true
+          }
+        },
+        "promptId": "effa18501e44aafd9bc42a2f64ffc9b6350f94025520ca2ed382f9bdc4b6e982",
+        "promptIdx": 1,
+        "provider": {
+          "id": "tool-selection:gpt-5.6-luna:mixed",
+          "label": "gpt-5.6-luna · mixed"
+        },
+        "response": {
+          "output": {
+            "toolCalls": [
+              {
+                "toolName": "update-team",
+                "input": {
+                  "team_token": "team_abc123",
+                  "name": "Platform Engineering",
+                  "default_dashboard_token": null
+                }
+              }
+            ],
+            "text": ""
+          },
+          "metadata": {
+            "modelId": "gpt-5.6-luna",
+            "mode": "mixed",
+            "target": "update-team",
+            "toolNames": [
+              "update-team",
+              "create-team",
+              "get-team",
+              "add-team-member",
+              "update-workspace"
+            ],
+            "toolCalls": [
+              {
+                "toolName": "update-team",
+                "input": {
+                  "team_token": "team_abc123",
+                  "name": "Platform Engineering",
+                  "default_dashboard_token": null
+                }
+              }
+            ]
+          }
+        },
+        "score": 1,
+        "success": true,
+        "testCase": {
+          "description": "update-team · direct · Use update-team to rename team_abc123 to Platform Engineering and clear its default Dashboard.",
+          "vars": {
+            "prompt": "Use update-team to rename team_abc123 to Platform Engineering and clear its default Dashboard.",
+            "target": "update-team",
+            "expected": [
+              {
+                "toolName": "update-team",
+                "input": {
+                  "team_token": "team_abc123",
+                  "name": "Platform Engineering",
+                  "default_dashboard_token": null
+                }
+              }
+            ],
+            "distractors": [
+              "create-team",
+              "get-team",
+              "add-team-member",
+              "update-workspace"
+            ]
+          },
+          "options": {
+            "disableVarExpansion": true
+          },
+          "metadata": {
+            "tool": "update-team",
+            "resource": "teams",
+            "phrasing": "direct"
+          },
+          "assert": [
+            {
+              "type": "javascript",
+              "value": "file://_lib/assertToolCalls.ts"
+            }
+          ]
+        },
+        "testIdx": 0,
+        "tokenUsage": {
+          "prompt": 0,
+          "completion": 0,
+          "cached": 0,
+          "total": 0,
+          "numRequests": 1,
+          "completionDetails": {
+            "reasoning": 0,
+            "acceptedPrediction": 0,
+            "rejectedPrediction": 0,
+            "cacheReadInputTokens": 0,
+            "cacheCreationInputTokens": 0
+          },
+          "assertions": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 1,
+            "completionDetails": {
+              "reasoning": 0,
+              "acceptedPrediction": 0,
+              "rejectedPrediction": 0,
+              "cacheReadInputTokens": 0,
+              "cacheCreationInputTokens": 0
+            }
+          }
+        },
+        "vars": {
+          "prompt": "Use update-team to rename team_abc123 to Platform Engineering and clear its default Dashboard.",
+          "target": "update-team",
+          "expected": [
+            {
+              "toolName": "update-team",
+              "input": {
+                "team_token": "team_abc123",
+                "name": "Platform Engineering",
+                "default_dashboard_token": null
+              }
+            }
+          ],
+          "distractors": [
+            "create-team",
+            "get-team",
+            "add-team-member",
+            "update-workspace"
+          ]
+        },
+        "metadata": {
+          "tool": "update-team",
+          "resource": "teams",
+          "phrasing": "direct",
+          "modelId": "gpt-5.6-luna",
+          "mode": "mixed",
+          "target": "update-team",
+          "toolNames": [
+            "update-team",
+            "create-team",
+            "get-team",
+            "add-team-member",
+            "update-workspace"
+          ],
+          "toolCalls": [
+            {
+              "toolName": "update-team",
+              "input": {
+                "team_token": "team_abc123",
+                "name": "Platform Engineering",
+                "default_dashboard_token": null
+              }
+            }
+          ],
+          "_promptfooFileMetadata": {}
+        },
+        "failureReason": 0
+      },
+      {
+        "cost": 0,
+        "gradingResult": {
+          "pass": true,
+          "score": 1,
+          "reason": "All assertions passed",
+          "namedScores": {},
+          "tokensUsed": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 0
+          },
+          "componentResults": [
+            {
+              "pass": true,
+              "score": 1,
+              "reason": "Expected tool call matched.",
+              "assertion": {
+                "type": "javascript",
+                "value": "file://_lib/assertToolCalls.ts"
+              }
+            }
+          ]
+        },
+        "id": "22b925b0-5f90-4152-9a39-33f2070da2d5",
+        "latencyMs": 1874,
+        "namedScores": {},
+        "prompt": {
+          "raw": "Use update-team to rename team_abc123 to Platform Engineering and clear its default Dashboard.",
+          "label": "{{prompt}}",
+          "config": {
+            "disableVarExpansion": true
+          }
+        },
+        "promptId": "effa18501e44aafd9bc42a2f64ffc9b6350f94025520ca2ed382f9bdc4b6e982",
+        "promptIdx": 0,
+        "provider": {
+          "id": "tool-selection:gpt-5.6-luna:isolated",
+          "label": "gpt-5.6-luna · isolated"
+        },
+        "response": {
+          "output": {
+            "toolCalls": [
+              {
+                "toolName": "update-team",
+                "input": {
+                  "team_token": "team_abc123",
+                  "name": "Platform Engineering",
+                  "default_dashboard_token": null
+                }
+              }
+            ],
+            "text": ""
+          },
+          "metadata": {
+            "modelId": "gpt-5.6-luna",
+            "mode": "isolated",
+            "target": "update-team",
+            "toolNames": [
+              "update-team"
+            ],
+            "toolCalls": [
+              {
+                "toolName": "update-team",
+                "input": {
+                  "team_token": "team_abc123",
+                  "name": "Platform Engineering",
+                  "default_dashboard_token": null
+                }
+              }
+            ]
+          }
+        },
+        "score": 1,
+        "success": true,
+        "testCase": {
+          "description": "update-team · direct · Use update-team to rename team_abc123 to Platform Engineering and clear its default Dashboard.",
+          "vars": {
+            "prompt": "Use update-team to rename team_abc123 to Platform Engineering and clear its default Dashboard.",
+            "target": "update-team",
+            "expected": [
+              {
+                "toolName": "update-team",
+                "input": {
+                  "team_token": "team_abc123",
+                  "name": "Platform Engineering",
+                  "default_dashboard_token": null
+                }
+              }
+            ],
+            "distractors": [
+              "create-team",
+              "get-team",
+              "add-team-member",
+              "update-workspace"
+            ]
+          },
+          "options": {
+            "disableVarExpansion": true
+          },
+          "metadata": {
+            "tool": "update-team",
+            "resource": "teams",
+            "phrasing": "direct"
+          },
+          "assert": [
+            {
+              "type": "javascript",
+              "value": "file://_lib/assertToolCalls.ts"
+            }
+          ]
+        },
+        "testIdx": 0,
+        "tokenUsage": {
+          "prompt": 0,
+          "completion": 0,
+          "cached": 0,
+          "total": 0,
+          "numRequests": 1,
+          "completionDetails": {
+            "reasoning": 0,
+            "acceptedPrediction": 0,
+            "rejectedPrediction": 0,
+            "cacheReadInputTokens": 0,
+            "cacheCreationInputTokens": 0
+          },
+          "assertions": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 1,
+            "completionDetails": {
+              "reasoning": 0,
+              "acceptedPrediction": 0,
+              "rejectedPrediction": 0,
+              "cacheReadInputTokens": 0,
+              "cacheCreationInputTokens": 0
+            }
+          }
+        },
+        "vars": {
+          "prompt": "Use update-team to rename team_abc123 to Platform Engineering and clear its default Dashboard.",
+          "target": "update-team",
+          "expected": [
+            {
+              "toolName": "update-team",
+              "input": {
+                "team_token": "team_abc123",
+                "name": "Platform Engineering",
+                "default_dashboard_token": null
+              }
+            }
+          ],
+          "distractors": [
+            "create-team",
+            "get-team",
+            "add-team-member",
+            "update-workspace"
+          ]
+        },
+        "metadata": {
+          "tool": "update-team",
+          "resource": "teams",
+          "phrasing": "direct",
+          "modelId": "gpt-5.6-luna",
+          "mode": "isolated",
+          "target": "update-team",
+          "toolNames": [
+            "update-team"
+          ],
+          "toolCalls": [
+            {
+              "toolName": "update-team",
+              "input": {
+                "team_token": "team_abc123",
+                "name": "Platform Engineering",
+                "default_dashboard_token": null
+              }
+            }
+          ],
+          "_promptfooFileMetadata": {}
+        },
+        "failureReason": 0
+      },
+      {
+        "cost": 0,
+        "gradingResult": {
+          "pass": true,
+          "score": 1,
+          "reason": "All assertions passed",
+          "namedScores": {},
+          "tokensUsed": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 0
+          },
+          "componentResults": [
+            {
+              "pass": true,
+              "score": 1,
+              "reason": "Expected tool call matched.",
+              "assertion": {
+                "type": "javascript",
+                "value": "file://_lib/assertToolCalls.ts"
+              }
+            }
+          ]
+        },
+        "id": "b9d137ad-a82a-472a-b8e2-d7c2aae0a4c7",
+        "latencyMs": 1422,
+        "namedScores": {},
+        "prompt": {
+          "raw": "The Vantage Team team_abc123 should now be called Cloud Efficiency.",
+          "label": "{{prompt}}",
+          "config": {
+            "disableVarExpansion": true
+          }
+        },
+        "promptId": "effa18501e44aafd9bc42a2f64ffc9b6350f94025520ca2ed382f9bdc4b6e982",
+        "promptIdx": 0,
+        "provider": {
+          "id": "tool-selection:gpt-5.6-luna:isolated",
+          "label": "gpt-5.6-luna · isolated"
+        },
+        "response": {
+          "output": {
+            "toolCalls": [
+              {
+                "toolName": "update-team",
+                "input": {
+                  "team_token": "team_abc123",
+                  "name": "Cloud Efficiency"
+                }
+              }
+            ],
+            "text": ""
+          },
+          "metadata": {
+            "modelId": "gpt-5.6-luna",
+            "mode": "isolated",
+            "target": "update-team",
+            "toolNames": [
+              "update-team"
+            ],
+            "toolCalls": [
+              {
+                "toolName": "update-team",
+                "input": {
+                  "team_token": "team_abc123",
+                  "name": "Cloud Efficiency"
+                }
+              }
+            ]
+          }
+        },
+        "score": 1,
+        "success": true,
+        "testCase": {
+          "description": "update-team · inferred · The Vantage Team team_abc123 should now be called Cloud Efficiency.",
+          "vars": {
+            "prompt": "The Vantage Team team_abc123 should now be called Cloud Efficiency.",
+            "target": "update-team",
+            "expected": [
+              {
+                "toolName": "update-team",
+                "input": {
+                  "team_token": "team_abc123",
+                  "name": "Cloud Efficiency"
+                }
+              }
+            ],
+            "distractors": [
+              "create-team",
+              "get-team",
+              "add-team-member",
+              "update-workspace"
+            ]
+          },
+          "options": {
+            "disableVarExpansion": true
+          },
+          "metadata": {
+            "tool": "update-team",
+            "resource": "teams",
+            "phrasing": "inferred"
+          },
+          "assert": [
+            {
+              "type": "javascript",
+              "value": "file://_lib/assertToolCalls.ts"
+            }
+          ]
+        },
+        "testIdx": 1,
+        "tokenUsage": {
+          "prompt": 0,
+          "completion": 0,
+          "cached": 0,
+          "total": 0,
+          "numRequests": 1,
+          "completionDetails": {
+            "reasoning": 0,
+            "acceptedPrediction": 0,
+            "rejectedPrediction": 0,
+            "cacheReadInputTokens": 0,
+            "cacheCreationInputTokens": 0
+          },
+          "assertions": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 1,
+            "completionDetails": {
+              "reasoning": 0,
+              "acceptedPrediction": 0,
+              "rejectedPrediction": 0,
+              "cacheReadInputTokens": 0,
+              "cacheCreationInputTokens": 0
+            }
+          }
+        },
+        "vars": {
+          "prompt": "The Vantage Team team_abc123 should now be called Cloud Efficiency.",
+          "target": "update-team",
+          "expected": [
+            {
+              "toolName": "update-team",
+              "input": {
+                "team_token": "team_abc123",
+                "name": "Cloud Efficiency"
+              }
+            }
+          ],
+          "distractors": [
+            "create-team",
+            "get-team",
+            "add-team-member",
+            "update-workspace"
+          ]
+        },
+        "metadata": {
+          "tool": "update-team",
+          "resource": "teams",
+          "phrasing": "inferred",
+          "modelId": "gpt-5.6-luna",
+          "mode": "isolated",
+          "target": "update-team",
+          "toolNames": [
+            "update-team"
+          ],
+          "toolCalls": [
+            {
+              "toolName": "update-team",
+              "input": {
+                "team_token": "team_abc123",
+                "name": "Cloud Efficiency"
+              }
+            }
+          ],
+          "_promptfooFileMetadata": {}
+        },
+        "failureReason": 0
+      },
+      {
+        "cost": 0,
+        "gradingResult": {
+          "pass": true,
+          "score": 1,
+          "reason": "All assertions passed",
+          "namedScores": {},
+          "tokensUsed": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 0
+          },
+          "componentResults": [
+            {
+              "pass": true,
+              "score": 1,
+              "reason": "Expected tool call matched.",
+              "assertion": {
+                "type": "javascript",
+                "value": "file://_lib/assertToolCalls.ts"
+              }
+            }
+          ]
+        },
+        "id": "e9b64ab8-4e73-4bad-868d-a46c9ef22a98",
+        "latencyMs": 1536,
+        "namedScores": {},
+        "prompt": {
+          "raw": "The Vantage Team team_abc123 should now be called Cloud Efficiency.",
+          "label": "{{prompt}}",
+          "config": {
+            "disableVarExpansion": true
+          }
+        },
+        "promptId": "effa18501e44aafd9bc42a2f64ffc9b6350f94025520ca2ed382f9bdc4b6e982",
+        "promptIdx": 1,
+        "provider": {
+          "id": "tool-selection:gpt-5.6-luna:mixed",
+          "label": "gpt-5.6-luna · mixed"
+        },
+        "response": {
+          "output": {
+            "toolCalls": [
+              {
+                "toolName": "update-team",
+                "input": {
+                  "team_token": "team_abc123",
+                  "name": "Cloud Efficiency"
+                }
+              }
+            ],
+            "text": ""
+          },
+          "metadata": {
+            "modelId": "gpt-5.6-luna",
+            "mode": "mixed",
+            "target": "update-team",
+            "toolNames": [
+              "update-team",
+              "create-team",
+              "get-team",
+              "add-team-member",
+              "update-workspace"
+            ],
+            "toolCalls": [
+              {
+                "toolName": "update-team",
+                "input": {
+                  "team_token": "team_abc123",
+                  "name": "Cloud Efficiency"
+                }
+              }
+            ]
+          }
+        },
+        "score": 1,
+        "success": true,
+        "testCase": {
+          "description": "update-team · inferred · The Vantage Team team_abc123 should now be called Cloud Efficiency.",
+          "vars": {
+            "prompt": "The Vantage Team team_abc123 should now be called Cloud Efficiency.",
+            "target": "update-team",
+            "expected": [
+              {
+                "toolName": "update-team",
+                "input": {
+                  "team_token": "team_abc123",
+                  "name": "Cloud Efficiency"
+                }
+              }
+            ],
+            "distractors": [
+              "create-team",
+              "get-team",
+              "add-team-member",
+              "update-workspace"
+            ]
+          },
+          "options": {
+            "disableVarExpansion": true
+          },
+          "metadata": {
+            "tool": "update-team",
+            "resource": "teams",
+            "phrasing": "inferred"
+          },
+          "assert": [
+            {
+              "type": "javascript",
+              "value": "file://_lib/assertToolCalls.ts"
+            }
+          ]
+        },
+        "testIdx": 1,
+        "tokenUsage": {
+          "prompt": 0,
+          "completion": 0,
+          "cached": 0,
+          "total": 0,
+          "numRequests": 1,
+          "completionDetails": {
+            "reasoning": 0,
+            "acceptedPrediction": 0,
+            "rejectedPrediction": 0,
+            "cacheReadInputTokens": 0,
+            "cacheCreationInputTokens": 0
+          },
+          "assertions": {
+            "total": 0,
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "numRequests": 1,
+            "completionDetails": {
+              "reasoning": 0,
+              "acceptedPrediction": 0,
+              "rejectedPrediction": 0,
+              "cacheReadInputTokens": 0,
+              "cacheCreationInputTokens": 0
+            }
+          }
+        },
+        "vars": {
+          "prompt": "The Vantage Team team_abc123 should now be called Cloud Efficiency.",
+          "target": "update-team",
+          "expected": [
+            {
+              "toolName": "update-team",
+              "input": {
+                "team_token": "team_abc123",
+                "name": "Cloud Efficiency"
+              }
+            }
+          ],
+          "distractors": [
+            "create-team",
+            "get-team",
+            "add-team-member",
+            "update-workspace"
+          ]
+        },
+        "metadata": {
+          "tool": "update-team",
+          "resource": "teams",
+          "phrasing": "inferred",
+          "modelId": "gpt-5.6-luna",
+          "mode": "mixed",
+          "target": "update-team",
+          "toolNames": [
+            "update-team",
+            "create-team",
+            "get-team",
+            "add-team-member",
+            "update-workspace"
+          ],
+          "toolCalls": [
+            {
+              "toolName": "update-team",
+              "input": {
+                "team_token": "team_abc123",
+                "name": "Cloud Efficiency"
+              }
+            }
+          ],
+          "_promptfooFileMetadata": {}
+        },
+        "failureReason": 0
+      }
+    ],
+    "prompts": [],
+    "stats": {
+      "successes": 4,
+      "failures": 0,
+      "errors": 0,
+      "tokenUsage": {
+        "prompt": 0,
+        "completion": 0,
+        "cached": 0,
+        "total": 0,
+        "numRequests": 4,
+        "completionDetails": {
+          "reasoning": 0,
+          "acceptedPrediction": 0,
+          "rejectedPrediction": 0
+        }
+      }
+    }
+  },
+  "config": {
+    "tags": {},
+    "description": "Vantage MCP tool-selection evals",
+    "prompts": [
+      "{{prompt}}"
+    ],
+    "providers": [
+      {
+        "id": "file://_lib/provider.ts",
+        "label": "gpt-5.6-luna · isolated",
+        "config": {
+          "modelId": "gpt-5.6-luna",
+          "mode": "isolated"
+        }
+      },
+      {
+        "id": "file://_lib/provider.ts",
+        "label": "gpt-5.6-luna · mixed",
+        "config": {
+          "modelId": "gpt-5.6-luna",
+          "mode": "mixed"
+        }
+      }
+    ],
+    "tests": [
+      "file://cases/cost-providers/get-cost-provider-accounts.eval.ts",
+      "file://cases/current-user/get-myself.eval.ts",
+      "file://cases/teams/add-team-member.eval.ts",
+      "file://cases/teams/create-team.eval.ts",
+      "file://cases/teams/delete-team.eval.ts",
+      "file://cases/teams/get-team-members.eval.ts",
+      "file://cases/teams/remove-team-member.eval.ts",
+      "file://cases/teams/update-team.eval.ts"
+    ],
+    "env": {},
+    "extensions": [],
+    "metadata": {},
+    "evaluateOptions": {
+      "maxConcurrency": 4
+    }
+  },
+  "shareableUrl": null,
+  "metadata": {
+    "promptfooVersion": "0.122.0",
+    "nodeVersion": "v23.11.0",
+    "platform": "darwin",
+    "arch": "arm64",
+    "exportedAt": "2026-09-03T16:55:17.540Z",
+    "evaluationCreatedAt": "2026-09-03T16:55:15.597Z"
+  }
+}

--- a/src/tools/teams/add-team-member.ts
+++ b/src/tools/teams/add-team-member.ts
@@ -1,0 +1,38 @@
+import { type AddTeamMemberRequest, pathEncode } from "@vantage-sh/vantage-client";
+import z from "zod";
+import { vantageToken } from "../../utils/zod";
+import MCPUserError from "../structure/MCPUserError";
+import registerTool from "../structure/registerTool";
+import { teamMemberRole } from "./schemas";
+
+const description = `
+Add a user to a Team by email address and assign their Team role.
+`.trim();
+
+export default registerTool({
+  name: "add-team-member",
+  title: "Add Team Member",
+  description,
+  annotations: {
+    destructive: false,
+    openWorld: false,
+    readOnly: false,
+  },
+  args: {
+    team_token: vantageToken("team"),
+    user_email: z.email().describe("Email address of the user to add to the Team."),
+    role: teamMemberRole.optional().default("editor").describe("Team role, defaults to editor."),
+  },
+  async execute(args, ctx) {
+    const { team_token, ...body } = args;
+    const response = await ctx.callVantageApi(
+      `/v2/teams/${pathEncode(team_token)}/members`,
+      body as AddTeamMemberRequest,
+      "POST"
+    );
+    if (!response.ok) {
+      throw new MCPUserError({ errors: response.errors });
+    }
+    return response.data;
+  },
+});

--- a/src/tools/teams/create-team.ts
+++ b/src/tools/teams/create-team.ts
@@ -1,0 +1,47 @@
+import type { RequestBodyForPathAndMethod } from "@vantage-sh/vantage-client";
+import MCPUserError from "../structure/MCPUserError";
+import registerTool from "../structure/registerTool";
+import {
+  teamDefaultDashboardToken,
+  teamDescription,
+  teamName,
+  teamRole,
+  teamUserEmails,
+  teamUserTokens,
+  teamWorkspaceTokens,
+} from "./schemas";
+
+const description = `
+Create a Team and optionally associate it with Workspaces, users, and a default Dashboard.
+`.trim();
+
+type CreateTeamRequest = RequestBodyForPathAndMethod<"/v2/teams", "POST">;
+
+export default registerTool({
+  name: "create-team",
+  title: "Create Team",
+  description,
+  annotations: {
+    destructive: false,
+    openWorld: false,
+    readOnly: false,
+  },
+  args: {
+    name: teamName.describe("Team name."),
+    description: teamDescription.optional().describe("Team description."),
+    workspace_tokens: teamWorkspaceTokens.optional().describe("Workspaces to associate with the Team."),
+    user_tokens: teamUserTokens.optional().describe("Existing users to associate with the Team."),
+    user_emails: teamUserEmails.optional().describe("User email addresses to associate with the Team."),
+    role: teamRole.optional().describe("Role to assign to the provided users. The Vantage API defaults to editor."),
+    default_dashboard_token: teamDefaultDashboardToken
+      .optional()
+      .describe("Dashboard to set as the Team default. Send null for no default Dashboard."),
+  },
+  async execute(args, ctx) {
+    const response = await ctx.callVantageApi("/v2/teams", args as CreateTeamRequest, "POST");
+    if (!response.ok) {
+      throw new MCPUserError({ errors: response.errors });
+    }
+    return response.data;
+  },
+});

--- a/src/tools/teams/delete-team.ts
+++ b/src/tools/teams/delete-team.ts
@@ -1,0 +1,29 @@
+import { pathEncode } from "@vantage-sh/vantage-client";
+import { vantageToken } from "../../utils/zod";
+import MCPUserError from "../structure/MCPUserError";
+import registerTool from "../structure/registerTool";
+
+const description = `
+Delete a Team.
+`.trim();
+
+export default registerTool({
+  name: "delete-team",
+  title: "Delete Team",
+  description,
+  annotations: {
+    destructive: true,
+    openWorld: false,
+    readOnly: false,
+  },
+  args: {
+    team_token: vantageToken("team"),
+  },
+  async execute(args, ctx) {
+    const response = await ctx.callVantageApi(`/v2/teams/${pathEncode(args.team_token)}`, {}, "DELETE");
+    if (!response.ok) {
+      throw new MCPUserError({ errors: response.errors });
+    }
+    return { token: args.team_token };
+  },
+});

--- a/src/tools/teams/get-team-members.ts
+++ b/src/tools/teams/get-team-members.ts
@@ -1,0 +1,40 @@
+import { pathEncode } from "@vantage-sh/vantage-client";
+import z from "zod";
+import paginationData from "../../utils/paginationData";
+import { vantageToken } from "../../utils/zod";
+import { DEFAULT_LIMIT } from "../structure/constants";
+import MCPUserError from "../structure/MCPUserError";
+import registerTool from "../structure/registerTool";
+
+const description = `
+Return the members of a Team, including each user's name, email, token, and Team role.
+`.trim();
+
+export default registerTool({
+  name: "get-team-members",
+  title: "Get Team Members",
+  description,
+  annotations: {
+    destructive: false,
+    openWorld: false,
+    readOnly: true,
+  },
+  args: {
+    team_token: vantageToken("team"),
+    page: z.number().int().min(1).optional().default(1).describe("Page number, defaults to 1."),
+  },
+  async execute(args, ctx) {
+    const response = await ctx.callVantageApi(
+      `/v2/teams/${pathEncode(args.team_token)}/members`,
+      { page: args.page, limit: DEFAULT_LIMIT },
+      "GET"
+    );
+    if (!response.ok) {
+      throw new MCPUserError({ errors: response.errors });
+    }
+    return {
+      members: response.data.members,
+      pagination: paginationData(response.data),
+    };
+  },
+});

--- a/src/tools/teams/index.ts
+++ b/src/tools/teams/index.ts
@@ -1,2 +1,8 @@
+import "./add-team-member";
+import "./create-team";
+import "./delete-team";
 import "./get-team";
+import "./get-team-members";
 import "./get-teams";
+import "./remove-team-member";
+import "./update-team";

--- a/src/tools/teams/remove-team-member.ts
+++ b/src/tools/teams/remove-team-member.ts
@@ -1,0 +1,34 @@
+import { pathEncode } from "@vantage-sh/vantage-client";
+import { vantageToken } from "../../utils/zod";
+import MCPUserError from "../structure/MCPUserError";
+import registerTool from "../structure/registerTool";
+
+const description = `
+Remove a user from a Team without deleting the user.
+`.trim();
+
+export default registerTool({
+  name: "remove-team-member",
+  title: "Remove Team Member",
+  description,
+  annotations: {
+    destructive: true,
+    openWorld: false,
+    readOnly: false,
+  },
+  args: {
+    team_token: vantageToken("team"),
+    user_token: vantageToken("user"),
+  },
+  async execute(args, ctx) {
+    const response = await ctx.callVantageApi(
+      `/v2/teams/${pathEncode(args.team_token)}/members/${pathEncode(args.user_token)}`,
+      {},
+      "DELETE"
+    );
+    if (!response.ok) {
+      throw new MCPUserError({ errors: response.errors });
+    }
+    return { team_token: args.team_token, user_token: args.user_token };
+  },
+});

--- a/src/tools/teams/schemas.ts
+++ b/src/tools/teams/schemas.ts
@@ -1,0 +1,11 @@
+import z from "zod";
+import { nonempty, vantageToken } from "../../utils/zod";
+
+export const teamName = nonempty();
+export const teamDescription = nonempty();
+export const teamWorkspaceTokens = z.array(vantageToken("workspace"));
+export const teamUserTokens = z.array(vantageToken("user"));
+export const teamUserEmails = z.array(z.email());
+export const teamRole = z.enum(["owner", "editor", "viewer"]);
+export const teamDefaultDashboardToken = vantageToken("dashboard").nullable();
+export const teamMemberRole = z.enum(["owner", "editor", "viewer", "integration_owner"]);

--- a/src/tools/teams/update-team.ts
+++ b/src/tools/teams/update-team.ts
@@ -1,0 +1,48 @@
+import { pathEncode, type UpdateTeamRequest } from "@vantage-sh/vantage-client";
+import { vantageToken } from "../../utils/zod";
+import MCPUserError from "../structure/MCPUserError";
+import registerTool from "../structure/registerTool";
+import {
+  teamDefaultDashboardToken,
+  teamDescription,
+  teamName,
+  teamRole,
+  teamUserEmails,
+  teamUserTokens,
+  teamWorkspaceTokens,
+} from "./schemas";
+
+const description = `
+Update a Team's name, description, Workspace and user associations, user role, or default Dashboard.
+`.trim();
+
+export default registerTool({
+  name: "update-team",
+  title: "Update Team",
+  description,
+  annotations: {
+    destructive: true,
+    openWorld: false,
+    readOnly: false,
+  },
+  args: {
+    team_token: vantageToken("team"),
+    name: teamName.optional().describe("Updated Team name."),
+    description: teamDescription.optional().describe("Updated Team description."),
+    workspace_tokens: teamWorkspaceTokens.optional().describe("Updated Workspaces associated with the Team."),
+    user_tokens: teamUserTokens.optional().describe("Updated existing users associated with the Team."),
+    user_emails: teamUserEmails.optional().describe("Updated user email addresses associated with the Team."),
+    role: teamRole.optional().describe("Role to assign to the provided users. The Vantage API defaults to editor."),
+    default_dashboard_token: teamDefaultDashboardToken
+      .optional()
+      .describe("Updated default Dashboard. Send null to clear the default Dashboard."),
+  },
+  async execute(args, ctx) {
+    const { team_token, ...body } = args;
+    const response = await ctx.callVantageApi(`/v2/teams/${pathEncode(team_token)}`, body as UpdateTeamRequest, "PUT");
+    if (!response.ok) {
+      throw new MCPUserError({ errors: response.errors });
+    }
+    return response.data;
+  },
+});

--- a/test/evals/evalArgs.test.ts
+++ b/test/evals/evalArgs.test.ts
@@ -7,12 +7,29 @@ describe("eval command arguments", () => {
       parseEvalArgs(["--tool", "get-myself", "--model", "gpt-5.6-sol-high", "--filter-metadata", "phrasing=direct"])
     ).toEqual({
       all: false,
+      dryRun: false,
       help: false,
       listModels: false,
-      tool: "get-myself",
       model: "gpt-5.6-sol-high",
       passthrough: ["--filter-metadata", "phrasing=direct"],
+      resources: [],
+      tools: ["get-myself"],
     });
+  });
+
+  it("accumulates exact tool and resource selectors", () => {
+    expect(
+      parseEvalArgs(["--tool", "get-team", "--tool", "get-teams", "--resource", "workspaces", "--dry-run"])
+    ).toMatchObject({
+      dryRun: true,
+      resources: ["workspaces"],
+      tools: ["get-team", "get-teams"],
+    });
+  });
+
+  it("rejects selectors without values", () => {
+    expect(() => parseEvalArgs(["--tool", "--dry-run"])).toThrow("--tool requires a value");
+    expect(() => parseEvalArgs(["--resource"])).toThrow("--resource requires a value");
   });
 
   it("allows an explicit full eval", () => {
@@ -23,13 +40,13 @@ describe("eval command arguments", () => {
   it("rejects an implicit full eval", () => {
     const parsed = parseEvalArgs(["--model", "gpt-5.6-sol-high"]);
     const error = validateEvalScope(parsed);
-    expect(error).toMatch(/--tool <name> is required/);
+    expect(error).toMatch(/--tool <name> or --resource <name>/);
     expect(error).toMatch(/npm run eval -- --tool/);
   });
 
   it("rejects combining a targeted and full eval", () => {
     const parsed = parseEvalArgs(["--all", "--tool", "get-myself", "--model", "gpt-5.6-sol-high"]);
-    expect(validateEvalScope(parsed)).toMatch(/either --tool <name> or the eval:all command/);
+    expect(validateEvalScope(parsed)).toMatch(/--tool\/--resource selectors or the eval:all command/);
   });
 
   it("recognizes promptfoo filters that produce partial result sets", () => {

--- a/test/evals/evalScope.test.ts
+++ b/test/evals/evalScope.test.ts
@@ -1,0 +1,56 @@
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  discoverEvalCases,
+  type EvalCaseFile,
+  parseSelectedCasePaths,
+  selectEvalCases,
+} from "../../evals/_lib/evalScope";
+
+const cases: EvalCaseFile[] = [
+  { path: "file://cases/teams/get-team.eval.ts", resource: "teams", tool: "get-team" },
+  { path: "file://cases/teams/get-team-members.eval.ts", resource: "teams", tool: "get-team-members" },
+  { path: "file://cases/teams/get-teams.eval.ts", resource: "teams", tool: "get-teams" },
+  { path: "file://cases/current-user/get-myself.eval.ts", resource: "current-user", tool: "get-myself" },
+];
+
+describe("eval scope selection", () => {
+  it("discovers resource and tool names from case paths", () => {
+    const discovered = discoverEvalCases(join(process.cwd(), "evals/cases"));
+    expect(discovered).toContainEqual({
+      path: "file://cases/current-user/get-myself.eval.ts",
+      resource: "current-user",
+      tool: "get-myself",
+    });
+  });
+
+  it("matches one tool exactly instead of using a prefix or substring", () => {
+    expect(selectEvalCases(cases, { all: false, resources: [], tools: ["get-team"] })).toEqual([cases[0]]);
+  });
+
+  it("unions repeated tools and resources without duplicates", () => {
+    expect(
+      selectEvalCases(cases, {
+        all: false,
+        resources: ["teams/"],
+        tools: ["get-team", "get-myself"],
+      })
+    ).toEqual(cases);
+  });
+
+  it("rejects unknown exact selectors", () => {
+    expect(() => selectEvalCases(cases, { all: false, resources: [], tools: ["team"] })).toThrow(
+      "No eval case found for tool: team"
+    );
+    expect(() => selectEvalCases(cases, { all: false, resources: ["team"], tools: [] })).toThrow(
+      "No eval cases found for resource: team"
+    );
+  });
+
+  it("parses selected case paths passed to Promptfoo", () => {
+    const selected = ["file://cases/teams/get-team.eval.ts"];
+    expect(parseSelectedCasePaths(JSON.stringify(selected), [])).toEqual(selected);
+    expect(parseSelectedCasePaths(undefined, selected)).toEqual(selected);
+    expect(() => parseSelectedCasePaths("[]", selected)).toThrow("non-empty JSON array");
+  });
+});

--- a/test/tools/teams/add-team-member.test.ts
+++ b/test/tools/teams/add-team-member.test.ts
@@ -1,0 +1,80 @@
+import { type AddTeamMemberResponse, pathEncode } from "@vantage-sh/vantage-client";
+import { expect } from "vitest";
+import tool from "../../../src/tools/teams/add-team-member";
+import {
+  type ExecutionTestTableItem,
+  type ExtractOutputSchema,
+  type ExtractValidators,
+  type InferValidators,
+  requestsInOrder,
+  type SchemaTestTableItem,
+  testTool,
+} from "../../../src/utils/testing";
+
+type Validators = ExtractValidators<typeof tool>;
+type OutputSchema = ExtractOutputSchema<typeof tool>;
+
+const validArguments: InferValidators<Validators> = {
+  team_token: "team_123",
+  user_email: "integration@example.com",
+  role: "integration_owner",
+};
+
+const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
+  {
+    name: "role defaults to editor",
+    data: { team_token: "team_123", user_email: "member@example.com", role: undefined },
+  },
+  { name: "valid arguments", data: validArguments },
+  {
+    name: "validates user email",
+    data: { ...validArguments, user_email: "not-an-email" },
+    expectedIssues: ["Invalid email address"],
+  },
+  {
+    name: "validates member role",
+    data: { ...validArguments, role: "admin" as never },
+    expectedIssues: ['Invalid option: expected one of "owner"|"editor"|"viewer"|"integration_owner"'],
+  },
+];
+
+const successData: AddTeamMemberResponse = {
+  name: "Integration User",
+  email: "integration@example.com",
+  user_token: "usr_123",
+  role: "integration_owner",
+};
+
+const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
+  {
+    name: "successful call",
+    apiCallHandler: requestsInOrder([
+      {
+        endpoint: `/v2/teams/${pathEncode("team_123")}/members`,
+        params: { user_email: "integration@example.com", role: "integration_owner" },
+        method: "POST",
+        result: { ok: true, data: successData },
+      },
+    ]),
+    handler: async ({ callExpectingSuccess }) => {
+      expect(await callExpectingSuccess(validArguments)).toEqual(successData);
+    },
+  },
+  {
+    name: "unsuccessful call",
+    apiCallHandler: requestsInOrder([
+      {
+        endpoint: `/v2/teams/${pathEncode("team_123")}/members`,
+        params: { user_email: "integration@example.com", role: "integration_owner" },
+        method: "POST",
+        result: { ok: false, errors: [{ message: "User not found" }] },
+      },
+    ]),
+    handler: async ({ callExpectingMCPUserError }) => {
+      const error = await callExpectingMCPUserError(validArguments);
+      expect(error.exception).toEqual({ errors: [{ message: "User not found" }] });
+    },
+  },
+];
+
+testTool(tool, argumentSchemaTests, executionTests);

--- a/test/tools/teams/create-team.test.ts
+++ b/test/tools/teams/create-team.test.ts
@@ -1,0 +1,113 @@
+import type { CreateTeamResponse } from "@vantage-sh/vantage-client";
+import { expect } from "vitest";
+import tool from "../../../src/tools/teams/create-team";
+import {
+  type ExecutionTestTableItem,
+  type ExtractOutputSchema,
+  type ExtractValidators,
+  type InferValidators,
+  requestsInOrder,
+  type SchemaTestTableItem,
+  testTool,
+} from "../../../src/utils/testing";
+
+type Validators = ExtractValidators<typeof tool>;
+type OutputSchema = ExtractOutputSchema<typeof tool>;
+
+const undefineds = {
+  description: undefined,
+  workspace_tokens: undefined,
+  user_tokens: undefined,
+  user_emails: undefined,
+  role: undefined,
+  default_dashboard_token: undefined,
+};
+
+const minimalValidArguments: InferValidators<Validators> = {
+  ...undefineds,
+  name: "FinOps",
+};
+
+const validArguments: InferValidators<Validators> = {
+  name: "Platform",
+  description: "Platform engineering",
+  workspace_tokens: ["wrkspc_123"],
+  user_tokens: ["usr_123"],
+  user_emails: ["engineer@example.com"],
+  role: "editor",
+  default_dashboard_token: "dshbrd_123",
+};
+
+const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
+  { name: "minimal valid arguments", data: minimalValidArguments },
+  { name: "all valid arguments", data: validArguments },
+  {
+    name: "name is required",
+    data: undefineds as never,
+    expectedIssues: ["Invalid input: expected string, received undefined"],
+  },
+  {
+    name: "name cannot be blank",
+    data: { ...minimalValidArguments, name: "   " },
+    expectedIssues: ["Too small: expected string to have >=1 characters"],
+  },
+  {
+    name: "validates Workspace tokens",
+    data: { ...validArguments, workspace_tokens: ["usr_123"] },
+    expectedIssues: ["Must be a Workspace token (wrkspc_*)"],
+  },
+  {
+    name: "validates user emails",
+    data: { ...validArguments, user_emails: ["not-an-email"] },
+    expectedIssues: ["Invalid email address"],
+  },
+  {
+    name: "validates Team roles",
+    data: { ...validArguments, role: "integration_owner" as never },
+    expectedIssues: ['Invalid option: expected one of "owner"|"editor"|"viewer"'],
+  },
+];
+
+const successData: CreateTeamResponse = {
+  token: "team_123",
+  name: "Platform",
+  description: "Platform engineering",
+  workspace_tokens: ["wrkspc_123"],
+  user_tokens: ["usr_123"],
+  user_emails: ["engineer@example.com"],
+  default_dashboard_token: "dshbrd_123",
+};
+
+const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
+  {
+    name: "successful call",
+    apiCallHandler: requestsInOrder([
+      {
+        endpoint: "/v2/teams",
+        params: validArguments,
+        method: "POST",
+        result: { ok: true, data: successData },
+      },
+    ]),
+    handler: async ({ callExpectingSuccess }) => {
+      expect(await callExpectingSuccess(validArguments)).toEqual(successData);
+    },
+  },
+  {
+    name: "unsuccessful call",
+    apiCallHandler: requestsInOrder([
+      {
+        endpoint: "/v2/teams",
+        params: minimalValidArguments,
+        method: "POST",
+        result: { ok: false, errors: [{ message: "Team name already exists" }] },
+      },
+    ]),
+    handler: async ({ callExpectingMCPUserError }) => {
+      const error = await callExpectingMCPUserError(minimalValidArguments);
+      expect(error.exception).toEqual({ errors: [{ message: "Team name already exists" }] });
+    },
+  },
+];
+
+testTool(tool, argumentSchemaTests, executionTests);

--- a/test/tools/teams/delete-team.test.ts
+++ b/test/tools/teams/delete-team.test.ts
@@ -1,0 +1,50 @@
+import { pathEncode } from "@vantage-sh/vantage-client";
+import { expect } from "vitest";
+import tool from "../../../src/tools/teams/delete-team";
+import { requestsInOrder, testTool } from "../../../src/utils/testing";
+
+testTool(
+  tool,
+  [
+    {
+      name: "takes a Team token",
+      data: { team_token: "team_123" },
+    },
+    {
+      name: "validates Team token",
+      data: { team_token: "usr_123" },
+      expectedIssues: ["Must be a Team token (team_*)"],
+    },
+  ],
+  [
+    {
+      name: "successful call",
+      apiCallHandler: requestsInOrder([
+        {
+          endpoint: `/v2/teams/${pathEncode("team_123")}`,
+          params: {},
+          method: "DELETE",
+          result: { ok: true, data: undefined },
+        },
+      ]),
+      handler: async ({ callExpectingSuccess }) => {
+        expect(await callExpectingSuccess({ team_token: "team_123" })).toEqual({ token: "team_123" });
+      },
+    },
+    {
+      name: "unsuccessful call",
+      apiCallHandler: requestsInOrder([
+        {
+          endpoint: `/v2/teams/${pathEncode("team_missing")}`,
+          params: {},
+          method: "DELETE",
+          result: { ok: false, errors: [{ message: "Team not found" }] },
+        },
+      ]),
+      handler: async ({ callExpectingMCPUserError }) => {
+        const error = await callExpectingMCPUserError({ team_token: "team_missing" });
+        expect(error.exception).toEqual({ errors: [{ message: "Team not found" }] });
+      },
+    },
+  ]
+);

--- a/test/tools/teams/get-team-members.test.ts
+++ b/test/tools/teams/get-team-members.test.ts
@@ -1,0 +1,88 @@
+import type { GetTeamMembersResponse } from "@vantage-sh/vantage-client";
+import { pathEncode } from "@vantage-sh/vantage-client";
+import { expect } from "vitest";
+import { DEFAULT_LIMIT } from "../../../src/tools/structure/constants";
+import tool from "../../../src/tools/teams/get-team-members";
+import {
+  type ExecutionTestTableItem,
+  type ExtractOutputSchema,
+  type ExtractValidators,
+  type InferValidators,
+  requestsInOrder,
+  type SchemaTestTableItem,
+  testTool,
+} from "../../../src/utils/testing";
+
+type Validators = ExtractValidators<typeof tool>;
+type OutputSchema = ExtractOutputSchema<typeof tool>;
+
+const validArguments: InferValidators<Validators> = {
+  team_token: "team_123",
+  page: 2,
+};
+
+const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
+  { name: "default page", data: { team_token: "team_123", page: undefined } },
+  { name: "valid arguments", data: validArguments },
+  {
+    name: "page must be positive",
+    data: { ...validArguments, page: 0 },
+    expectedIssues: ["Too small: expected number to be >=1"],
+  },
+  {
+    name: "page must be an integer",
+    data: { ...validArguments, page: 1.5 },
+    expectedIssues: ["Invalid input: expected int, received number"],
+  },
+];
+
+const successData: GetTeamMembersResponse = {
+  members: [
+    {
+      name: "Ada Lovelace",
+      email: "ada@example.com",
+      user_token: "usr_123",
+      role: "owner",
+    },
+  ],
+  links: {
+    next: "https://api.vantage.sh/v2/teams/team_123/members?page=3",
+  },
+};
+
+const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
+  {
+    name: "successful call",
+    apiCallHandler: requestsInOrder([
+      {
+        endpoint: `/v2/teams/${pathEncode("team_123")}/members`,
+        params: { page: 2, limit: DEFAULT_LIMIT },
+        method: "GET",
+        result: { ok: true, data: successData },
+      },
+    ]),
+    handler: async ({ callExpectingSuccess }) => {
+      expect(await callExpectingSuccess(validArguments)).toEqual({
+        members: successData.members,
+        pagination: { hasNextPage: true, nextPage: 3 },
+      });
+    },
+  },
+  {
+    name: "unsuccessful call",
+    apiCallHandler: requestsInOrder([
+      {
+        endpoint: `/v2/teams/${pathEncode("team_123")}/members`,
+        params: { page: 2, limit: DEFAULT_LIMIT },
+        method: "GET",
+        result: { ok: false, errors: [{ message: "Team not found" }] },
+      },
+    ]),
+    handler: async ({ callExpectingMCPUserError }) => {
+      const error = await callExpectingMCPUserError(validArguments);
+      expect(error.exception).toEqual({ errors: [{ message: "Team not found" }] });
+    },
+  },
+];
+
+testTool(tool, argumentSchemaTests, executionTests);

--- a/test/tools/teams/remove-team-member.test.ts
+++ b/test/tools/teams/remove-team-member.test.ts
@@ -1,0 +1,60 @@
+import { pathEncode } from "@vantage-sh/vantage-client";
+import { expect } from "vitest";
+import tool from "../../../src/tools/teams/remove-team-member";
+import { requestsInOrder, testTool } from "../../../src/utils/testing";
+
+const validArguments = {
+  team_token: "team_123",
+  user_token: "usr_123",
+};
+
+testTool(
+  tool,
+  [
+    { name: "takes Team and user tokens", data: validArguments },
+    {
+      name: "validates Team token",
+      data: { ...validArguments, team_token: "usr_123" },
+      expectedIssues: ["Must be a Team token (team_*)"],
+    },
+    {
+      name: "validates user token",
+      data: { ...validArguments, user_token: "team_123" },
+      expectedIssues: ["Must be a User token (usr_*)"],
+    },
+  ],
+  [
+    {
+      name: "successful call",
+      apiCallHandler: requestsInOrder([
+        {
+          endpoint: `/v2/teams/${pathEncode("team_123")}/members/${pathEncode("usr_123")}`,
+          params: {},
+          method: "DELETE",
+          result: { ok: true, data: undefined },
+        },
+      ]),
+      handler: async ({ callExpectingSuccess }) => {
+        expect(await callExpectingSuccess(validArguments)).toEqual(validArguments);
+      },
+    },
+    {
+      name: "unsuccessful call",
+      apiCallHandler: requestsInOrder([
+        {
+          endpoint: `/v2/teams/${pathEncode("team_123")}/members/${pathEncode("usr_missing")}`,
+          params: {},
+          method: "DELETE",
+          result: { ok: false, errors: [{ message: "Team member not found" }] },
+        },
+      ]),
+      handler: async ({ callExpectingMCPUserError }) => {
+        const error = await callExpectingMCPUserError({
+          team_token: "team_123",
+          user_token: "usr_missing",
+        });
+        expect(error.exception).toEqual({ errors: [{ message: "Team member not found" }] });
+      },
+    },
+  ]
+);

--- a/test/tools/teams/update-team.test.ts
+++ b/test/tools/teams/update-team.test.ts
@@ -1,0 +1,102 @@
+import { pathEncode, type UpdateTeamResponse } from "@vantage-sh/vantage-client";
+import { expect } from "vitest";
+import tool from "../../../src/tools/teams/update-team";
+import {
+  type ExecutionTestTableItem,
+  type ExtractOutputSchema,
+  type ExtractValidators,
+  type InferValidators,
+  requestsInOrder,
+  type SchemaTestTableItem,
+  testTool,
+} from "../../../src/utils/testing";
+
+type Validators = ExtractValidators<typeof tool>;
+type OutputSchema = ExtractOutputSchema<typeof tool>;
+
+const undefineds = {
+  name: undefined,
+  description: undefined,
+  workspace_tokens: undefined,
+  user_tokens: undefined,
+  user_emails: undefined,
+  role: undefined,
+  default_dashboard_token: undefined,
+};
+
+const minimalValidArguments: InferValidators<Validators> = {
+  ...undefineds,
+  team_token: "team_123",
+};
+
+const validArguments: InferValidators<Validators> = {
+  team_token: "team_123",
+  name: "Platform",
+  description: "Updated platform team",
+  workspace_tokens: ["wrkspc_123"],
+  user_tokens: ["usr_123"],
+  user_emails: ["engineer@example.com"],
+  role: "owner",
+  default_dashboard_token: null,
+};
+
+const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
+  { name: "minimal valid arguments", data: minimalValidArguments },
+  { name: "all valid arguments", data: validArguments },
+  {
+    name: "validates Team token",
+    data: { ...minimalValidArguments, team_token: "usr_123" },
+    expectedIssues: ["Must be a Team token (team_*)"],
+  },
+  {
+    name: "validates default Dashboard token",
+    data: { ...validArguments, default_dashboard_token: "rprt_123" },
+    expectedIssues: ["Must be a Dashboard token (dshbrd_*)"],
+  },
+];
+
+const successData: UpdateTeamResponse = {
+  token: "team_123",
+  name: "Platform",
+  description: "Updated platform team",
+  workspace_tokens: ["wrkspc_123"],
+  user_tokens: ["usr_123"],
+  user_emails: ["engineer@example.com"],
+  default_dashboard_token: null,
+};
+
+const { team_token: _teamToken, ...body } = validArguments;
+
+const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
+  {
+    name: "successful call",
+    apiCallHandler: requestsInOrder([
+      {
+        endpoint: `/v2/teams/${pathEncode("team_123")}`,
+        params: body,
+        method: "PUT",
+        result: { ok: true, data: successData },
+      },
+    ]),
+    handler: async ({ callExpectingSuccess }) => {
+      expect(await callExpectingSuccess(validArguments)).toEqual(successData);
+    },
+  },
+  {
+    name: "unsuccessful call",
+    apiCallHandler: requestsInOrder([
+      {
+        endpoint: `/v2/teams/${pathEncode("team_123")}`,
+        params: {},
+        method: "PUT",
+        result: { ok: false, errors: [{ message: "Team not found" }] },
+      },
+    ]),
+    handler: async ({ callExpectingMCPUserError }) => {
+      const error = await callExpectingMCPUserError(minimalValidArguments);
+      expect(error.exception).toEqual({ errors: [{ message: "Team not found" }] });
+    },
+  },
+];
+
+testTool(tool, argumentSchemaTests, executionTests);


### PR DESCRIPTION
## What Changed

Added all the rest of the tools needed to manage `Team` records

## Testing Done

- [x] Unit tests added
- [x] Evals added

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to the eval harness, documentation, and committed eval artifacts—not runtime MCP tool behavior.
> 
> **Overview**
> Expands the eval CLI so runs can target **multiple tools**, an entire **resource directory** (`--resource teams`), or preview scope with **`--dry-run`** without model calls. Case selection moves into new **`evalScope.ts`**, and Promptfoo now receives an explicit **`EVAL_CASE_PATHS`** list instead of relying on `--filter-metadata tool=…`.
> 
> Adds **eight teams tool-selection case files** (create/get/list/update/delete teams and member add/remove), each with one direct and one inferred prompt plus sibling distractors. Commits **`gpt-5.6-luna`** baseline JSON under `evals/results/…/teams/` and updates the **writing-evals** skill docs to match the new commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f5d49acdad80dcada0ee0d015af15f32f445216. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->