### PR TITLE
feat: Add usage budget fields to MCP tools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
         "@cloudflare/workers-oauth-provider": "^0.0.11",
         "@modelcontextprotocol/sdk": "1.29.0",
         "@sentry/cloudflare": "10.30.0",
-        "@vantage-sh/vantage-client": "2.24.0",
+        "@vantage-sh/vantage-client": "2.27.0",
         "agents": "^0.13.2",
         "axios": "1.13.5",
         "hono": "4.12.12",
@@ -7841,9 +7841,9 @@
       }
     },
     "node_modules/@vantage-sh/vantage-client": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/@vantage-sh/vantage-client/-/vantage-client-2.24.0.tgz",
-      "integrity": "sha512-9JsS37yykTtp6jcJFOCqXUOnoe9NDzOeqWJEQX+2q+nCOk4PL/BhfPzxnEWP1N7qf5RCdlSiVF3xLAsBSkLyBQ==",
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/@vantage-sh/vantage-client/-/vantage-client-2.27.0.tgz",
+      "integrity": "sha512-JWSzsPMhLuKmsuFYfNPAYTF0vVQyE/aynDbLmfMcpzIILltm/pHcAAmsl1qb1m2FJyh2tQqx0uNe4+Ru1/2jdg==",
       "license": "MIT"
     },
     "node_modules/@vercel/oidc": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@cloudflare/workers-oauth-provider": "^0.0.11",
     "@modelcontextprotocol/sdk": "1.29.0",
     "@sentry/cloudflare": "10.30.0",
-    "@vantage-sh/vantage-client": "2.24.0",
+    "@vantage-sh/vantage-client": "2.27.0",
     "agents": "^0.13.2",
     "axios": "1.13.5",
     "hono": "4.12.12",

--- a/src/tools/budgets/create-budget.ts
+++ b/src/tools/budgets/create-budget.ts
@@ -2,7 +2,7 @@ import z from "zod";
 import { vantageToken } from "../../utils/zod";
 import MCPUserError from "../structure/MCPUserError";
 import registerTool from "../structure/registerTool";
-import { budgetPeriod, periodCadence } from "./schemas";
+import { budgetPeriod, budgetType, budgetUnit, periodCadence } from "./schemas";
 
 const description = `
 Creates a budget based on the parameters specified. This is useful if you have been tasked with managing budgets
@@ -26,6 +26,10 @@ export default registerTool({
     cost_report_token: vantageToken("cost_report", {
       description: "Ignored for hierarchical Budgets.",
     }).optional(),
+    type: budgetType
+      .optional()
+      .describe("The type of Budget. Use cost for spend-based Budgets or usage for usage-based Budgets."),
+    unit: budgetUnit.optional().describe("The usage unit for usage Budgets. Only valid when type is usage."),
     child_budget_tokens: z
       .array(vantageToken("budget"))
       .optional()

--- a/src/tools/budgets/schemas.ts
+++ b/src/tools/budgets/schemas.ts
@@ -1,5 +1,10 @@
 import z from "zod";
 import dateValidator from "../../utils/dateValidator";
+import { nonempty } from "../../utils/zod";
+
+export const budgetType = z.enum(["cost", "usage"]);
+
+export const budgetUnit = nonempty();
 
 export const budgetPeriod = z.object({
   start_at: dateValidator("The start date of the period."),

--- a/src/tools/budgets/update-budget.ts
+++ b/src/tools/budgets/update-budget.ts
@@ -3,7 +3,7 @@ import z from "zod";
 import { vantageToken } from "../../utils/zod";
 import MCPUserError from "../structure/MCPUserError";
 import registerTool from "../structure/registerTool";
-import { budgetPeriod, periodCadence } from "./schemas";
+import { budgetPeriod, budgetType, budgetUnit, periodCadence } from "./schemas";
 
 const description = `
 Updates an existing Budget. You can update the name, linked Cost Report, child Budget tokens for hierarchical budgets, period cadence, or budget periods.
@@ -24,6 +24,13 @@ export default registerTool({
     cost_report_token: vantageToken("cost_report", {
       description: "Ignored for hierarchical Budgets.",
     }).optional(),
+    type: budgetType
+      .optional()
+      .describe("The updated Budget type. Use cost for spend-based Budgets or usage for usage-based Budgets."),
+    unit: budgetUnit
+      .nullable()
+      .optional()
+      .describe("The updated usage unit for usage Budgets. Send null to clear. Only valid when type is usage."),
     child_budget_tokens: z
       .array(vantageToken("budget"))
       .optional()

--- a/test/tools/budgets/create-budget.test.ts
+++ b/test/tools/budgets/create-budget.test.ts
@@ -21,6 +21,8 @@ const undefineds = {
   child_budget_tokens: undefined,
   period_cadence: undefined,
   periods: undefined,
+  type: undefined,
+  unit: undefined,
 };
 
 const validInputArguments: InferValidators<Validators> = {
@@ -45,6 +47,8 @@ const validInputArguments: InferValidators<Validators> = {
       amount: 1200,
     },
   ],
+  type: "usage",
+  unit: "GB-Hours",
 };
 
 const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
@@ -58,6 +62,34 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
   {
     name: "all valid arguments",
     data: validInputArguments,
+  },
+  {
+    name: "usage budget with unit",
+    data: {
+      ...undefineds,
+      name: "Usage Budget",
+      type: "usage",
+      unit: "GB-Hours",
+    },
+  },
+  {
+    name: "invalid budget type",
+    data: {
+      ...undefineds,
+      name: "Invalid Type Budget",
+      type: "forecast" as "usage",
+    },
+    expectedIssues: ['Invalid option: expected one of "cost"|"usage"'],
+  },
+  {
+    name: "empty unit",
+    data: {
+      ...undefineds,
+      name: "Empty Unit Budget",
+      type: "usage",
+      unit: "",
+    },
+    expectedIssues: ["Too small: expected string to have >=1 characters"],
   },
   {
     name: "empty name",
@@ -287,6 +319,8 @@ const successData: CreateBudgetResponse = {
   budget_alert_tokens: [],
   child_budget_tokens: [],
   created_at: "2023-01-01T00:00:00Z",
+  type: "usage",
+  unit: "GB-Hours",
   period_cadence: {
     starts_at: "2024-01-01",
     interval_count: 1,

--- a/test/tools/budgets/update-budget.test.ts
+++ b/test/tools/budgets/update-budget.test.ts
@@ -20,6 +20,8 @@ const undefineds = {
   child_budget_tokens: undefined,
   period_cadence: undefined,
   periods: undefined,
+  type: undefined,
+  unit: undefined,
 };
 
 const minimalValidInputArguments: InferValidators<Validators> = {
@@ -49,6 +51,8 @@ const validInputArguments: InferValidators<Validators> = {
       amount: 1200,
     },
   ],
+  type: "usage",
+  unit: "GB-Hours",
 };
 
 const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
@@ -59,6 +63,42 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
   {
     name: "all valid arguments",
     data: validInputArguments,
+  },
+  {
+    name: "usage budget type and unit",
+    data: {
+      ...undefineds,
+      budget_token: "bdgt_123",
+      type: "usage",
+      unit: "GB-Hours",
+    },
+  },
+  {
+    name: "clears unit",
+    data: {
+      ...undefineds,
+      budget_token: "bdgt_123",
+      unit: null,
+    },
+  },
+  {
+    name: "invalid budget type",
+    data: {
+      ...undefineds,
+      budget_token: "bdgt_123",
+      type: "forecast" as "usage",
+    },
+    expectedIssues: ['Invalid option: expected one of "cost"|"usage"'],
+  },
+  {
+    name: "empty unit",
+    data: {
+      ...undefineds,
+      budget_token: "bdgt_123",
+      type: "usage",
+      unit: "",
+    },
+    expectedIssues: ["Too small: expected string to have >=1 characters"],
   },
   {
     name: "empty name",
@@ -222,6 +262,8 @@ const successData: UpdateBudgetResponse = {
   budget_alert_tokens: [],
   child_budget_tokens: ["bdgt_child1", "bdgt_child2"],
   created_at: "2023-01-01T00:00:00Z",
+  type: "usage",
+  unit: "GB-Hours",
   period_cadence: {
     starts_at: "2024-01-01",
     interval_count: 1,
@@ -260,6 +302,8 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
             { start_at: "2024-01-01", end_at: "2024-01-31", amount: 1000 },
             { start_at: "2024-02-01", end_at: "2024-02-29", amount: 1200 },
           ],
+          type: "usage",
+          unit: "GB-Hours",
         },
         method: "PUT",
         result: {


### PR DESCRIPTION
## Summary

Adds MCP support for the Budget API usage budget fields from [FIN-4636](https://linear.app/vantage-sh/issue/FIN-4636/api-and-mcp-usage-budget-type-and-unit):

- Bumps `@vantage-sh/vantage-client` from `2.24.0` to `2.27.0`.
- Adds `type` (`cost` or `usage`) and `unit` inputs to `create-budget`.
- Adds `type` (`cost` or `usage`) and nullable `unit` input to `update-budget`, matching the API client contract that allows clearing `unit` on update.
- Covers schema validation and request forwarding in budget tool tests.

## Verification

- `npm test -- test/tools/budgets/create-budget.test.ts test/tools/budgets/update-budget.test.ts`
- `npm run type-check`
- `npm run check:lint:all`
- `npm test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive optional MCP inputs and a client version bump; behavior for existing callers is unchanged unless they pass the new fields.
> 
> **Overview**
> Extends budget MCP tools to match the Vantage API’s **usage budget** support and bumps **`@vantage-sh/vantage-client`** from **2.24.0** to **2.27.0**.
> 
> **`create-budget`** and **`update-budget`** now accept optional **`type`** (`cost` or `usage`) and **`unit`** (non-empty usage unit when type is usage). On **update**, **`unit`** can be set to **`null`** to clear it. Shared Zod helpers **`budgetType`** and **`budgetUnit`** live in `schemas.ts`; validated args are forwarded to the existing `/v2/budgets` POST/PUT handlers unchanged.
> 
> Tests add schema cases (invalid type, empty unit, usage + unit, clearing unit on update) and expect **`type`** / **`unit`** in mocked API payloads and responses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0c271d0ca57249548295d6c9aa2d496836ce323. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->