### PR TITLE
Add API error messages to the traces and emit an error log

### DIFF
--- a/src/cf-worker.ts
+++ b/src/cf-worker.ts
@@ -18,7 +18,7 @@ import { logger } from "./logger";
 import setupRegisteredResources from "./resources";
 import { callApi, serverMeta } from "./shared";
 import { setupRegisteredTools } from "./tools/structure/registerTool";
-import { tracer } from "./tracing";
+import { datadogTraceLogTags, formatErrorsForTelemetry, tracer } from "./tracing";
 
 // Side effect import to register all tools
 import "./tools";
@@ -63,6 +63,7 @@ export class VantageMCP extends McpAgent<Env, Record<string, never>, UserProps> 
       logger.setTags({
         endpoint: endpoint as string,
         method: method as string,
+        ...datadogTraceLogTags(tracer.getActiveTraceContext()),
       });
 
       const vantageHeaders =
@@ -96,8 +97,17 @@ export class VantageMCP extends McpAgent<Env, Record<string, never>, UserProps> 
         this.env
       );
 
-      logger.setTags({ ok: result.ok });
-      logger.info("Vantage API request");
+      logger.setTags({
+        ok: result.ok,
+        ...datadogTraceLogTags(tracer.getActiveTraceContext()),
+      });
+
+      if (!result.ok) {
+        logger.setTags({ api_errors: formatErrorsForTelemetry(result.errors) });
+        logger.error("Vantage API request failed");
+      } else {
+        logger.info("Vantage API request");
+      }
 
       return result;
     });

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -6,6 +6,12 @@ export type LogTagHints = {
   endpoint?: string;
   method?: string;
   ok?: boolean;
+  /** JSON-serialized API error payload for failed Vantage calls. */
+  api_errors?: string;
+  "dd.trace_id"?: string;
+  "dd.span_id"?: string;
+  "otel.trace_id"?: string;
+  "otel.span_id"?: string;
 };
 
 export const logger = new WorkersLogger<LogTagHints>();

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -6,7 +6,7 @@ import type {
 } from "@vantage-sh/vantage-client";
 import type { AppEnv } from "./env";
 import { SERVER_VERSION } from "./tools/structure/constants";
-import { tracer } from "./tracing";
+import { formatErrorsForTelemetry, tracer } from "./tracing";
 
 export const serverMeta = {
   name: "Vantage Cloud Costs Helper",
@@ -53,29 +53,40 @@ export async function callApi<
   const response = await tracer.traceFetch(fetch, url.toString(), options, { env });
   if (!response.ok) {
     const bestAnyDetail = await response.text();
+    let errors: unknown[];
     try {
       const res = JSON.parse(bestAnyDetail) as { errors?: string[] };
       if (Array.isArray(res.errors)) {
-        return {
-          errors: res.errors,
-          ok: false,
-        };
+        errors = res.errors;
+      } else {
+        errors = [
+          {
+            message: "Vantage API request failed",
+            status: response.status,
+            endpoint,
+            details: bestAnyDetail,
+          },
+        ];
       }
     } catch {
-      // ignore JSON parse error - instead just use the text
-    }
-
-    return {
-      errors: [
+      errors = [
         {
           message: "Vantage API request failed",
           status: response.status,
           endpoint,
           details: bestAnyDetail,
         },
-      ],
-      ok: false,
-    };
+      ];
+    }
+
+    // Attach the parsed API errors onto the active tool span (client span is enriched in traceFetch).
+    const activeSpan = tracer.getActiveSpan();
+    if (activeSpan) {
+      activeSpan.attributes["error.message"] = formatErrorsForTelemetry(errors, bestAnyDetail);
+      activeSpan.attributes["http.response.status_code"] = response.status;
+    }
+
+    return { errors, ok: false };
   }
 
   if (response.status === 204) {

--- a/src/tools/structure/registerTool.ts
+++ b/src/tools/structure/registerTool.ts
@@ -9,7 +9,13 @@ import type {
 } from "@vantage-sh/vantage-client";
 import type z from "zod";
 import type { AppEnv } from "../../env";
-import { tracer, type WaitUntil } from "../../tracing";
+import {
+  formatErrorsForTelemetry,
+  TRACE_STATUS_MESSAGE_MAX_LENGTH,
+  tracer,
+  truncateAttribute,
+  type WaitUntil,
+} from "../../tracing";
 import MCPUserError from "./MCPUserError";
 
 export type ToolCallContext = {
@@ -116,7 +122,7 @@ export default function registerTool<Input extends z.ZodRawShape, Output extends
               ...(source ? { "mcp.source": source } : {}),
             },
           },
-          async () => {
+          async (span) => {
             try {
               const res = await toolProps.execute(args, ctx);
 
@@ -139,6 +145,12 @@ export default function registerTool<Input extends z.ZodRawShape, Output extends
               };
             } catch (e) {
               if (e instanceof MCPUserError) {
+                const message = formatErrorsForTelemetry(e.exception);
+                span.status = {
+                  code: 2,
+                  message: truncateAttribute(message, TRACE_STATUS_MESSAGE_MAX_LENGTH),
+                };
+                span.attributes["error.message"] = message;
                 return {
                   content: [
                     {

--- a/src/tracing/tracer.ts
+++ b/src/tracing/tracer.ts
@@ -21,17 +21,19 @@ export type TraceContext = {
 
 export type SpanKind = "client" | "consumer" | "internal" | "producer" | "server";
 
+export type SpanStatus = {
+  code: 0 | 1 | 2;
+  message?: string;
+};
+
 export type TraceSpan = TraceContext & {
   name: string;
   kind: SpanKind;
   parentSpanId?: string;
   startedAt: number;
   attributes: TraceAttributes;
-};
-
-type SpanStatus = {
-  code: 0 | 1 | 2;
-  message?: string;
+  /** Optional status applied when the span ends successfully via runWithSpan. */
+  status?: SpanStatus;
 };
 
 export type StartSpanOptions = {
@@ -53,6 +55,11 @@ export type EndSpanOptions = {
 type TraceFetchOptions = StartSpanOptions & {
   spanName?: string;
 };
+
+/** Max chars stored on span `error.message` / log tags for API error bodies. */
+export const TRACE_ERROR_BODY_MAX_LENGTH = 2048;
+/** Max chars stored on OTel span status.message (Datadog surfaces this as error.message). */
+export const TRACE_STATUS_MESSAGE_MAX_LENGTH = 512;
 
 export type WaitUntil = (promise: Promise<unknown>) => void;
 
@@ -229,7 +236,7 @@ export class CloudflareWorkerTracer {
     const runInsideSpan = async (): Promise<T> => {
       try {
         const result = await fn(span);
-        this.endSpan(span, { env: options.env });
+        this.endSpan(span, { env: options.env, status: span.status });
         return result;
       } catch (error) {
         this.endSpan(span, {
@@ -323,12 +330,23 @@ export class CloudflareWorkerTracer {
         const response =
           input instanceof Request ? await fetcher(new Request(input, tracedInit)) : await fetcher(input, tracedInit);
 
+        const attributes: TraceAttributes = {
+          "http.response.status_code": response.status,
+        };
+        let status = httpStatusToSpanStatus(response.status, span.kind);
+
+        if (shouldCaptureHttpErrorBody(response.status, span.kind)) {
+          const errorBody = await readResponseBodyPreview(response);
+          if (errorBody) {
+            attributes["error.message"] = errorBody;
+            status = { code: 2, message: truncateAttribute(errorBody, TRACE_STATUS_MESSAGE_MAX_LENGTH) };
+          }
+        }
+
         this.endSpan(span, {
           env: options.env,
-          attributes: {
-            "http.response.status_code": response.status,
-          },
-          status: httpStatusToSpanStatus(response.status, span.kind),
+          attributes,
+          status,
         });
 
         return response;
@@ -533,6 +551,60 @@ function httpStatusToSpanStatus(statusCode: number, kind: SpanKind = "internal")
   }
 
   return { code: 0 };
+}
+
+function shouldCaptureHttpErrorBody(statusCode: number, kind: SpanKind): boolean {
+  if (statusCode >= 500) {
+    return true;
+  }
+  return kind === "client" && statusCode >= 400;
+}
+
+async function readResponseBodyPreview(response: Response): Promise<string | undefined> {
+  try {
+    const text = (await response.clone().text()).trim();
+    if (!text) {
+      return undefined;
+    }
+    return truncateAttribute(text, TRACE_ERROR_BODY_MAX_LENGTH);
+  } catch {
+    return undefined;
+  }
+}
+
+export function truncateAttribute(value: string, maxLength: number): string {
+  if (value.length <= maxLength) {
+    return value;
+  }
+  return `${value.slice(0, maxLength - 3)}...`;
+}
+
+export function formatErrorsForTelemetry(errors: unknown, fallback = ""): string {
+  try {
+    return truncateAttribute(JSON.stringify(errors), TRACE_ERROR_BODY_MAX_LENGTH);
+  } catch {
+    return truncateAttribute(fallback || "Unknown error", TRACE_ERROR_BODY_MAX_LENGTH);
+  }
+}
+
+/** Datadog log↔trace correlation fields for the active (or provided) trace context. */
+export function datadogTraceLogTags(context?: TraceContext): Record<string, string> {
+  if (!context) {
+    return {};
+  }
+
+  return {
+    // Classic APM correlation uses the lower 64 bits of a 128-bit trace id as decimal.
+    "dd.trace_id": hexToUnsignedDecimal(context.traceId.slice(-16)),
+    "dd.span_id": hexToUnsignedDecimal(context.spanId),
+    // OTel / 128-bit friendly identifiers (matches span tags like otel.trace_id).
+    "otel.trace_id": context.traceId,
+    "otel.span_id": context.spanId,
+  };
+}
+
+function hexToUnsignedDecimal(hex: string): string {
+  return BigInt(`0x${hex}`).toString();
 }
 
 function isAllZeros(value: string): boolean {

--- a/test/shared/callApi.test.ts
+++ b/test/shared/callApi.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { callApi } from "../../src/shared";
+import { tracer } from "../../src/tracing";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("callApi error telemetry", () => {
+  it("attaches parsed API errors to the active tool span", async () => {
+    const errorBody = JSON.stringify({ errors: ["Title can't be blank"] });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(errorBody, { status: 400, headers: { "Content-Type": "application/json" } }))
+    );
+
+    await tracer.runWithSpan("tool/create-financial-commitment-report", {}, async (span) => {
+      const result = await callApi(
+        "https://api.example",
+        {},
+        { title: "" } as never,
+        "POST" as never,
+        "/v2/financial_commitment_reports" as never
+      );
+
+      expect(result).toEqual({ ok: false, errors: ["Title can't be blank"] });
+      expect(span.attributes["error.message"]).toBe(JSON.stringify(["Title can't be blank"]));
+      expect(span.attributes["http.response.status_code"]).toBe(400);
+    });
+  });
+});

--- a/test/tracing/tracer.test.ts
+++ b/test/tracing/tracer.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AppEnv } from "../../src/env";
-import { CloudflareWorkerTracer } from "../../src/tracing/tracer";
+import { CloudflareWorkerTracer, datadogTraceLogTags } from "../../src/tracing/tracer";
 
 const FIXED_NOW = 1_700_000_000_000;
 
@@ -322,6 +322,48 @@ describe("runWithSpan", () => {
     expect(span.status).toEqual({ code: 2, message: "boom" });
     expect(span.events[0].name).toBe("exception");
   });
+
+  it("applies span.status set by the callback on successful return", async () => {
+    const fetchSpy = vi.fn<typeof fetch>(async () => new Response(null, { status: 200 }));
+    const tracer = makeTracer({ exporterFetch: fetchSpy });
+
+    await tracer.runWithSpan("op", { env: appEnv }, async (span) => {
+      span.status = { code: 2, message: '{"errors":["nope"]}' };
+      span.attributes["error.message"] = '{"errors":["nope"]}';
+      return "handled";
+    });
+
+    const body = JSON.parse(fetchSpy.mock.calls[0][1]?.body as string);
+    const span = body.resourceSpans[0].scopeSpans[0].spans[0];
+    expect(span.status).toEqual({ code: 2, message: '{"errors":["nope"]}' });
+    const attrs = Object.fromEntries(
+      span.attributes.map((a: { key: string; value: { stringValue?: string } }) => [a.key, a.value])
+    );
+    expect(attrs["error.message"].stringValue).toBe('{"errors":["nope"]}');
+  });
+});
+
+describe("datadogTraceLogTags", () => {
+  it("emits classic dd.* decimals and otel hex ids", () => {
+    expect(
+      datadogTraceLogTags({
+        traceId: "012045e13ff5466d621637c8ee2b3266",
+        spanId: "4f9c1a2b3c4d5e6f",
+        traceFlags: "01",
+        sampled: true,
+      })
+    ).toEqual({
+      "dd.trace_id": BigInt("0x621637c8ee2b3266").toString(),
+      "dd.span_id": BigInt("0x4f9c1a2b3c4d5e6f").toString(),
+      "otel.trace_id": "012045e13ff5466d621637c8ee2b3266",
+      "otel.span_id": "4f9c1a2b3c4d5e6f",
+    });
+  });
+
+  it("returns an empty object when context is missing", () => {
+    expect(datadogTraceLogTags()).toEqual({});
+    expect(datadogTraceLogTags(undefined)).toEqual({});
+  });
 });
 
 describe("traceFetch", () => {
@@ -373,6 +415,32 @@ describe("traceFetch", () => {
     const body = JSON.parse(fetchSpy.mock.calls[0][1]?.body as string);
     const fetchSpan = body.resourceSpans[0].scopeSpans[0].spans.find((s: { kind: number }) => s.kind === 3);
     expect(fetchSpan.status).toEqual({ code: 2, message: "HTTP 503" });
+  });
+
+  it("attaches 4xx response bodies to the client span error message", async () => {
+    const fetchSpy = vi.fn<typeof fetch>(async () => new Response(null, { status: 200 }));
+    const tracer = makeTracer({ exporterFetch: fetchSpy });
+    const errorBody = JSON.stringify({ errors: ["Title can't be blank"] });
+
+    const inner = vi.fn<typeof fetch>(async () => new Response(errorBody, { status: 400 }));
+    await tracer.runWithSpan("root", { env: appEnv }, async () => {
+      const response = await tracer.traceFetch(
+        inner,
+        "https://api.example/create",
+        { method: "POST" },
+        { env: appEnv }
+      );
+      // Original body must remain readable by the caller.
+      expect(await response.text()).toBe(errorBody);
+    });
+
+    const body = JSON.parse(fetchSpy.mock.calls[0][1]?.body as string);
+    const fetchSpan = body.resourceSpans[0].scopeSpans[0].spans.find((s: { kind: number }) => s.kind === 3);
+    expect(fetchSpan.status).toEqual({ code: 2, message: errorBody });
+    const attrs = Object.fromEntries(
+      fetchSpan.attributes.map((a: { key: string; value: { stringValue?: string } }) => [a.key, a.value])
+    );
+    expect(attrs["error.message"].stringValue).toBe(errorBody);
   });
 
   it("captures fetcher errors as an exception event", async () => {


### PR DESCRIPTION
## What Changed

Found an observability gap when attempting to investigate a 400 a customer got with the `create-financial-commitment-report` too. We aren't attaching the error message from the API to anything so it was not possible to discern what went wrong. This PR attaches the API error message to the errored trace and separately emits an error log

## Testing Done

- [x] Unit tests added

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Error response bodies are copied into traces and logs (truncated), which could include sensitive details; behavior is observability-only and does not change API auth or business logic.
> 
> **Overview**
> Closes an observability gap where failed Vantage API responses (e.g. 400s) did not surface the API’s error payload in traces or logs, making customer failures hard to debug.
> 
> **Tracing** now captures truncated HTTP error bodies on client spans for 4xx/5xx (via `traceFetch`), serializes API errors with `formatErrorsForTelemetry`, and lets tool/MCP handlers set `span.status` and `error.message` without throwing—including `MCPUserError` paths and the active span in `callApi` when the JSON `errors` array is parsed. **`runWithSpan`** exports callback-set status on successful completion.
> 
> **Logging** switches failed Vantage calls to `logger.error` with an `api_errors` tag and adds Datadog/OTel trace correlation fields (`dd.trace_id`, `dd.span_id`, `otel.*`) on API request logs. Unit tests cover span enrichment and `datadogTraceLogTags`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65c1e48d9a3cd8071590da809335307316b6f0b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->