### PR TITLE
FCR fixes - Grouping validations, tests, evals

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Exclude generated eval results from GitHub language statistics
+evals/results/** linguist-generated

--- a/evals/cases/financial-commitment-reports/create-financial-commitment-report.eval.ts
+++ b/evals/cases/financial-commitment-reports/create-financial-commitment-report.eval.ts
@@ -1,0 +1,50 @@
+import { buildToolCases } from "../../_lib/buildCases";
+
+const TARGET = "create-financial-commitment-report";
+
+export default function generateTests() {
+  return buildToolCases({
+    target: TARGET,
+    resource: "financial-commitment-reports",
+    distractors: [
+      "update-financial-commitment-report",
+      "query-financial-commitment-report-costs",
+      "create-cost-report",
+      "list-financial-commitment-reports",
+    ],
+    directPrompts: [
+      {
+        input:
+          "Use create-financial-commitment-report to create a report titled AWS Commitment Coverage in workspace wrkspc_abc123 for the last 30 days, grouped by resource_account_id and service.",
+        expected: [
+          {
+            toolName: TARGET,
+            input: {
+              workspace_token: "wrkspc_abc123",
+              title: "AWS Commitment Coverage",
+              date_interval: "last_30_days",
+              groupings: ["resource_account_id", "service"],
+            },
+          },
+        ],
+      },
+    ],
+    inferredPrompts: [
+      {
+        input:
+          "Set up a new Vantage financial commitment report named Linked Account Savings Plan Coverage in workspace wrkspc_abc123. Use the last month and break it down by the account whose resources consumed the commitment and by commitment type.",
+        expected: [
+          {
+            toolName: TARGET,
+            input: {
+              workspace_token: "wrkspc_abc123",
+              title: "Linked Account Savings Plan Coverage",
+              date_interval: "last_month",
+              groupings: ["resource_account_id", "commitment_type"],
+            },
+          },
+        ],
+      },
+    ],
+  });
+}

--- a/evals/cases/financial-commitment-reports/delete-financial-commitment-report.eval.ts
+++ b/evals/cases/financial-commitment-reports/delete-financial-commitment-report.eval.ts
@@ -1,0 +1,39 @@
+import { buildToolCases } from "../../_lib/buildCases";
+
+const TARGET = "delete-financial-commitment-report";
+
+export default function generateTests() {
+  return buildToolCases({
+    target: TARGET,
+    resource: "financial-commitment-reports",
+    distractors: [
+      "get-financial-commitment-report",
+      "update-financial-commitment-report",
+      "delete-cost-report",
+      "list-financial-commitment-reports",
+    ],
+    directPrompts: [
+      {
+        input:
+          "Use delete-financial-commitment-report to permanently delete Vantage financial commitment report fncl_cmnt_rprt_abc123.",
+        expected: [
+          {
+            toolName: TARGET,
+            input: { financial_commitment_report_token: "fncl_cmnt_rprt_abc123" },
+          },
+        ],
+      },
+    ],
+    inferredPrompts: [
+      {
+        input: "Remove the obsolete Vantage financial commitment report fncl_cmnt_rprt_legacy456 for good.",
+        expected: [
+          {
+            toolName: TARGET,
+            input: { financial_commitment_report_token: "fncl_cmnt_rprt_legacy456" },
+          },
+        ],
+      },
+    ],
+  });
+}

--- a/evals/cases/financial-commitment-reports/get-financial-commitment-report.eval.ts
+++ b/evals/cases/financial-commitment-reports/get-financial-commitment-report.eval.ts
@@ -1,0 +1,40 @@
+import { buildToolCases } from "../../_lib/buildCases";
+
+const TARGET = "get-financial-commitment-report";
+
+export default function generateTests() {
+  return buildToolCases({
+    target: TARGET,
+    resource: "financial-commitment-reports",
+    distractors: [
+      "list-financial-commitment-reports",
+      "query-financial-commitment-report-costs",
+      "update-financial-commitment-report",
+      "get-cost-report",
+    ],
+    directPrompts: [
+      {
+        input:
+          "Use get-financial-commitment-report to retrieve the saved configuration for Vantage financial commitment report fncl_cmnt_rprt_abc123.",
+        expected: [
+          {
+            toolName: TARGET,
+            input: { financial_commitment_report_token: "fncl_cmnt_rprt_abc123" },
+          },
+        ],
+      },
+    ],
+    inferredPrompts: [
+      {
+        input:
+          "Show me the title, date range, groupings, and filter configured on Vantage financial commitment report fncl_cmnt_rprt_coverage789.",
+        expected: [
+          {
+            toolName: TARGET,
+            input: { financial_commitment_report_token: "fncl_cmnt_rprt_coverage789" },
+          },
+        ],
+      },
+    ],
+  });
+}

--- a/evals/cases/financial-commitment-reports/list-financial-commitment-reports.eval.ts
+++ b/evals/cases/financial-commitment-reports/list-financial-commitment-reports.eval.ts
@@ -1,0 +1,40 @@
+import { buildToolCases } from "../../_lib/buildCases";
+
+const TARGET = "list-financial-commitment-reports";
+
+export default function generateTests() {
+  return buildToolCases({
+    target: TARGET,
+    resource: "financial-commitment-reports",
+    distractors: [
+      "get-financial-commitment-report",
+      "query-financial-commitment-report-costs",
+      "list-cost-reports",
+      "list-workspaces",
+    ],
+    directPrompts: [
+      {
+        input:
+          "Use list-financial-commitment-reports to search page 2 for Vantage financial commitment reports titled Savings Plans in workspace wrkspc_abc123.",
+        expected: [
+          {
+            toolName: TARGET,
+            input: { page: 2, q: "Savings Plans", workspace_token: "wrkspc_abc123" },
+          },
+        ],
+      },
+    ],
+    inferredPrompts: [
+      {
+        input:
+          "Which saved Vantage financial commitment reports are available in workspace wrkspc_finops789? Show the first page.",
+        expected: [
+          {
+            toolName: TARGET,
+            input: { page: 1, workspace_token: "wrkspc_finops789" },
+          },
+        ],
+      },
+    ],
+  });
+}

--- a/evals/cases/financial-commitment-reports/query-financial-commitment-report-costs.eval.ts
+++ b/evals/cases/financial-commitment-reports/query-financial-commitment-report-costs.eval.ts
@@ -10,7 +10,7 @@ export default function generateTests() {
     directPrompts: [
       {
         input:
-          "Use query-financial-commitment-report-costs to fetch cost data for financial commitment report fncl_cmnt_rprt_abc123 from 2024-03-01 through 2024-03-31, grouped by cost_type and service.",
+          "Use query-financial-commitment-report-costs to fetch cost data for financial commitment report fncl_cmnt_rprt_abc123 from 2024-03-01 through 2024-03-31, grouped by resource_account_id and service.",
         expected: [
           {
             toolName: TARGET,
@@ -18,7 +18,7 @@ export default function generateTests() {
               financial_commitment_report_token: "fncl_cmnt_rprt_abc123",
               start_date: "2024-03-01",
               end_date: "2024-03-31",
-              groupings: ["cost_type", "service"],
+              groupings: ["resource_account_id", "service"],
               page: 1,
             },
           },
@@ -28,12 +28,13 @@ export default function generateTests() {
     inferredPrompts: [
       {
         input:
-          "I have financial commitment report fncl_cmnt_rprt_abc123 and need the committed vs on-demand cost rows for that report — use its saved date range and filters.",
+          "For Vantage financial commitment report fncl_cmnt_rprt_abc123, show me which linked accounts' resources are actually consuming the commitments, broken down by resource account and commitment type. Use the report's saved date range and filters.",
         expected: [
           {
             toolName: TARGET,
             input: {
               financial_commitment_report_token: "fncl_cmnt_rprt_abc123",
+              groupings: ["resource_account_id", "commitment_type"],
               page: 1,
             },
           },

--- a/evals/cases/financial-commitment-reports/update-financial-commitment-report.eval.ts
+++ b/evals/cases/financial-commitment-reports/update-financial-commitment-report.eval.ts
@@ -1,0 +1,47 @@
+import { buildToolCases } from "../../_lib/buildCases";
+
+const TARGET = "update-financial-commitment-report";
+
+export default function generateTests() {
+  return buildToolCases({
+    target: TARGET,
+    resource: "financial-commitment-reports",
+    distractors: [
+      "create-financial-commitment-report",
+      "query-financial-commitment-report-costs",
+      "get-financial-commitment-report",
+      "update-cost-report",
+    ],
+    directPrompts: [
+      {
+        input:
+          "Use update-financial-commitment-report to rename fncl_cmnt_rprt_abc123 to Account Commitment Coverage and group it by resource_account_id and service.",
+        expected: [
+          {
+            toolName: TARGET,
+            input: {
+              financial_commitment_report_token: "fncl_cmnt_rprt_abc123",
+              title: "Account Commitment Coverage",
+              groupings: ["resource_account_id", "service"],
+            },
+          },
+        ],
+      },
+    ],
+    inferredPrompts: [
+      {
+        input:
+          "Change Vantage financial commitment report fncl_cmnt_rprt_abc123 so its breakdown shows the commitment billing account alongside the cost type.",
+        expected: [
+          {
+            toolName: TARGET,
+            input: {
+              financial_commitment_report_token: "fncl_cmnt_rprt_abc123",
+              groupings: ["provider_account_id", "cost_type"],
+            },
+          },
+        ],
+      },
+    ],
+  });
+}

--- a/evals/cases/financial-commitment-reports/update-financial-commitment-report.eval.ts
+++ b/evals/cases/financial-commitment-reports/update-financial-commitment-report.eval.ts
@@ -31,13 +31,15 @@ export default function generateTests() {
     inferredPrompts: [
       {
         input:
-          "Change Vantage financial commitment report fncl_cmnt_rprt_abc123 so its breakdown shows the commitment billing account alongside the cost type.",
+          "Change Vantage financial commitment report fncl_cmnt_rprt_abc123 to be weekly, make on demand discountable, and group by cost type and commitment type",
         expected: [
           {
             toolName: TARGET,
             input: {
               financial_commitment_report_token: "fncl_cmnt_rprt_abc123",
-              groupings: ["provider_account_id", "cost_type"],
+              date_bucket: "week",
+              on_demand_costs_scope: "discountable",
+              groupings: ["cost_type", "commitment_type"],
             },
           },
         ],

--- a/evals/results/gpt-5.6-luna/financial-commitment-reports/create-financial-commitment-report.json
+++ b/evals/results/gpt-5.6-luna/financial-commitment-reports/create-financial-commitment-report.json
@@ -2,7 +2,7 @@
   "evalId": null,
   "results": {
     "version": 3,
-    "timestamp": "2026-09-10T20:47:27.803Z",
+    "timestamp": "2026-09-10T20:45:56.500Z",
     "results": [
       {
         "cost": 0,
@@ -30,11 +30,11 @@
             }
           ]
         },
-        "id": "fbed8fb4-6ea1-4928-86c5-cef3166225cb",
-        "latencyMs": 3606,
+        "id": "d37bfcda-790c-4f8a-8958-a46b22e38f69",
+        "latencyMs": 3344,
         "namedScores": {},
         "prompt": {
-          "raw": "Use query-financial-commitment-report-costs to fetch cost data for financial commitment report fncl_cmnt_rprt_abc123 from 2024-03-01 through 2024-03-31, grouped by resource_account_id and service.",
+          "raw": "Use create-financial-commitment-report to create a report titled AWS Commitment Coverage in workspace wrkspc_abc123 for the last 30 days, grouped by resource_account_id and service.",
           "label": "{{prompt}}",
           "config": {
             "disableVarExpansion": true
@@ -50,12 +50,11 @@
           "output": {
             "toolCalls": [
               {
-                "toolName": "query-financial-commitment-report-costs",
+                "toolName": "create-financial-commitment-report",
                 "input": {
-                  "financial_commitment_report_token": "fncl_cmnt_rprt_abc123",
-                  "page": 1,
-                  "start_date": "2024-03-01",
-                  "end_date": "2024-03-31",
+                  "workspace_token": "wrkspc_abc123",
+                  "title": "AWS Commitment Coverage",
+                  "date_interval": "last_30_days",
                   "groupings": [
                     "resource_account_id",
                     "service"
@@ -68,22 +67,21 @@
           "metadata": {
             "modelId": "gpt-5.6-luna",
             "mode": "mixed",
-            "target": "query-financial-commitment-report-costs",
+            "target": "create-financial-commitment-report",
             "toolNames": [
+              "create-financial-commitment-report",
+              "update-financial-commitment-report",
               "query-financial-commitment-report-costs",
-              "get-financial-commitment-report",
-              "list-financial-commitment-reports",
-              "list-costs",
-              "query-costs"
+              "create-cost-report",
+              "list-financial-commitment-reports"
             ],
             "toolCalls": [
               {
-                "toolName": "query-financial-commitment-report-costs",
+                "toolName": "create-financial-commitment-report",
                 "input": {
-                  "financial_commitment_report_token": "fncl_cmnt_rprt_abc123",
-                  "page": 1,
-                  "start_date": "2024-03-01",
-                  "end_date": "2024-03-31",
+                  "workspace_token": "wrkspc_abc123",
+                  "title": "AWS Commitment Coverage",
+                  "date_interval": "last_30_days",
                   "groupings": [
                     "resource_account_id",
                     "service"
@@ -96,37 +94,36 @@
         "score": 1,
         "success": true,
         "testCase": {
-          "description": "query-financial-commitment-report-costs · direct · Use query-financial-commitment-report-costs to fetch cost data for financial commitment report fncl_cmnt_rprt_abc123 from 2024-03-01 through 2024-03-31, grouped by resource_account_id and service.",
+          "description": "create-financial-commitment-report · direct · Use create-financial-commitment-report to create a report titled AWS Commitment Coverage in workspace wrkspc_abc123 for the last 30 days, grouped by resource_account_id and service.",
           "vars": {
-            "prompt": "Use query-financial-commitment-report-costs to fetch cost data for financial commitment report fncl_cmnt_rprt_abc123 from 2024-03-01 through 2024-03-31, grouped by resource_account_id and service.",
-            "target": "query-financial-commitment-report-costs",
+            "prompt": "Use create-financial-commitment-report to create a report titled AWS Commitment Coverage in workspace wrkspc_abc123 for the last 30 days, grouped by resource_account_id and service.",
+            "target": "create-financial-commitment-report",
             "expected": [
               {
-                "toolName": "query-financial-commitment-report-costs",
+                "toolName": "create-financial-commitment-report",
                 "input": {
-                  "financial_commitment_report_token": "fncl_cmnt_rprt_abc123",
-                  "start_date": "2024-03-01",
-                  "end_date": "2024-03-31",
+                  "workspace_token": "wrkspc_abc123",
+                  "title": "AWS Commitment Coverage",
+                  "date_interval": "last_30_days",
                   "groupings": [
                     "resource_account_id",
                     "service"
-                  ],
-                  "page": 1
+                  ]
                 }
               }
             ],
             "distractors": [
-              "get-financial-commitment-report",
-              "list-financial-commitment-reports",
-              "list-costs",
-              "query-costs"
+              "update-financial-commitment-report",
+              "query-financial-commitment-report-costs",
+              "create-cost-report",
+              "list-financial-commitment-reports"
             ]
           },
           "options": {
             "disableVarExpansion": true
           },
           "metadata": {
-            "tool": "query-financial-commitment-report-costs",
+            "tool": "create-financial-commitment-report",
             "resource": "financial-commitment-reports",
             "phrasing": "direct"
           },
@@ -167,52 +164,50 @@
           }
         },
         "vars": {
-          "prompt": "Use query-financial-commitment-report-costs to fetch cost data for financial commitment report fncl_cmnt_rprt_abc123 from 2024-03-01 through 2024-03-31, grouped by resource_account_id and service.",
-          "target": "query-financial-commitment-report-costs",
+          "prompt": "Use create-financial-commitment-report to create a report titled AWS Commitment Coverage in workspace wrkspc_abc123 for the last 30 days, grouped by resource_account_id and service.",
+          "target": "create-financial-commitment-report",
           "expected": [
             {
-              "toolName": "query-financial-commitment-report-costs",
+              "toolName": "create-financial-commitment-report",
               "input": {
-                "financial_commitment_report_token": "fncl_cmnt_rprt_abc123",
-                "start_date": "2024-03-01",
-                "end_date": "2024-03-31",
+                "workspace_token": "wrkspc_abc123",
+                "title": "AWS Commitment Coverage",
+                "date_interval": "last_30_days",
                 "groupings": [
                   "resource_account_id",
                   "service"
-                ],
-                "page": 1
+                ]
               }
             }
           ],
           "distractors": [
-            "get-financial-commitment-report",
-            "list-financial-commitment-reports",
-            "list-costs",
-            "query-costs"
+            "update-financial-commitment-report",
+            "query-financial-commitment-report-costs",
+            "create-cost-report",
+            "list-financial-commitment-reports"
           ]
         },
         "metadata": {
-          "tool": "query-financial-commitment-report-costs",
+          "tool": "create-financial-commitment-report",
           "resource": "financial-commitment-reports",
           "phrasing": "direct",
           "modelId": "gpt-5.6-luna",
           "mode": "mixed",
-          "target": "query-financial-commitment-report-costs",
+          "target": "create-financial-commitment-report",
           "toolNames": [
+            "create-financial-commitment-report",
+            "update-financial-commitment-report",
             "query-financial-commitment-report-costs",
-            "get-financial-commitment-report",
-            "list-financial-commitment-reports",
-            "list-costs",
-            "query-costs"
+            "create-cost-report",
+            "list-financial-commitment-reports"
           ],
           "toolCalls": [
             {
-              "toolName": "query-financial-commitment-report-costs",
+              "toolName": "create-financial-commitment-report",
               "input": {
-                "financial_commitment_report_token": "fncl_cmnt_rprt_abc123",
-                "page": 1,
-                "start_date": "2024-03-01",
-                "end_date": "2024-03-31",
+                "workspace_token": "wrkspc_abc123",
+                "title": "AWS Commitment Coverage",
+                "date_interval": "last_30_days",
                 "groupings": [
                   "resource_account_id",
                   "service"
@@ -250,11 +245,11 @@
             }
           ]
         },
-        "id": "cbd2c88a-bb39-41df-9ada-068fbdb7c777",
-        "latencyMs": 2439,
+        "id": "8ea41b56-8d92-463f-906c-f9d266d2cea9",
+        "latencyMs": 3339,
         "namedScores": {},
         "prompt": {
-          "raw": "For Vantage financial commitment report fncl_cmnt_rprt_abc123, show me which linked accounts' resources are actually consuming the commitments, broken down by resource account and commitment type. Use the report's saved date range and filters.",
+          "raw": "Set up a new Vantage financial commitment report named Linked Account Savings Plan Coverage in workspace wrkspc_abc123. Use the last month and break it down by the account whose resources consumed the commitment and by commitment type.",
           "label": "{{prompt}}",
           "config": {
             "disableVarExpansion": true
@@ -270,10 +265,11 @@
           "output": {
             "toolCalls": [
               {
-                "toolName": "query-financial-commitment-report-costs",
+                "toolName": "create-financial-commitment-report",
                 "input": {
-                  "financial_commitment_report_token": "fncl_cmnt_rprt_abc123",
-                  "page": 1,
+                  "workspace_token": "wrkspc_abc123",
+                  "title": "Linked Account Savings Plan Coverage",
+                  "date_interval": "last_month",
                   "groupings": [
                     "resource_account_id",
                     "commitment_type"
@@ -286,20 +282,21 @@
           "metadata": {
             "modelId": "gpt-5.6-luna",
             "mode": "mixed",
-            "target": "query-financial-commitment-report-costs",
+            "target": "create-financial-commitment-report",
             "toolNames": [
+              "create-financial-commitment-report",
+              "update-financial-commitment-report",
               "query-financial-commitment-report-costs",
-              "get-financial-commitment-report",
-              "list-financial-commitment-reports",
-              "list-costs",
-              "query-costs"
+              "create-cost-report",
+              "list-financial-commitment-reports"
             ],
             "toolCalls": [
               {
-                "toolName": "query-financial-commitment-report-costs",
+                "toolName": "create-financial-commitment-report",
                 "input": {
-                  "financial_commitment_report_token": "fncl_cmnt_rprt_abc123",
-                  "page": 1,
+                  "workspace_token": "wrkspc_abc123",
+                  "title": "Linked Account Savings Plan Coverage",
+                  "date_interval": "last_month",
                   "groupings": [
                     "resource_account_id",
                     "commitment_type"
@@ -312,35 +309,36 @@
         "score": 1,
         "success": true,
         "testCase": {
-          "description": "query-financial-commitment-report-costs · inferred · For Vantage financial commitment report fncl_cmnt_rprt_abc123, show me which linked accounts' resources are actually consuming the commitments, broken down by resource account and commitment type. Use the report's saved date range and filters.",
+          "description": "create-financial-commitment-report · inferred · Set up a new Vantage financial commitment report named Linked Account Savings Plan Coverage in workspace wrkspc_abc123. Use the last month and break it down by the account whose resources consumed the commitment and by commitment type.",
           "vars": {
-            "prompt": "For Vantage financial commitment report fncl_cmnt_rprt_abc123, show me which linked accounts' resources are actually consuming the commitments, broken down by resource account and commitment type. Use the report's saved date range and filters.",
-            "target": "query-financial-commitment-report-costs",
+            "prompt": "Set up a new Vantage financial commitment report named Linked Account Savings Plan Coverage in workspace wrkspc_abc123. Use the last month and break it down by the account whose resources consumed the commitment and by commitment type.",
+            "target": "create-financial-commitment-report",
             "expected": [
               {
-                "toolName": "query-financial-commitment-report-costs",
+                "toolName": "create-financial-commitment-report",
                 "input": {
-                  "financial_commitment_report_token": "fncl_cmnt_rprt_abc123",
+                  "workspace_token": "wrkspc_abc123",
+                  "title": "Linked Account Savings Plan Coverage",
+                  "date_interval": "last_month",
                   "groupings": [
                     "resource_account_id",
                     "commitment_type"
-                  ],
-                  "page": 1
+                  ]
                 }
               }
             ],
             "distractors": [
-              "get-financial-commitment-report",
-              "list-financial-commitment-reports",
-              "list-costs",
-              "query-costs"
+              "update-financial-commitment-report",
+              "query-financial-commitment-report-costs",
+              "create-cost-report",
+              "list-financial-commitment-reports"
             ]
           },
           "options": {
             "disableVarExpansion": true
           },
           "metadata": {
-            "tool": "query-financial-commitment-report-costs",
+            "tool": "create-financial-commitment-report",
             "resource": "financial-commitment-reports",
             "phrasing": "inferred"
           },
@@ -381,48 +379,50 @@
           }
         },
         "vars": {
-          "prompt": "For Vantage financial commitment report fncl_cmnt_rprt_abc123, show me which linked accounts' resources are actually consuming the commitments, broken down by resource account and commitment type. Use the report's saved date range and filters.",
-          "target": "query-financial-commitment-report-costs",
+          "prompt": "Set up a new Vantage financial commitment report named Linked Account Savings Plan Coverage in workspace wrkspc_abc123. Use the last month and break it down by the account whose resources consumed the commitment and by commitment type.",
+          "target": "create-financial-commitment-report",
           "expected": [
             {
-              "toolName": "query-financial-commitment-report-costs",
+              "toolName": "create-financial-commitment-report",
               "input": {
-                "financial_commitment_report_token": "fncl_cmnt_rprt_abc123",
+                "workspace_token": "wrkspc_abc123",
+                "title": "Linked Account Savings Plan Coverage",
+                "date_interval": "last_month",
                 "groupings": [
                   "resource_account_id",
                   "commitment_type"
-                ],
-                "page": 1
+                ]
               }
             }
           ],
           "distractors": [
-            "get-financial-commitment-report",
-            "list-financial-commitment-reports",
-            "list-costs",
-            "query-costs"
+            "update-financial-commitment-report",
+            "query-financial-commitment-report-costs",
+            "create-cost-report",
+            "list-financial-commitment-reports"
           ]
         },
         "metadata": {
-          "tool": "query-financial-commitment-report-costs",
+          "tool": "create-financial-commitment-report",
           "resource": "financial-commitment-reports",
           "phrasing": "inferred",
           "modelId": "gpt-5.6-luna",
           "mode": "mixed",
-          "target": "query-financial-commitment-report-costs",
+          "target": "create-financial-commitment-report",
           "toolNames": [
+            "create-financial-commitment-report",
+            "update-financial-commitment-report",
             "query-financial-commitment-report-costs",
-            "get-financial-commitment-report",
-            "list-financial-commitment-reports",
-            "list-costs",
-            "query-costs"
+            "create-cost-report",
+            "list-financial-commitment-reports"
           ],
           "toolCalls": [
             {
-              "toolName": "query-financial-commitment-report-costs",
+              "toolName": "create-financial-commitment-report",
               "input": {
-                "financial_commitment_report_token": "fncl_cmnt_rprt_abc123",
-                "page": 1,
+                "workspace_token": "wrkspc_abc123",
+                "title": "Linked Account Savings Plan Coverage",
+                "date_interval": "last_month",
                 "groupings": [
                   "resource_account_id",
                   "commitment_type"
@@ -470,7 +470,7 @@
       }
     ],
     "tests": [
-      "file://cases/financial-commitment-reports/query-financial-commitment-report-costs.eval.ts"
+      "file://cases/financial-commitment-reports/create-financial-commitment-report.eval.ts"
     ],
     "env": {},
     "extensions": [],
@@ -485,7 +485,7 @@
     "nodeVersion": "v23.11.0",
     "platform": "darwin",
     "arch": "arm64",
-    "exportedAt": "2026-09-10T20:47:27.425Z",
-    "evaluationCreatedAt": "2026-09-10T20:47:23.716Z"
+    "exportedAt": "2026-09-10T20:45:56.162Z",
+    "evaluationCreatedAt": "2026-09-10T20:45:52.719Z"
   }
 }

--- a/evals/results/gpt-5.6-luna/financial-commitment-reports/delete-financial-commitment-report.json
+++ b/evals/results/gpt-5.6-luna/financial-commitment-reports/delete-financial-commitment-report.json
@@ -2,7 +2,7 @@
   "evalId": null,
   "results": {
     "version": 3,
-    "timestamp": "2026-09-10T20:47:27.803Z",
+    "timestamp": "2026-09-10T20:46:18.694Z",
     "results": [
       {
         "cost": 0,
@@ -30,11 +30,11 @@
             }
           ]
         },
-        "id": "fbed8fb4-6ea1-4928-86c5-cef3166225cb",
-        "latencyMs": 3606,
+        "id": "026971e5-a704-4a58-9423-780d2dccd5ec",
+        "latencyMs": 1714,
         "namedScores": {},
         "prompt": {
-          "raw": "Use query-financial-commitment-report-costs to fetch cost data for financial commitment report fncl_cmnt_rprt_abc123 from 2024-03-01 through 2024-03-31, grouped by resource_account_id and service.",
+          "raw": "Use delete-financial-commitment-report to permanently delete Vantage financial commitment report fncl_cmnt_rprt_abc123.",
           "label": "{{prompt}}",
           "config": {
             "disableVarExpansion": true
@@ -50,16 +50,9 @@
           "output": {
             "toolCalls": [
               {
-                "toolName": "query-financial-commitment-report-costs",
+                "toolName": "delete-financial-commitment-report",
                 "input": {
-                  "financial_commitment_report_token": "fncl_cmnt_rprt_abc123",
-                  "page": 1,
-                  "start_date": "2024-03-01",
-                  "end_date": "2024-03-31",
-                  "groupings": [
-                    "resource_account_id",
-                    "service"
-                  ]
+                  "financial_commitment_report_token": "fncl_cmnt_rprt_abc123"
                 }
               }
             ],
@@ -68,26 +61,19 @@
           "metadata": {
             "modelId": "gpt-5.6-luna",
             "mode": "mixed",
-            "target": "query-financial-commitment-report-costs",
+            "target": "delete-financial-commitment-report",
             "toolNames": [
-              "query-financial-commitment-report-costs",
+              "delete-financial-commitment-report",
               "get-financial-commitment-report",
-              "list-financial-commitment-reports",
-              "list-costs",
-              "query-costs"
+              "update-financial-commitment-report",
+              "delete-cost-report",
+              "list-financial-commitment-reports"
             ],
             "toolCalls": [
               {
-                "toolName": "query-financial-commitment-report-costs",
+                "toolName": "delete-financial-commitment-report",
                 "input": {
-                  "financial_commitment_report_token": "fncl_cmnt_rprt_abc123",
-                  "page": 1,
-                  "start_date": "2024-03-01",
-                  "end_date": "2024-03-31",
-                  "groupings": [
-                    "resource_account_id",
-                    "service"
-                  ]
+                  "financial_commitment_report_token": "fncl_cmnt_rprt_abc123"
                 }
               }
             ]
@@ -96,37 +82,30 @@
         "score": 1,
         "success": true,
         "testCase": {
-          "description": "query-financial-commitment-report-costs · direct · Use query-financial-commitment-report-costs to fetch cost data for financial commitment report fncl_cmnt_rprt_abc123 from 2024-03-01 through 2024-03-31, grouped by resource_account_id and service.",
+          "description": "delete-financial-commitment-report · direct · Use delete-financial-commitment-report to permanently delete Vantage financial commitment report fncl_cmnt_rprt_abc123.",
           "vars": {
-            "prompt": "Use query-financial-commitment-report-costs to fetch cost data for financial commitment report fncl_cmnt_rprt_abc123 from 2024-03-01 through 2024-03-31, grouped by resource_account_id and service.",
-            "target": "query-financial-commitment-report-costs",
+            "prompt": "Use delete-financial-commitment-report to permanently delete Vantage financial commitment report fncl_cmnt_rprt_abc123.",
+            "target": "delete-financial-commitment-report",
             "expected": [
               {
-                "toolName": "query-financial-commitment-report-costs",
+                "toolName": "delete-financial-commitment-report",
                 "input": {
-                  "financial_commitment_report_token": "fncl_cmnt_rprt_abc123",
-                  "start_date": "2024-03-01",
-                  "end_date": "2024-03-31",
-                  "groupings": [
-                    "resource_account_id",
-                    "service"
-                  ],
-                  "page": 1
+                  "financial_commitment_report_token": "fncl_cmnt_rprt_abc123"
                 }
               }
             ],
             "distractors": [
               "get-financial-commitment-report",
-              "list-financial-commitment-reports",
-              "list-costs",
-              "query-costs"
+              "update-financial-commitment-report",
+              "delete-cost-report",
+              "list-financial-commitment-reports"
             ]
           },
           "options": {
             "disableVarExpansion": true
           },
           "metadata": {
-            "tool": "query-financial-commitment-report-costs",
+            "tool": "delete-financial-commitment-report",
             "resource": "financial-commitment-reports",
             "phrasing": "direct"
           },
@@ -167,56 +146,42 @@
           }
         },
         "vars": {
-          "prompt": "Use query-financial-commitment-report-costs to fetch cost data for financial commitment report fncl_cmnt_rprt_abc123 from 2024-03-01 through 2024-03-31, grouped by resource_account_id and service.",
-          "target": "query-financial-commitment-report-costs",
+          "prompt": "Use delete-financial-commitment-report to permanently delete Vantage financial commitment report fncl_cmnt_rprt_abc123.",
+          "target": "delete-financial-commitment-report",
           "expected": [
             {
-              "toolName": "query-financial-commitment-report-costs",
+              "toolName": "delete-financial-commitment-report",
               "input": {
-                "financial_commitment_report_token": "fncl_cmnt_rprt_abc123",
-                "start_date": "2024-03-01",
-                "end_date": "2024-03-31",
-                "groupings": [
-                  "resource_account_id",
-                  "service"
-                ],
-                "page": 1
+                "financial_commitment_report_token": "fncl_cmnt_rprt_abc123"
               }
             }
           ],
           "distractors": [
             "get-financial-commitment-report",
-            "list-financial-commitment-reports",
-            "list-costs",
-            "query-costs"
+            "update-financial-commitment-report",
+            "delete-cost-report",
+            "list-financial-commitment-reports"
           ]
         },
         "metadata": {
-          "tool": "query-financial-commitment-report-costs",
+          "tool": "delete-financial-commitment-report",
           "resource": "financial-commitment-reports",
           "phrasing": "direct",
           "modelId": "gpt-5.6-luna",
           "mode": "mixed",
-          "target": "query-financial-commitment-report-costs",
+          "target": "delete-financial-commitment-report",
           "toolNames": [
-            "query-financial-commitment-report-costs",
+            "delete-financial-commitment-report",
             "get-financial-commitment-report",
-            "list-financial-commitment-reports",
-            "list-costs",
-            "query-costs"
+            "update-financial-commitment-report",
+            "delete-cost-report",
+            "list-financial-commitment-reports"
           ],
           "toolCalls": [
             {
-              "toolName": "query-financial-commitment-report-costs",
+              "toolName": "delete-financial-commitment-report",
               "input": {
-                "financial_commitment_report_token": "fncl_cmnt_rprt_abc123",
-                "page": 1,
-                "start_date": "2024-03-01",
-                "end_date": "2024-03-31",
-                "groupings": [
-                  "resource_account_id",
-                  "service"
-                ]
+                "financial_commitment_report_token": "fncl_cmnt_rprt_abc123"
               }
             }
           ],
@@ -250,11 +215,11 @@
             }
           ]
         },
-        "id": "cbd2c88a-bb39-41df-9ada-068fbdb7c777",
-        "latencyMs": 2439,
+        "id": "bb4683a4-c219-42f9-95fc-92a8b877614d",
+        "latencyMs": 2526,
         "namedScores": {},
         "prompt": {
-          "raw": "For Vantage financial commitment report fncl_cmnt_rprt_abc123, show me which linked accounts' resources are actually consuming the commitments, broken down by resource account and commitment type. Use the report's saved date range and filters.",
+          "raw": "Remove the obsolete Vantage financial commitment report fncl_cmnt_rprt_legacy456 for good.",
           "label": "{{prompt}}",
           "config": {
             "disableVarExpansion": true
@@ -270,14 +235,9 @@
           "output": {
             "toolCalls": [
               {
-                "toolName": "query-financial-commitment-report-costs",
+                "toolName": "delete-financial-commitment-report",
                 "input": {
-                  "financial_commitment_report_token": "fncl_cmnt_rprt_abc123",
-                  "page": 1,
-                  "groupings": [
-                    "resource_account_id",
-                    "commitment_type"
-                  ]
+                  "financial_commitment_report_token": "fncl_cmnt_rprt_legacy456"
                 }
               }
             ],
@@ -286,24 +246,19 @@
           "metadata": {
             "modelId": "gpt-5.6-luna",
             "mode": "mixed",
-            "target": "query-financial-commitment-report-costs",
+            "target": "delete-financial-commitment-report",
             "toolNames": [
-              "query-financial-commitment-report-costs",
+              "delete-financial-commitment-report",
               "get-financial-commitment-report",
-              "list-financial-commitment-reports",
-              "list-costs",
-              "query-costs"
+              "update-financial-commitment-report",
+              "delete-cost-report",
+              "list-financial-commitment-reports"
             ],
             "toolCalls": [
               {
-                "toolName": "query-financial-commitment-report-costs",
+                "toolName": "delete-financial-commitment-report",
                 "input": {
-                  "financial_commitment_report_token": "fncl_cmnt_rprt_abc123",
-                  "page": 1,
-                  "groupings": [
-                    "resource_account_id",
-                    "commitment_type"
-                  ]
+                  "financial_commitment_report_token": "fncl_cmnt_rprt_legacy456"
                 }
               }
             ]
@@ -312,35 +267,30 @@
         "score": 1,
         "success": true,
         "testCase": {
-          "description": "query-financial-commitment-report-costs · inferred · For Vantage financial commitment report fncl_cmnt_rprt_abc123, show me which linked accounts' resources are actually consuming the commitments, broken down by resource account and commitment type. Use the report's saved date range and filters.",
+          "description": "delete-financial-commitment-report · inferred · Remove the obsolete Vantage financial commitment report fncl_cmnt_rprt_legacy456 for good.",
           "vars": {
-            "prompt": "For Vantage financial commitment report fncl_cmnt_rprt_abc123, show me which linked accounts' resources are actually consuming the commitments, broken down by resource account and commitment type. Use the report's saved date range and filters.",
-            "target": "query-financial-commitment-report-costs",
+            "prompt": "Remove the obsolete Vantage financial commitment report fncl_cmnt_rprt_legacy456 for good.",
+            "target": "delete-financial-commitment-report",
             "expected": [
               {
-                "toolName": "query-financial-commitment-report-costs",
+                "toolName": "delete-financial-commitment-report",
                 "input": {
-                  "financial_commitment_report_token": "fncl_cmnt_rprt_abc123",
-                  "groupings": [
-                    "resource_account_id",
-                    "commitment_type"
-                  ],
-                  "page": 1
+                  "financial_commitment_report_token": "fncl_cmnt_rprt_legacy456"
                 }
               }
             ],
             "distractors": [
               "get-financial-commitment-report",
-              "list-financial-commitment-reports",
-              "list-costs",
-              "query-costs"
+              "update-financial-commitment-report",
+              "delete-cost-report",
+              "list-financial-commitment-reports"
             ]
           },
           "options": {
             "disableVarExpansion": true
           },
           "metadata": {
-            "tool": "query-financial-commitment-report-costs",
+            "tool": "delete-financial-commitment-report",
             "resource": "financial-commitment-reports",
             "phrasing": "inferred"
           },
@@ -381,52 +331,42 @@
           }
         },
         "vars": {
-          "prompt": "For Vantage financial commitment report fncl_cmnt_rprt_abc123, show me which linked accounts' resources are actually consuming the commitments, broken down by resource account and commitment type. Use the report's saved date range and filters.",
-          "target": "query-financial-commitment-report-costs",
+          "prompt": "Remove the obsolete Vantage financial commitment report fncl_cmnt_rprt_legacy456 for good.",
+          "target": "delete-financial-commitment-report",
           "expected": [
             {
-              "toolName": "query-financial-commitment-report-costs",
+              "toolName": "delete-financial-commitment-report",
               "input": {
-                "financial_commitment_report_token": "fncl_cmnt_rprt_abc123",
-                "groupings": [
-                  "resource_account_id",
-                  "commitment_type"
-                ],
-                "page": 1
+                "financial_commitment_report_token": "fncl_cmnt_rprt_legacy456"
               }
             }
           ],
           "distractors": [
             "get-financial-commitment-report",
-            "list-financial-commitment-reports",
-            "list-costs",
-            "query-costs"
+            "update-financial-commitment-report",
+            "delete-cost-report",
+            "list-financial-commitment-reports"
           ]
         },
         "metadata": {
-          "tool": "query-financial-commitment-report-costs",
+          "tool": "delete-financial-commitment-report",
           "resource": "financial-commitment-reports",
           "phrasing": "inferred",
           "modelId": "gpt-5.6-luna",
           "mode": "mixed",
-          "target": "query-financial-commitment-report-costs",
+          "target": "delete-financial-commitment-report",
           "toolNames": [
-            "query-financial-commitment-report-costs",
+            "delete-financial-commitment-report",
             "get-financial-commitment-report",
-            "list-financial-commitment-reports",
-            "list-costs",
-            "query-costs"
+            "update-financial-commitment-report",
+            "delete-cost-report",
+            "list-financial-commitment-reports"
           ],
           "toolCalls": [
             {
-              "toolName": "query-financial-commitment-report-costs",
+              "toolName": "delete-financial-commitment-report",
               "input": {
-                "financial_commitment_report_token": "fncl_cmnt_rprt_abc123",
-                "page": 1,
-                "groupings": [
-                  "resource_account_id",
-                  "commitment_type"
-                ]
+                "financial_commitment_report_token": "fncl_cmnt_rprt_legacy456"
               }
             }
           ],
@@ -470,7 +410,7 @@
       }
     ],
     "tests": [
-      "file://cases/financial-commitment-reports/query-financial-commitment-report-costs.eval.ts"
+      "file://cases/financial-commitment-reports/delete-financial-commitment-report.eval.ts"
     ],
     "env": {},
     "extensions": [],
@@ -485,7 +425,7 @@
     "nodeVersion": "v23.11.0",
     "platform": "darwin",
     "arch": "arm64",
-    "exportedAt": "2026-09-10T20:47:27.425Z",
-    "evaluationCreatedAt": "2026-09-10T20:47:23.716Z"
+    "exportedAt": "2026-09-10T20:46:18.353Z",
+    "evaluationCreatedAt": "2026-09-10T20:46:15.753Z"
   }
 }

--- a/evals/results/gpt-5.6-luna/financial-commitment-reports/get-financial-commitment-report.json
+++ b/evals/results/gpt-5.6-luna/financial-commitment-reports/get-financial-commitment-report.json
@@ -2,7 +2,7 @@
   "evalId": null,
   "results": {
     "version": 3,
-    "timestamp": "2026-09-10T20:47:27.803Z",
+    "timestamp": "2026-09-10T20:46:35.862Z",
     "results": [
       {
         "cost": 0,
@@ -30,11 +30,11 @@
             }
           ]
         },
-        "id": "fbed8fb4-6ea1-4928-86c5-cef3166225cb",
-        "latencyMs": 3606,
+        "id": "f7911285-9ca3-4f59-9f9c-7c7f7dd37523",
+        "latencyMs": 1693,
         "namedScores": {},
         "prompt": {
-          "raw": "Use query-financial-commitment-report-costs to fetch cost data for financial commitment report fncl_cmnt_rprt_abc123 from 2024-03-01 through 2024-03-31, grouped by resource_account_id and service.",
+          "raw": "Use get-financial-commitment-report to retrieve the saved configuration for Vantage financial commitment report fncl_cmnt_rprt_abc123.",
           "label": "{{prompt}}",
           "config": {
             "disableVarExpansion": true
@@ -50,16 +50,9 @@
           "output": {
             "toolCalls": [
               {
-                "toolName": "query-financial-commitment-report-costs",
+                "toolName": "get-financial-commitment-report",
                 "input": {
-                  "financial_commitment_report_token": "fncl_cmnt_rprt_abc123",
-                  "page": 1,
-                  "start_date": "2024-03-01",
-                  "end_date": "2024-03-31",
-                  "groupings": [
-                    "resource_account_id",
-                    "service"
-                  ]
+                  "financial_commitment_report_token": "fncl_cmnt_rprt_abc123"
                 }
               }
             ],
@@ -68,26 +61,19 @@
           "metadata": {
             "modelId": "gpt-5.6-luna",
             "mode": "mixed",
-            "target": "query-financial-commitment-report-costs",
+            "target": "get-financial-commitment-report",
             "toolNames": [
-              "query-financial-commitment-report-costs",
               "get-financial-commitment-report",
               "list-financial-commitment-reports",
-              "list-costs",
-              "query-costs"
+              "query-financial-commitment-report-costs",
+              "update-financial-commitment-report",
+              "get-cost-report"
             ],
             "toolCalls": [
               {
-                "toolName": "query-financial-commitment-report-costs",
+                "toolName": "get-financial-commitment-report",
                 "input": {
-                  "financial_commitment_report_token": "fncl_cmnt_rprt_abc123",
-                  "page": 1,
-                  "start_date": "2024-03-01",
-                  "end_date": "2024-03-31",
-                  "groupings": [
-                    "resource_account_id",
-                    "service"
-                  ]
+                  "financial_commitment_report_token": "fncl_cmnt_rprt_abc123"
                 }
               }
             ]
@@ -96,37 +82,30 @@
         "score": 1,
         "success": true,
         "testCase": {
-          "description": "query-financial-commitment-report-costs · direct · Use query-financial-commitment-report-costs to fetch cost data for financial commitment report fncl_cmnt_rprt_abc123 from 2024-03-01 through 2024-03-31, grouped by resource_account_id and service.",
+          "description": "get-financial-commitment-report · direct · Use get-financial-commitment-report to retrieve the saved configuration for Vantage financial commitment report fncl_cmnt_rprt_abc123.",
           "vars": {
-            "prompt": "Use query-financial-commitment-report-costs to fetch cost data for financial commitment report fncl_cmnt_rprt_abc123 from 2024-03-01 through 2024-03-31, grouped by resource_account_id and service.",
-            "target": "query-financial-commitment-report-costs",
+            "prompt": "Use get-financial-commitment-report to retrieve the saved configuration for Vantage financial commitment report fncl_cmnt_rprt_abc123.",
+            "target": "get-financial-commitment-report",
             "expected": [
               {
-                "toolName": "query-financial-commitment-report-costs",
+                "toolName": "get-financial-commitment-report",
                 "input": {
-                  "financial_commitment_report_token": "fncl_cmnt_rprt_abc123",
-                  "start_date": "2024-03-01",
-                  "end_date": "2024-03-31",
-                  "groupings": [
-                    "resource_account_id",
-                    "service"
-                  ],
-                  "page": 1
+                  "financial_commitment_report_token": "fncl_cmnt_rprt_abc123"
                 }
               }
             ],
             "distractors": [
-              "get-financial-commitment-report",
               "list-financial-commitment-reports",
-              "list-costs",
-              "query-costs"
+              "query-financial-commitment-report-costs",
+              "update-financial-commitment-report",
+              "get-cost-report"
             ]
           },
           "options": {
             "disableVarExpansion": true
           },
           "metadata": {
-            "tool": "query-financial-commitment-report-costs",
+            "tool": "get-financial-commitment-report",
             "resource": "financial-commitment-reports",
             "phrasing": "direct"
           },
@@ -167,56 +146,42 @@
           }
         },
         "vars": {
-          "prompt": "Use query-financial-commitment-report-costs to fetch cost data for financial commitment report fncl_cmnt_rprt_abc123 from 2024-03-01 through 2024-03-31, grouped by resource_account_id and service.",
-          "target": "query-financial-commitment-report-costs",
+          "prompt": "Use get-financial-commitment-report to retrieve the saved configuration for Vantage financial commitment report fncl_cmnt_rprt_abc123.",
+          "target": "get-financial-commitment-report",
           "expected": [
             {
-              "toolName": "query-financial-commitment-report-costs",
+              "toolName": "get-financial-commitment-report",
               "input": {
-                "financial_commitment_report_token": "fncl_cmnt_rprt_abc123",
-                "start_date": "2024-03-01",
-                "end_date": "2024-03-31",
-                "groupings": [
-                  "resource_account_id",
-                  "service"
-                ],
-                "page": 1
+                "financial_commitment_report_token": "fncl_cmnt_rprt_abc123"
               }
             }
           ],
           "distractors": [
-            "get-financial-commitment-report",
             "list-financial-commitment-reports",
-            "list-costs",
-            "query-costs"
+            "query-financial-commitment-report-costs",
+            "update-financial-commitment-report",
+            "get-cost-report"
           ]
         },
         "metadata": {
-          "tool": "query-financial-commitment-report-costs",
+          "tool": "get-financial-commitment-report",
           "resource": "financial-commitment-reports",
           "phrasing": "direct",
           "modelId": "gpt-5.6-luna",
           "mode": "mixed",
-          "target": "query-financial-commitment-report-costs",
+          "target": "get-financial-commitment-report",
           "toolNames": [
-            "query-financial-commitment-report-costs",
             "get-financial-commitment-report",
             "list-financial-commitment-reports",
-            "list-costs",
-            "query-costs"
+            "query-financial-commitment-report-costs",
+            "update-financial-commitment-report",
+            "get-cost-report"
           ],
           "toolCalls": [
             {
-              "toolName": "query-financial-commitment-report-costs",
+              "toolName": "get-financial-commitment-report",
               "input": {
-                "financial_commitment_report_token": "fncl_cmnt_rprt_abc123",
-                "page": 1,
-                "start_date": "2024-03-01",
-                "end_date": "2024-03-31",
-                "groupings": [
-                  "resource_account_id",
-                  "service"
-                ]
+                "financial_commitment_report_token": "fncl_cmnt_rprt_abc123"
               }
             }
           ],
@@ -250,11 +215,11 @@
             }
           ]
         },
-        "id": "cbd2c88a-bb39-41df-9ada-068fbdb7c777",
-        "latencyMs": 2439,
+        "id": "08514c78-dcc1-4fc6-bd44-859b55744752",
+        "latencyMs": 2328,
         "namedScores": {},
         "prompt": {
-          "raw": "For Vantage financial commitment report fncl_cmnt_rprt_abc123, show me which linked accounts' resources are actually consuming the commitments, broken down by resource account and commitment type. Use the report's saved date range and filters.",
+          "raw": "Show me the title, date range, groupings, and filter configured on Vantage financial commitment report fncl_cmnt_rprt_coverage789.",
           "label": "{{prompt}}",
           "config": {
             "disableVarExpansion": true
@@ -270,14 +235,9 @@
           "output": {
             "toolCalls": [
               {
-                "toolName": "query-financial-commitment-report-costs",
+                "toolName": "get-financial-commitment-report",
                 "input": {
-                  "financial_commitment_report_token": "fncl_cmnt_rprt_abc123",
-                  "page": 1,
-                  "groupings": [
-                    "resource_account_id",
-                    "commitment_type"
-                  ]
+                  "financial_commitment_report_token": "fncl_cmnt_rprt_coverage789"
                 }
               }
             ],
@@ -286,24 +246,19 @@
           "metadata": {
             "modelId": "gpt-5.6-luna",
             "mode": "mixed",
-            "target": "query-financial-commitment-report-costs",
+            "target": "get-financial-commitment-report",
             "toolNames": [
-              "query-financial-commitment-report-costs",
               "get-financial-commitment-report",
               "list-financial-commitment-reports",
-              "list-costs",
-              "query-costs"
+              "query-financial-commitment-report-costs",
+              "update-financial-commitment-report",
+              "get-cost-report"
             ],
             "toolCalls": [
               {
-                "toolName": "query-financial-commitment-report-costs",
+                "toolName": "get-financial-commitment-report",
                 "input": {
-                  "financial_commitment_report_token": "fncl_cmnt_rprt_abc123",
-                  "page": 1,
-                  "groupings": [
-                    "resource_account_id",
-                    "commitment_type"
-                  ]
+                  "financial_commitment_report_token": "fncl_cmnt_rprt_coverage789"
                 }
               }
             ]
@@ -312,35 +267,30 @@
         "score": 1,
         "success": true,
         "testCase": {
-          "description": "query-financial-commitment-report-costs · inferred · For Vantage financial commitment report fncl_cmnt_rprt_abc123, show me which linked accounts' resources are actually consuming the commitments, broken down by resource account and commitment type. Use the report's saved date range and filters.",
+          "description": "get-financial-commitment-report · inferred · Show me the title, date range, groupings, and filter configured on Vantage financial commitment report fncl_cmnt_rprt_coverage789.",
           "vars": {
-            "prompt": "For Vantage financial commitment report fncl_cmnt_rprt_abc123, show me which linked accounts' resources are actually consuming the commitments, broken down by resource account and commitment type. Use the report's saved date range and filters.",
-            "target": "query-financial-commitment-report-costs",
+            "prompt": "Show me the title, date range, groupings, and filter configured on Vantage financial commitment report fncl_cmnt_rprt_coverage789.",
+            "target": "get-financial-commitment-report",
             "expected": [
               {
-                "toolName": "query-financial-commitment-report-costs",
+                "toolName": "get-financial-commitment-report",
                 "input": {
-                  "financial_commitment_report_token": "fncl_cmnt_rprt_abc123",
-                  "groupings": [
-                    "resource_account_id",
-                    "commitment_type"
-                  ],
-                  "page": 1
+                  "financial_commitment_report_token": "fncl_cmnt_rprt_coverage789"
                 }
               }
             ],
             "distractors": [
-              "get-financial-commitment-report",
               "list-financial-commitment-reports",
-              "list-costs",
-              "query-costs"
+              "query-financial-commitment-report-costs",
+              "update-financial-commitment-report",
+              "get-cost-report"
             ]
           },
           "options": {
             "disableVarExpansion": true
           },
           "metadata": {
-            "tool": "query-financial-commitment-report-costs",
+            "tool": "get-financial-commitment-report",
             "resource": "financial-commitment-reports",
             "phrasing": "inferred"
           },
@@ -381,52 +331,42 @@
           }
         },
         "vars": {
-          "prompt": "For Vantage financial commitment report fncl_cmnt_rprt_abc123, show me which linked accounts' resources are actually consuming the commitments, broken down by resource account and commitment type. Use the report's saved date range and filters.",
-          "target": "query-financial-commitment-report-costs",
+          "prompt": "Show me the title, date range, groupings, and filter configured on Vantage financial commitment report fncl_cmnt_rprt_coverage789.",
+          "target": "get-financial-commitment-report",
           "expected": [
             {
-              "toolName": "query-financial-commitment-report-costs",
+              "toolName": "get-financial-commitment-report",
               "input": {
-                "financial_commitment_report_token": "fncl_cmnt_rprt_abc123",
-                "groupings": [
-                  "resource_account_id",
-                  "commitment_type"
-                ],
-                "page": 1
+                "financial_commitment_report_token": "fncl_cmnt_rprt_coverage789"
               }
             }
           ],
           "distractors": [
-            "get-financial-commitment-report",
             "list-financial-commitment-reports",
-            "list-costs",
-            "query-costs"
+            "query-financial-commitment-report-costs",
+            "update-financial-commitment-report",
+            "get-cost-report"
           ]
         },
         "metadata": {
-          "tool": "query-financial-commitment-report-costs",
+          "tool": "get-financial-commitment-report",
           "resource": "financial-commitment-reports",
           "phrasing": "inferred",
           "modelId": "gpt-5.6-luna",
           "mode": "mixed",
-          "target": "query-financial-commitment-report-costs",
+          "target": "get-financial-commitment-report",
           "toolNames": [
-            "query-financial-commitment-report-costs",
             "get-financial-commitment-report",
             "list-financial-commitment-reports",
-            "list-costs",
-            "query-costs"
+            "query-financial-commitment-report-costs",
+            "update-financial-commitment-report",
+            "get-cost-report"
           ],
           "toolCalls": [
             {
-              "toolName": "query-financial-commitment-report-costs",
+              "toolName": "get-financial-commitment-report",
               "input": {
-                "financial_commitment_report_token": "fncl_cmnt_rprt_abc123",
-                "page": 1,
-                "groupings": [
-                  "resource_account_id",
-                  "commitment_type"
-                ]
+                "financial_commitment_report_token": "fncl_cmnt_rprt_coverage789"
               }
             }
           ],
@@ -470,7 +410,7 @@
       }
     ],
     "tests": [
-      "file://cases/financial-commitment-reports/query-financial-commitment-report-costs.eval.ts"
+      "file://cases/financial-commitment-reports/get-financial-commitment-report.eval.ts"
     ],
     "env": {},
     "extensions": [],
@@ -485,7 +425,7 @@
     "nodeVersion": "v23.11.0",
     "platform": "darwin",
     "arch": "arm64",
-    "exportedAt": "2026-09-10T20:47:27.425Z",
-    "evaluationCreatedAt": "2026-09-10T20:47:23.716Z"
+    "exportedAt": "2026-09-10T20:46:35.528Z",
+    "evaluationCreatedAt": "2026-09-10T20:46:33.123Z"
   }
 }

--- a/evals/results/gpt-5.6-luna/financial-commitment-reports/list-financial-commitment-reports.json
+++ b/evals/results/gpt-5.6-luna/financial-commitment-reports/list-financial-commitment-reports.json
@@ -2,7 +2,7 @@
   "evalId": null,
   "results": {
     "version": 3,
-    "timestamp": "2026-09-10T20:47:27.803Z",
+    "timestamp": "2026-09-10T20:46:52.541Z",
     "results": [
       {
         "cost": 0,
@@ -30,11 +30,11 @@
             }
           ]
         },
-        "id": "fbed8fb4-6ea1-4928-86c5-cef3166225cb",
-        "latencyMs": 3606,
+        "id": "9ff15ac2-9d2f-4c74-85aa-ca5c58061dd5",
+        "latencyMs": 1640,
         "namedScores": {},
         "prompt": {
-          "raw": "Use query-financial-commitment-report-costs to fetch cost data for financial commitment report fncl_cmnt_rprt_abc123 from 2024-03-01 through 2024-03-31, grouped by resource_account_id and service.",
+          "raw": "Use list-financial-commitment-reports to search page 2 for Vantage financial commitment reports titled Savings Plans in workspace wrkspc_abc123.",
           "label": "{{prompt}}",
           "config": {
             "disableVarExpansion": true
@@ -50,16 +50,11 @@
           "output": {
             "toolCalls": [
               {
-                "toolName": "query-financial-commitment-report-costs",
+                "toolName": "list-financial-commitment-reports",
                 "input": {
-                  "financial_commitment_report_token": "fncl_cmnt_rprt_abc123",
-                  "page": 1,
-                  "start_date": "2024-03-01",
-                  "end_date": "2024-03-31",
-                  "groupings": [
-                    "resource_account_id",
-                    "service"
-                  ]
+                  "page": 2,
+                  "q": "Savings Plans",
+                  "workspace_token": "wrkspc_abc123"
                 }
               }
             ],
@@ -68,26 +63,21 @@
           "metadata": {
             "modelId": "gpt-5.6-luna",
             "mode": "mixed",
-            "target": "query-financial-commitment-report-costs",
+            "target": "list-financial-commitment-reports",
             "toolNames": [
-              "query-financial-commitment-report-costs",
-              "get-financial-commitment-report",
               "list-financial-commitment-reports",
-              "list-costs",
-              "query-costs"
+              "get-financial-commitment-report",
+              "query-financial-commitment-report-costs",
+              "list-cost-reports",
+              "list-workspaces"
             ],
             "toolCalls": [
               {
-                "toolName": "query-financial-commitment-report-costs",
+                "toolName": "list-financial-commitment-reports",
                 "input": {
-                  "financial_commitment_report_token": "fncl_cmnt_rprt_abc123",
-                  "page": 1,
-                  "start_date": "2024-03-01",
-                  "end_date": "2024-03-31",
-                  "groupings": [
-                    "resource_account_id",
-                    "service"
-                  ]
+                  "page": 2,
+                  "q": "Savings Plans",
+                  "workspace_token": "wrkspc_abc123"
                 }
               }
             ]
@@ -96,37 +86,32 @@
         "score": 1,
         "success": true,
         "testCase": {
-          "description": "query-financial-commitment-report-costs · direct · Use query-financial-commitment-report-costs to fetch cost data for financial commitment report fncl_cmnt_rprt_abc123 from 2024-03-01 through 2024-03-31, grouped by resource_account_id and service.",
+          "description": "list-financial-commitment-reports · direct · Use list-financial-commitment-reports to search page 2 for Vantage financial commitment reports titled Savings Plans in workspace wrkspc_abc123.",
           "vars": {
-            "prompt": "Use query-financial-commitment-report-costs to fetch cost data for financial commitment report fncl_cmnt_rprt_abc123 from 2024-03-01 through 2024-03-31, grouped by resource_account_id and service.",
-            "target": "query-financial-commitment-report-costs",
+            "prompt": "Use list-financial-commitment-reports to search page 2 for Vantage financial commitment reports titled Savings Plans in workspace wrkspc_abc123.",
+            "target": "list-financial-commitment-reports",
             "expected": [
               {
-                "toolName": "query-financial-commitment-report-costs",
+                "toolName": "list-financial-commitment-reports",
                 "input": {
-                  "financial_commitment_report_token": "fncl_cmnt_rprt_abc123",
-                  "start_date": "2024-03-01",
-                  "end_date": "2024-03-31",
-                  "groupings": [
-                    "resource_account_id",
-                    "service"
-                  ],
-                  "page": 1
+                  "page": 2,
+                  "q": "Savings Plans",
+                  "workspace_token": "wrkspc_abc123"
                 }
               }
             ],
             "distractors": [
               "get-financial-commitment-report",
-              "list-financial-commitment-reports",
-              "list-costs",
-              "query-costs"
+              "query-financial-commitment-report-costs",
+              "list-cost-reports",
+              "list-workspaces"
             ]
           },
           "options": {
             "disableVarExpansion": true
           },
           "metadata": {
-            "tool": "query-financial-commitment-report-costs",
+            "tool": "list-financial-commitment-reports",
             "resource": "financial-commitment-reports",
             "phrasing": "direct"
           },
@@ -167,56 +152,46 @@
           }
         },
         "vars": {
-          "prompt": "Use query-financial-commitment-report-costs to fetch cost data for financial commitment report fncl_cmnt_rprt_abc123 from 2024-03-01 through 2024-03-31, grouped by resource_account_id and service.",
-          "target": "query-financial-commitment-report-costs",
+          "prompt": "Use list-financial-commitment-reports to search page 2 for Vantage financial commitment reports titled Savings Plans in workspace wrkspc_abc123.",
+          "target": "list-financial-commitment-reports",
           "expected": [
             {
-              "toolName": "query-financial-commitment-report-costs",
+              "toolName": "list-financial-commitment-reports",
               "input": {
-                "financial_commitment_report_token": "fncl_cmnt_rprt_abc123",
-                "start_date": "2024-03-01",
-                "end_date": "2024-03-31",
-                "groupings": [
-                  "resource_account_id",
-                  "service"
-                ],
-                "page": 1
+                "page": 2,
+                "q": "Savings Plans",
+                "workspace_token": "wrkspc_abc123"
               }
             }
           ],
           "distractors": [
             "get-financial-commitment-report",
-            "list-financial-commitment-reports",
-            "list-costs",
-            "query-costs"
+            "query-financial-commitment-report-costs",
+            "list-cost-reports",
+            "list-workspaces"
           ]
         },
         "metadata": {
-          "tool": "query-financial-commitment-report-costs",
+          "tool": "list-financial-commitment-reports",
           "resource": "financial-commitment-reports",
           "phrasing": "direct",
           "modelId": "gpt-5.6-luna",
           "mode": "mixed",
-          "target": "query-financial-commitment-report-costs",
+          "target": "list-financial-commitment-reports",
           "toolNames": [
-            "query-financial-commitment-report-costs",
-            "get-financial-commitment-report",
             "list-financial-commitment-reports",
-            "list-costs",
-            "query-costs"
+            "get-financial-commitment-report",
+            "query-financial-commitment-report-costs",
+            "list-cost-reports",
+            "list-workspaces"
           ],
           "toolCalls": [
             {
-              "toolName": "query-financial-commitment-report-costs",
+              "toolName": "list-financial-commitment-reports",
               "input": {
-                "financial_commitment_report_token": "fncl_cmnt_rprt_abc123",
-                "page": 1,
-                "start_date": "2024-03-01",
-                "end_date": "2024-03-31",
-                "groupings": [
-                  "resource_account_id",
-                  "service"
-                ]
+                "page": 2,
+                "q": "Savings Plans",
+                "workspace_token": "wrkspc_abc123"
               }
             }
           ],
@@ -250,11 +225,11 @@
             }
           ]
         },
-        "id": "cbd2c88a-bb39-41df-9ada-068fbdb7c777",
-        "latencyMs": 2439,
+        "id": "f5369b92-3d60-445f-b49a-fe059125c2c7",
+        "latencyMs": 1673,
         "namedScores": {},
         "prompt": {
-          "raw": "For Vantage financial commitment report fncl_cmnt_rprt_abc123, show me which linked accounts' resources are actually consuming the commitments, broken down by resource account and commitment type. Use the report's saved date range and filters.",
+          "raw": "Which saved Vantage financial commitment reports are available in workspace wrkspc_finops789? Show the first page.",
           "label": "{{prompt}}",
           "config": {
             "disableVarExpansion": true
@@ -270,14 +245,10 @@
           "output": {
             "toolCalls": [
               {
-                "toolName": "query-financial-commitment-report-costs",
+                "toolName": "list-financial-commitment-reports",
                 "input": {
-                  "financial_commitment_report_token": "fncl_cmnt_rprt_abc123",
                   "page": 1,
-                  "groupings": [
-                    "resource_account_id",
-                    "commitment_type"
-                  ]
+                  "workspace_token": "wrkspc_finops789"
                 }
               }
             ],
@@ -286,24 +257,20 @@
           "metadata": {
             "modelId": "gpt-5.6-luna",
             "mode": "mixed",
-            "target": "query-financial-commitment-report-costs",
+            "target": "list-financial-commitment-reports",
             "toolNames": [
-              "query-financial-commitment-report-costs",
-              "get-financial-commitment-report",
               "list-financial-commitment-reports",
-              "list-costs",
-              "query-costs"
+              "get-financial-commitment-report",
+              "query-financial-commitment-report-costs",
+              "list-cost-reports",
+              "list-workspaces"
             ],
             "toolCalls": [
               {
-                "toolName": "query-financial-commitment-report-costs",
+                "toolName": "list-financial-commitment-reports",
                 "input": {
-                  "financial_commitment_report_token": "fncl_cmnt_rprt_abc123",
                   "page": 1,
-                  "groupings": [
-                    "resource_account_id",
-                    "commitment_type"
-                  ]
+                  "workspace_token": "wrkspc_finops789"
                 }
               }
             ]
@@ -312,35 +279,31 @@
         "score": 1,
         "success": true,
         "testCase": {
-          "description": "query-financial-commitment-report-costs · inferred · For Vantage financial commitment report fncl_cmnt_rprt_abc123, show me which linked accounts' resources are actually consuming the commitments, broken down by resource account and commitment type. Use the report's saved date range and filters.",
+          "description": "list-financial-commitment-reports · inferred · Which saved Vantage financial commitment reports are available in workspace wrkspc_finops789? Show the first page.",
           "vars": {
-            "prompt": "For Vantage financial commitment report fncl_cmnt_rprt_abc123, show me which linked accounts' resources are actually consuming the commitments, broken down by resource account and commitment type. Use the report's saved date range and filters.",
-            "target": "query-financial-commitment-report-costs",
+            "prompt": "Which saved Vantage financial commitment reports are available in workspace wrkspc_finops789? Show the first page.",
+            "target": "list-financial-commitment-reports",
             "expected": [
               {
-                "toolName": "query-financial-commitment-report-costs",
+                "toolName": "list-financial-commitment-reports",
                 "input": {
-                  "financial_commitment_report_token": "fncl_cmnt_rprt_abc123",
-                  "groupings": [
-                    "resource_account_id",
-                    "commitment_type"
-                  ],
-                  "page": 1
+                  "page": 1,
+                  "workspace_token": "wrkspc_finops789"
                 }
               }
             ],
             "distractors": [
               "get-financial-commitment-report",
-              "list-financial-commitment-reports",
-              "list-costs",
-              "query-costs"
+              "query-financial-commitment-report-costs",
+              "list-cost-reports",
+              "list-workspaces"
             ]
           },
           "options": {
             "disableVarExpansion": true
           },
           "metadata": {
-            "tool": "query-financial-commitment-report-costs",
+            "tool": "list-financial-commitment-reports",
             "resource": "financial-commitment-reports",
             "phrasing": "inferred"
           },
@@ -381,52 +344,44 @@
           }
         },
         "vars": {
-          "prompt": "For Vantage financial commitment report fncl_cmnt_rprt_abc123, show me which linked accounts' resources are actually consuming the commitments, broken down by resource account and commitment type. Use the report's saved date range and filters.",
-          "target": "query-financial-commitment-report-costs",
+          "prompt": "Which saved Vantage financial commitment reports are available in workspace wrkspc_finops789? Show the first page.",
+          "target": "list-financial-commitment-reports",
           "expected": [
             {
-              "toolName": "query-financial-commitment-report-costs",
+              "toolName": "list-financial-commitment-reports",
               "input": {
-                "financial_commitment_report_token": "fncl_cmnt_rprt_abc123",
-                "groupings": [
-                  "resource_account_id",
-                  "commitment_type"
-                ],
-                "page": 1
+                "page": 1,
+                "workspace_token": "wrkspc_finops789"
               }
             }
           ],
           "distractors": [
             "get-financial-commitment-report",
-            "list-financial-commitment-reports",
-            "list-costs",
-            "query-costs"
+            "query-financial-commitment-report-costs",
+            "list-cost-reports",
+            "list-workspaces"
           ]
         },
         "metadata": {
-          "tool": "query-financial-commitment-report-costs",
+          "tool": "list-financial-commitment-reports",
           "resource": "financial-commitment-reports",
           "phrasing": "inferred",
           "modelId": "gpt-5.6-luna",
           "mode": "mixed",
-          "target": "query-financial-commitment-report-costs",
+          "target": "list-financial-commitment-reports",
           "toolNames": [
-            "query-financial-commitment-report-costs",
-            "get-financial-commitment-report",
             "list-financial-commitment-reports",
-            "list-costs",
-            "query-costs"
+            "get-financial-commitment-report",
+            "query-financial-commitment-report-costs",
+            "list-cost-reports",
+            "list-workspaces"
           ],
           "toolCalls": [
             {
-              "toolName": "query-financial-commitment-report-costs",
+              "toolName": "list-financial-commitment-reports",
               "input": {
-                "financial_commitment_report_token": "fncl_cmnt_rprt_abc123",
                 "page": 1,
-                "groupings": [
-                  "resource_account_id",
-                  "commitment_type"
-                ]
+                "workspace_token": "wrkspc_finops789"
               }
             }
           ],
@@ -470,7 +425,7 @@
       }
     ],
     "tests": [
-      "file://cases/financial-commitment-reports/query-financial-commitment-report-costs.eval.ts"
+      "file://cases/financial-commitment-reports/list-financial-commitment-reports.eval.ts"
     ],
     "env": {},
     "extensions": [],
@@ -485,7 +440,7 @@
     "nodeVersion": "v23.11.0",
     "platform": "darwin",
     "arch": "arm64",
-    "exportedAt": "2026-09-10T20:47:27.425Z",
-    "evaluationCreatedAt": "2026-09-10T20:47:23.716Z"
+    "exportedAt": "2026-09-10T20:46:52.148Z",
+    "evaluationCreatedAt": "2026-09-10T20:46:50.417Z"
   }
 }

--- a/evals/results/gpt-5.6-luna/financial-commitment-reports/update-financial-commitment-report.json
+++ b/evals/results/gpt-5.6-luna/financial-commitment-reports/update-financial-commitment-report.json
@@ -2,7 +2,7 @@
   "evalId": null,
   "results": {
     "version": 3,
-    "timestamp": "2026-09-10T20:47:27.803Z",
+    "timestamp": "2026-09-10T22:50:52.824Z",
     "results": [
       {
         "cost": 0,
@@ -30,11 +30,11 @@
             }
           ]
         },
-        "id": "fbed8fb4-6ea1-4928-86c5-cef3166225cb",
-        "latencyMs": 3606,
+        "id": "273c5513-2b8f-40d9-a012-1a05928f91d1",
+        "latencyMs": 2268,
         "namedScores": {},
         "prompt": {
-          "raw": "Use query-financial-commitment-report-costs to fetch cost data for financial commitment report fncl_cmnt_rprt_abc123 from 2024-03-01 through 2024-03-31, grouped by resource_account_id and service.",
+          "raw": "Use update-financial-commitment-report to rename fncl_cmnt_rprt_abc123 to Account Commitment Coverage and group it by resource_account_id and service.",
           "label": "{{prompt}}",
           "config": {
             "disableVarExpansion": true
@@ -50,12 +50,10 @@
           "output": {
             "toolCalls": [
               {
-                "toolName": "query-financial-commitment-report-costs",
+                "toolName": "update-financial-commitment-report",
                 "input": {
                   "financial_commitment_report_token": "fncl_cmnt_rprt_abc123",
-                  "page": 1,
-                  "start_date": "2024-03-01",
-                  "end_date": "2024-03-31",
+                  "title": "Account Commitment Coverage",
                   "groupings": [
                     "resource_account_id",
                     "service"
@@ -68,22 +66,20 @@
           "metadata": {
             "modelId": "gpt-5.6-luna",
             "mode": "mixed",
-            "target": "query-financial-commitment-report-costs",
+            "target": "update-financial-commitment-report",
             "toolNames": [
+              "update-financial-commitment-report",
+              "create-financial-commitment-report",
               "query-financial-commitment-report-costs",
               "get-financial-commitment-report",
-              "list-financial-commitment-reports",
-              "list-costs",
-              "query-costs"
+              "update-cost-report"
             ],
             "toolCalls": [
               {
-                "toolName": "query-financial-commitment-report-costs",
+                "toolName": "update-financial-commitment-report",
                 "input": {
                   "financial_commitment_report_token": "fncl_cmnt_rprt_abc123",
-                  "page": 1,
-                  "start_date": "2024-03-01",
-                  "end_date": "2024-03-31",
+                  "title": "Account Commitment Coverage",
                   "groupings": [
                     "resource_account_id",
                     "service"
@@ -96,37 +92,35 @@
         "score": 1,
         "success": true,
         "testCase": {
-          "description": "query-financial-commitment-report-costs · direct · Use query-financial-commitment-report-costs to fetch cost data for financial commitment report fncl_cmnt_rprt_abc123 from 2024-03-01 through 2024-03-31, grouped by resource_account_id and service.",
+          "description": "update-financial-commitment-report · direct · Use update-financial-commitment-report to rename fncl_cmnt_rprt_abc123 to Account Commitment Coverage and group it by resource_account_id and service.",
           "vars": {
-            "prompt": "Use query-financial-commitment-report-costs to fetch cost data for financial commitment report fncl_cmnt_rprt_abc123 from 2024-03-01 through 2024-03-31, grouped by resource_account_id and service.",
-            "target": "query-financial-commitment-report-costs",
+            "prompt": "Use update-financial-commitment-report to rename fncl_cmnt_rprt_abc123 to Account Commitment Coverage and group it by resource_account_id and service.",
+            "target": "update-financial-commitment-report",
             "expected": [
               {
-                "toolName": "query-financial-commitment-report-costs",
+                "toolName": "update-financial-commitment-report",
                 "input": {
                   "financial_commitment_report_token": "fncl_cmnt_rprt_abc123",
-                  "start_date": "2024-03-01",
-                  "end_date": "2024-03-31",
+                  "title": "Account Commitment Coverage",
                   "groupings": [
                     "resource_account_id",
                     "service"
-                  ],
-                  "page": 1
+                  ]
                 }
               }
             ],
             "distractors": [
+              "create-financial-commitment-report",
+              "query-financial-commitment-report-costs",
               "get-financial-commitment-report",
-              "list-financial-commitment-reports",
-              "list-costs",
-              "query-costs"
+              "update-cost-report"
             ]
           },
           "options": {
             "disableVarExpansion": true
           },
           "metadata": {
-            "tool": "query-financial-commitment-report-costs",
+            "tool": "update-financial-commitment-report",
             "resource": "financial-commitment-reports",
             "phrasing": "direct"
           },
@@ -167,52 +161,48 @@
           }
         },
         "vars": {
-          "prompt": "Use query-financial-commitment-report-costs to fetch cost data for financial commitment report fncl_cmnt_rprt_abc123 from 2024-03-01 through 2024-03-31, grouped by resource_account_id and service.",
-          "target": "query-financial-commitment-report-costs",
+          "prompt": "Use update-financial-commitment-report to rename fncl_cmnt_rprt_abc123 to Account Commitment Coverage and group it by resource_account_id and service.",
+          "target": "update-financial-commitment-report",
           "expected": [
             {
-              "toolName": "query-financial-commitment-report-costs",
+              "toolName": "update-financial-commitment-report",
               "input": {
                 "financial_commitment_report_token": "fncl_cmnt_rprt_abc123",
-                "start_date": "2024-03-01",
-                "end_date": "2024-03-31",
+                "title": "Account Commitment Coverage",
                 "groupings": [
                   "resource_account_id",
                   "service"
-                ],
-                "page": 1
+                ]
               }
             }
           ],
           "distractors": [
+            "create-financial-commitment-report",
+            "query-financial-commitment-report-costs",
             "get-financial-commitment-report",
-            "list-financial-commitment-reports",
-            "list-costs",
-            "query-costs"
+            "update-cost-report"
           ]
         },
         "metadata": {
-          "tool": "query-financial-commitment-report-costs",
+          "tool": "update-financial-commitment-report",
           "resource": "financial-commitment-reports",
           "phrasing": "direct",
           "modelId": "gpt-5.6-luna",
           "mode": "mixed",
-          "target": "query-financial-commitment-report-costs",
+          "target": "update-financial-commitment-report",
           "toolNames": [
+            "update-financial-commitment-report",
+            "create-financial-commitment-report",
             "query-financial-commitment-report-costs",
             "get-financial-commitment-report",
-            "list-financial-commitment-reports",
-            "list-costs",
-            "query-costs"
+            "update-cost-report"
           ],
           "toolCalls": [
             {
-              "toolName": "query-financial-commitment-report-costs",
+              "toolName": "update-financial-commitment-report",
               "input": {
                 "financial_commitment_report_token": "fncl_cmnt_rprt_abc123",
-                "page": 1,
-                "start_date": "2024-03-01",
-                "end_date": "2024-03-31",
+                "title": "Account Commitment Coverage",
                 "groupings": [
                   "resource_account_id",
                   "service"
@@ -250,11 +240,11 @@
             }
           ]
         },
-        "id": "cbd2c88a-bb39-41df-9ada-068fbdb7c777",
-        "latencyMs": 2439,
+        "id": "7483c014-b243-4172-a8ce-f3d99796f5e0",
+        "latencyMs": 1996,
         "namedScores": {},
         "prompt": {
-          "raw": "For Vantage financial commitment report fncl_cmnt_rprt_abc123, show me which linked accounts' resources are actually consuming the commitments, broken down by resource account and commitment type. Use the report's saved date range and filters.",
+          "raw": "Change Vantage financial commitment report fncl_cmnt_rprt_abc123 to be weekly, make on demand discountable, and group by cost type and commitment type",
           "label": "{{prompt}}",
           "config": {
             "disableVarExpansion": true
@@ -270,12 +260,13 @@
           "output": {
             "toolCalls": [
               {
-                "toolName": "query-financial-commitment-report-costs",
+                "toolName": "update-financial-commitment-report",
                 "input": {
                   "financial_commitment_report_token": "fncl_cmnt_rprt_abc123",
-                  "page": 1,
+                  "date_bucket": "week",
+                  "on_demand_costs_scope": "discountable",
                   "groupings": [
-                    "resource_account_id",
+                    "cost_type",
                     "commitment_type"
                   ]
                 }
@@ -286,22 +277,23 @@
           "metadata": {
             "modelId": "gpt-5.6-luna",
             "mode": "mixed",
-            "target": "query-financial-commitment-report-costs",
+            "target": "update-financial-commitment-report",
             "toolNames": [
+              "update-financial-commitment-report",
+              "create-financial-commitment-report",
               "query-financial-commitment-report-costs",
               "get-financial-commitment-report",
-              "list-financial-commitment-reports",
-              "list-costs",
-              "query-costs"
+              "update-cost-report"
             ],
             "toolCalls": [
               {
-                "toolName": "query-financial-commitment-report-costs",
+                "toolName": "update-financial-commitment-report",
                 "input": {
                   "financial_commitment_report_token": "fncl_cmnt_rprt_abc123",
-                  "page": 1,
+                  "date_bucket": "week",
+                  "on_demand_costs_scope": "discountable",
                   "groupings": [
-                    "resource_account_id",
+                    "cost_type",
                     "commitment_type"
                   ]
                 }
@@ -312,35 +304,36 @@
         "score": 1,
         "success": true,
         "testCase": {
-          "description": "query-financial-commitment-report-costs · inferred · For Vantage financial commitment report fncl_cmnt_rprt_abc123, show me which linked accounts' resources are actually consuming the commitments, broken down by resource account and commitment type. Use the report's saved date range and filters.",
+          "description": "update-financial-commitment-report · inferred · Change Vantage financial commitment report fncl_cmnt_rprt_abc123 to be weekly, make on demand discountable, and group by cost type and commitment type",
           "vars": {
-            "prompt": "For Vantage financial commitment report fncl_cmnt_rprt_abc123, show me which linked accounts' resources are actually consuming the commitments, broken down by resource account and commitment type. Use the report's saved date range and filters.",
-            "target": "query-financial-commitment-report-costs",
+            "prompt": "Change Vantage financial commitment report fncl_cmnt_rprt_abc123 to be weekly, make on demand discountable, and group by cost type and commitment type",
+            "target": "update-financial-commitment-report",
             "expected": [
               {
-                "toolName": "query-financial-commitment-report-costs",
+                "toolName": "update-financial-commitment-report",
                 "input": {
                   "financial_commitment_report_token": "fncl_cmnt_rprt_abc123",
+                  "date_bucket": "week",
+                  "on_demand_costs_scope": "discountable",
                   "groupings": [
-                    "resource_account_id",
+                    "cost_type",
                     "commitment_type"
-                  ],
-                  "page": 1
+                  ]
                 }
               }
             ],
             "distractors": [
+              "create-financial-commitment-report",
+              "query-financial-commitment-report-costs",
               "get-financial-commitment-report",
-              "list-financial-commitment-reports",
-              "list-costs",
-              "query-costs"
+              "update-cost-report"
             ]
           },
           "options": {
             "disableVarExpansion": true
           },
           "metadata": {
-            "tool": "query-financial-commitment-report-costs",
+            "tool": "update-financial-commitment-report",
             "resource": "financial-commitment-reports",
             "phrasing": "inferred"
           },
@@ -381,50 +374,52 @@
           }
         },
         "vars": {
-          "prompt": "For Vantage financial commitment report fncl_cmnt_rprt_abc123, show me which linked accounts' resources are actually consuming the commitments, broken down by resource account and commitment type. Use the report's saved date range and filters.",
-          "target": "query-financial-commitment-report-costs",
+          "prompt": "Change Vantage financial commitment report fncl_cmnt_rprt_abc123 to be weekly, make on demand discountable, and group by cost type and commitment type",
+          "target": "update-financial-commitment-report",
           "expected": [
             {
-              "toolName": "query-financial-commitment-report-costs",
+              "toolName": "update-financial-commitment-report",
               "input": {
                 "financial_commitment_report_token": "fncl_cmnt_rprt_abc123",
+                "date_bucket": "week",
+                "on_demand_costs_scope": "discountable",
                 "groupings": [
-                  "resource_account_id",
+                  "cost_type",
                   "commitment_type"
-                ],
-                "page": 1
+                ]
               }
             }
           ],
           "distractors": [
+            "create-financial-commitment-report",
+            "query-financial-commitment-report-costs",
             "get-financial-commitment-report",
-            "list-financial-commitment-reports",
-            "list-costs",
-            "query-costs"
+            "update-cost-report"
           ]
         },
         "metadata": {
-          "tool": "query-financial-commitment-report-costs",
+          "tool": "update-financial-commitment-report",
           "resource": "financial-commitment-reports",
           "phrasing": "inferred",
           "modelId": "gpt-5.6-luna",
           "mode": "mixed",
-          "target": "query-financial-commitment-report-costs",
+          "target": "update-financial-commitment-report",
           "toolNames": [
+            "update-financial-commitment-report",
+            "create-financial-commitment-report",
             "query-financial-commitment-report-costs",
             "get-financial-commitment-report",
-            "list-financial-commitment-reports",
-            "list-costs",
-            "query-costs"
+            "update-cost-report"
           ],
           "toolCalls": [
             {
-              "toolName": "query-financial-commitment-report-costs",
+              "toolName": "update-financial-commitment-report",
               "input": {
                 "financial_commitment_report_token": "fncl_cmnt_rprt_abc123",
-                "page": 1,
+                "date_bucket": "week",
+                "on_demand_costs_scope": "discountable",
                 "groupings": [
-                  "resource_account_id",
+                  "cost_type",
                   "commitment_type"
                 ]
               }
@@ -470,7 +465,7 @@
       }
     ],
     "tests": [
-      "file://cases/financial-commitment-reports/query-financial-commitment-report-costs.eval.ts"
+      "file://cases/financial-commitment-reports/update-financial-commitment-report.eval.ts"
     ],
     "env": {},
     "extensions": [],
@@ -485,7 +480,7 @@
     "nodeVersion": "v23.11.0",
     "platform": "darwin",
     "arch": "arm64",
-    "exportedAt": "2026-09-10T20:47:27.425Z",
-    "evaluationCreatedAt": "2026-09-10T20:47:23.716Z"
+    "exportedAt": "2026-09-10T22:50:52.460Z",
+    "evaluationCreatedAt": "2026-09-10T22:50:50.095Z"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
         "@cloudflare/workers-oauth-provider": "^0.0.11",
         "@modelcontextprotocol/sdk": "1.29.0",
         "@sentry/cloudflare": "10.30.0",
-        "@vantage-sh/vantage-client": "2.24.0",
+        "@vantage-sh/vantage-client": "2.27.0",
         "agents": "^0.13.2",
         "axios": "1.13.5",
         "hono": "4.12.12",
@@ -7841,9 +7841,9 @@
       }
     },
     "node_modules/@vantage-sh/vantage-client": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/@vantage-sh/vantage-client/-/vantage-client-2.24.0.tgz",
-      "integrity": "sha512-9JsS37yykTtp6jcJFOCqXUOnoe9NDzOeqWJEQX+2q+nCOk4PL/BhfPzxnEWP1N7qf5RCdlSiVF3xLAsBSkLyBQ==",
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/@vantage-sh/vantage-client/-/vantage-client-2.27.0.tgz",
+      "integrity": "sha512-JWSzsPMhLuKmsuFYfNPAYTF0vVQyE/aynDbLmfMcpzIILltm/pHcAAmsl1qb1m2FJyh2tQqx0uNe4+Ru1/2jdg==",
       "license": "MIT"
     },
     "node_modules/@vercel/oidc": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@cloudflare/workers-oauth-provider": "^0.0.11",
     "@modelcontextprotocol/sdk": "1.29.0",
     "@sentry/cloudflare": "10.30.0",
-    "@vantage-sh/vantage-client": "2.24.0",
+    "@vantage-sh/vantage-client": "2.27.0",
     "agents": "^0.13.2",
     "axios": "1.13.5",
     "hono": "4.12.12",

--- a/src/tools/financial-commitment-reports/create-financial-commitment-report.ts
+++ b/src/tools/financial-commitment-reports/create-financial-commitment-report.ts
@@ -1,4 +1,3 @@
-import type { RequestBodyForPathAndMethod } from "@vantage-sh/vantage-client";
 import z from "zod";
 import { pastDateIntervalOptions } from "../../utils/dateIntervalOptions";
 import dateValidator from "../../utils/dateValidator";
@@ -8,28 +7,8 @@ import registerTool from "../structure/registerTool";
 import { groupingDescription, groupingSchema } from "./schemas";
 
 const description = `
-Create a new Financial Commitment Report in Vantage.
-
-Financial Commitment Reports track committed spend and on-demand costs over time. They can be filtered
-using VQL and grouped by dimensions such as commitment type, service, region, or tags.
-
-VQL Filtering Guide:
-Financial Commitment Report VQL uses the financial_commitments namespace. A provider filter should be
-included in each query, and string values should be wrapped in single quotes.
-
-Basic VQL Syntax:
-- Query on a provider: (financial_commitments.provider = 'aws')
-- Query on a service: (financial_commitments.provider = 'aws' AND financial_commitments.service = 'AmazonEC2')
-- Multiple services: (financial_commitments.provider = 'aws' AND financial_commitments.service IN ('AmazonEC2','AmazonRDS'))
-- Filter by billing account: (financial_commitments.provider = 'aws' AND financial_commitments.provider_account_id = '123456789012')
-- Filter by region: (financial_commitments.provider = 'aws' AND financial_commitments.region = 'us-east-1')
-- Filter by tag: (financial_commitments.provider = 'aws' AND financial_commitments.resource_tags->>'environment' = 'production')
-
-Use get-myself to find available workspaces. Use the VQL for Financial Commitment Reports resource for
-the full list of available financial_commitments fields and examples.
+Creates a saved Financial Commitment Report for analyzing committed spend and on-demand costs.
 `.trim();
-
-type CreateFinancialCommitmentReportRequest = RequestBodyForPathAndMethod<"/v2/financial_commitment_reports", "POST">;
 
 export default registerTool({
   name: "create-financial-commitment-report",
@@ -58,18 +37,10 @@ export default registerTool({
       ),
     date_bucket: z.enum(["hour", "day", "week", "month", "quarter"]).optional().describe("Date aggregation bucket"),
     on_demand_costs_scope: z.enum(["discountable", "all"]).optional().describe("Scope for on-demand costs"),
-    groupings: z
-      .array(groupingSchema)
-      .optional()
-      .transform((v) => v?.join(","))
-      .describe(groupingDescription),
+    groupings: z.array(groupingSchema).optional().describe(groupingDescription),
   },
   async execute(args, ctx) {
-    const response = await ctx.callVantageApi(
-      "/v2/financial_commitment_reports",
-      args as CreateFinancialCommitmentReportRequest,
-      "POST"
-    );
+    const response = await ctx.callVantageApi("/v2/financial_commitment_reports", args, "POST");
     if (!response.ok) {
       throw new MCPUserError({ errors: response.errors });
     }

--- a/src/tools/financial-commitment-reports/schemas.ts
+++ b/src/tools/financial-commitment-reports/schemas.ts
@@ -1,64 +1,28 @@
+import {
+  createNonEmptyString,
+  isNonEmptyString,
+  VANTAGE_FINANCIAL_COMMITMENT_GROUPINGS,
+  type VantageFinancialCommitmentGrouping,
+} from "@vantage-sh/vantage-client";
 import z from "zod";
 
-const financialCommitmentGroupings = [
-  "provider",
-  "service",
-  "resource_account_id",
-  "provider_account_id",
-  "commitment_type",
-  "commitment_id",
-  "cost_type",
-  "cost_category",
-  "cost_sub_category",
-  "instance_type",
-  "region",
-] as const;
+export const groupingDescription = "Grouping dimensions for the report. Use tag:<tag_key> to group by tag.";
 
-export const groupingDescription =
-  "Grouping dimensions for aggregating financial commitments on the report. Valid groupings: provider, service, resource_account_id, provider_account_id, commitment_type, commitment_id, cost_type, cost_category, cost_sub_category, instance_type, region, and tag:<tag_key>.";
-
-export const groupingSchema = z
-  .string()
-  .min(1)
-  .refine(
-    (value) =>
-      financialCommitmentGroupings.includes(value as (typeof financialCommitmentGroupings)[number]) ||
-      value.startsWith("tag:"),
-    {
-      error: groupingDescription,
-      when(payload) {
-        return z.string().min(1).safeParse(payload.value).success;
-      },
-    }
+const groupingValueSchema = (description: string) =>
+  z.union(
+    [
+      z.enum(VANTAGE_FINANCIAL_COMMITMENT_GROUPINGS),
+      z
+        .string()
+        .startsWith("tag:", { error: description })
+        .refine((value) => isNonEmptyString(value.slice(4)), { error: description })
+        .transform((value): VantageFinancialCommitmentGrouping => `tag:${createNonEmptyString(value.slice(4))}`),
+    ],
+    { error: description }
   );
 
-const financialCommitmentCostGroupings = [
-  "cost_type",
-  "commitment_type",
-  "commitment_id",
-  "service",
-  "resource_account_id",
-  "provider_account_id",
-  "region",
-  "cost_category",
-  "cost_sub_category",
-  "instance_type",
-] as const;
+export const groupingSchema = groupingValueSchema(groupingDescription);
 
-export const costGroupingDescription =
-  "Grouping dimensions for aggregating costs on the report. Valid groupings: cost_type, commitment_type, commitment_id, service, resource_account_id, provider_account_id, region, cost_category, cost_sub_category, instance_type, and tag:<tag_key>.";
+export const costGroupingDescription = "Grouping dimensions for returned costs. Use tag:<tag_key> to group by tag.";
 
-export const costGroupingSchema = z
-  .string()
-  .min(1)
-  .refine(
-    (value) =>
-      financialCommitmentCostGroupings.includes(value as (typeof financialCommitmentCostGroupings)[number]) ||
-      value.startsWith("tag:"),
-    {
-      error: costGroupingDescription,
-      when(payload) {
-        return z.string().min(1).safeParse(payload.value).success;
-      },
-    }
-  );
+export const costGroupingSchema = groupingValueSchema(costGroupingDescription);

--- a/src/tools/financial-commitment-reports/update-financial-commitment-report.ts
+++ b/src/tools/financial-commitment-reports/update-financial-commitment-report.ts
@@ -1,4 +1,4 @@
-import { pathEncode, type UpdateFinancialCommitmentReportRequest } from "@vantage-sh/vantage-client";
+import { pathEncode } from "@vantage-sh/vantage-client";
 import z from "zod";
 import { pastDateIntervalOptions } from "../../utils/dateIntervalOptions";
 import dateValidator from "../../utils/dateValidator";
@@ -8,15 +8,7 @@ import registerTool from "../structure/registerTool";
 import { groupingDescription, groupingSchema } from "./schemas";
 
 const description = `
-Updates an existing Financial Commitment Report. Use this to change the report title, VQL filter, date range, date bucket, on-demand costs scope, or grouping dimensions.
-
-Date ranges can be set with either:
-- date_interval, or
-- start_date and end_date.
-
-Unless date_interval is "custom", date_interval is incompatible with start_date and end_date.
-
-VQL filters use financial commitment fields and should follow Vantage Query Language syntax. Additional VQL documentation is available at https://docs.vantage.sh/vql.
+Updates a saved Financial Commitment Report. Use list-financial-commitment-reports to discover tokens.
 `.trim();
 
 export default registerTool({
@@ -51,17 +43,13 @@ export default registerTool({
       ),
     date_bucket: z.enum(["hour", "day", "week", "month", "quarter"]).optional().describe("Updated date bucket."),
     on_demand_costs_scope: z.enum(["discountable", "all"]).optional().describe("Updated on-demand costs scope."),
-    groupings: z
-      .array(groupingSchema)
-      .optional()
-      .transform((v) => v?.join(","))
-      .describe(groupingDescription),
+    groupings: z.array(groupingSchema).optional().describe(groupingDescription),
   },
   async execute(args, ctx) {
     const { financial_commitment_report_token, ...requestBody } = args;
     const response = await ctx.callVantageApi(
       `/v2/financial_commitment_reports/${pathEncode(financial_commitment_report_token)}`,
-      requestBody as UpdateFinancialCommitmentReportRequest,
+      requestBody,
       "PUT"
     );
     if (!response.ok) {

--- a/test/tools/financial-commitment-reports/create-financial-commitment-report.test.ts
+++ b/test/tools/financial-commitment-reports/create-financial-commitment-report.test.ts
@@ -1,4 +1,4 @@
-import type { RequestBodyForPathAndMethod } from "@vantage-sh/vantage-client";
+import { VANTAGE_FINANCIAL_COMMITMENT_GROUPINGS } from "@vantage-sh/vantage-client";
 import { expect } from "vitest";
 import tool from "../../../src/tools/financial-commitment-reports/create-financial-commitment-report";
 import {
@@ -15,8 +15,6 @@ import {
 
 type Validators = ExtractValidators<typeof tool>;
 type OutputSchema = ExtractOutputSchema<typeof tool>;
-type CreateFinancialCommitmentReportRequest = RequestBodyForPathAndMethod<"/v2/financial_commitment_reports", "POST">;
-
 const undefineds = {
   filter: undefined,
   start_date: undefined,
@@ -46,13 +44,6 @@ const validInputArguments: InferValidators<Validators> = {
   groupings: ["provider_account_id", "service"],
 };
 
-const expectedValidInputArguments = {
-  ...validInputArguments,
-  groupings: "provider_account_id,service",
-} as unknown as CreateFinancialCommitmentReportRequest;
-const expectedMinimalValidInputArguments =
-  minimalValidInputArguments as unknown as CreateFinancialCommitmentReportRequest;
-
 const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
   {
     name: "minimal valid arguments",
@@ -77,6 +68,13 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
       title: "",
     },
     expectedIssues: ["Too small: expected string to have >=1 characters"],
+  },
+  {
+    name: "all built-in groupings",
+    data: {
+      ...minimalValidInputArguments,
+      groupings: [...VANTAGE_FINANCIAL_COMMITMENT_GROUPINGS],
+    },
   },
   {
     name: "tag grouping",
@@ -104,22 +102,20 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
     expectedIssues: ['Invalid option: expected one of "discountable"|"all"'],
   },
   {
-    name: "invalid grouping",
+    name: "empty tag key",
     data: {
       ...validInputArguments,
-      groupings: ["unsupported_grouping"],
+      groupings: ["tag:"],
     },
-    expectedIssues: [
-      "Grouping dimensions for aggregating financial commitments on the report. Valid groupings: provider, service, resource_account_id, provider_account_id, commitment_type, commitment_id, cost_type, cost_category, cost_sub_category, instance_type, region, and tag:<tag_key>.",
-    ],
+    expectedIssues: ["Grouping dimensions for the report. Use tag:<tag_key> to group by tag."],
   },
   {
-    name: "empty grouping",
+    name: "whitespace-only tag key",
     data: {
       ...validInputArguments,
-      groupings: [""],
+      groupings: ["tag: \t"],
     },
-    expectedIssues: ["Too small: expected string to have >=1 characters"],
+    expectedIssues: ["Grouping dimensions for the report. Use tag:<tag_key> to group by tag."],
   },
   poisonOneValue(validInputArguments, "start_date", dateValidatorPoisoner),
   poisonOneValue(validInputArguments, "end_date", dateValidatorPoisoner),
@@ -147,7 +143,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
     apiCallHandler: requestsInOrder([
       {
         endpoint: "/v2/financial_commitment_reports",
-        params: expectedValidInputArguments,
+        params: validInputArguments,
         method: "POST",
         result: {
           ok: true,
@@ -165,7 +161,7 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
     apiCallHandler: requestsInOrder([
       {
         endpoint: "/v2/financial_commitment_reports",
-        params: expectedMinimalValidInputArguments,
+        params: minimalValidInputArguments,
         method: "POST",
         result: {
           ok: false,

--- a/test/tools/financial-commitment-reports/query-financial-commitment-report-costs.test.ts
+++ b/test/tools/financial-commitment-reports/query-financial-commitment-report-costs.test.ts
@@ -53,9 +53,15 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
       financial_commitment_report_token: "fncl_cmnt_rprt_123",
       groupings: ["provider"],
     },
-    expectedIssues: [
-      "Grouping dimensions for aggregating costs on the report. Valid groupings: cost_type, commitment_type, commitment_id, service, resource_account_id, provider_account_id, region, cost_category, cost_sub_category, instance_type, and tag:<tag_key>.",
-    ],
+    expectedIssues: ["Grouping dimensions for returned costs. Use tag:<tag_key> to group by tag."],
+  },
+  {
+    name: "rejects empty tag key",
+    data: {
+      financial_commitment_report_token: "fncl_cmnt_rprt_123",
+      groupings: ["tag:"],
+    },
+    expectedIssues: ["Grouping dimensions for returned costs. Use tag:<tag_key> to group by tag."],
   },
   poisonOneValue(validArguments, "start_date", dateValidatorPoisoner),
   poisonOneValue(validArguments, "end_date", dateValidatorPoisoner),

--- a/test/tools/financial-commitment-reports/update-financial-commitment-report.test.ts
+++ b/test/tools/financial-commitment-reports/update-financial-commitment-report.test.ts
@@ -1,7 +1,7 @@
 import {
   pathEncode,
-  type UpdateFinancialCommitmentReportRequest,
   type UpdateFinancialCommitmentReportResponse,
+  VANTAGE_FINANCIAL_COMMITMENT_GROUPINGS,
 } from "@vantage-sh/vantage-client";
 import { expect } from "vitest";
 import tool from "../../../src/tools/financial-commitment-reports/update-financial-commitment-report";
@@ -56,6 +56,13 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
     data: validInputArguments,
   },
   {
+    name: "all built-in groupings",
+    data: {
+      ...minimalValidInputArguments,
+      groupings: [...VANTAGE_FINANCIAL_COMMITMENT_GROUPINGS],
+    },
+  },
+  {
     name: "invalid date bucket",
     data: {
       ...validInputArguments,
@@ -75,11 +82,17 @@ const argumentSchemaTests: SchemaTestTableItem<Validators>[] = [
     name: "invalid grouping",
     data: {
       ...validInputArguments,
-      groupings: ["unsupported_grouping"],
+      groupings: ["provider"],
     },
-    expectedIssues: [
-      "Grouping dimensions for aggregating financial commitments on the report. Valid groupings: provider, service, resource_account_id, provider_account_id, commitment_type, commitment_id, cost_type, cost_category, cost_sub_category, instance_type, region, and tag:<tag_key>.",
-    ],
+    expectedIssues: ["Grouping dimensions for the report. Use tag:<tag_key> to group by tag."],
+  },
+  {
+    name: "empty tag key",
+    data: {
+      ...validInputArguments,
+      groupings: ["tag:"],
+    },
+    expectedIssues: ["Grouping dimensions for the report. Use tag:<tag_key> to group by tag."],
   },
   {
     name: "invalid start date",
@@ -145,8 +158,8 @@ const executionTests: ExecutionTestTableItem<Validators, OutputSchema>[] = [
           date_interval: "last_3_months",
           date_bucket: "week",
           on_demand_costs_scope: "discountable",
-          groupings: "cost_type,commitment_type",
-        } as unknown as UpdateFinancialCommitmentReportRequest,
+          groupings: ["cost_type", "commitment_type"],
+        },
         method: "PUT",
         result: {
           ok: true,


### PR DESCRIPTION
## What Changed

Got a report that `create-financial-commitment-report` wasn't working due to `provider` being included in groupings. Validated that `provider` is not accepted by the API. Upstream work in the API and `vantage-ts` was done to provide constants to the MCP so that this drift doesn't happen again. Any updates to the API will automatically sync to here

## Testing Done

- [x] Unit tests added and updated
- [x] Evals added
- [x] Tested locally

<img width="961" height="659" alt="image" src="https://github.com/user-attachments/assets/f74d921c-4077-4695-a87f-cb6e0eb463d0" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes validated grouping enums and the request shape for create/update report calls, which can reject previously accepted inputs but reduces API failures; covered by updated unit and eval tests.
> 
> **Overview**
> Aligns **Financial Commitment Report** MCP tools with the Vantage API by bumping `@vantage-sh/vantage-client` to **2.27.0** and driving grouping validation from `VANTAGE_FINANCIAL_COMMITMENT_GROUPINGS` instead of hand-maintained lists (fixing drift such as accepting **`provider`** when the API rejects it). Report and cost grouping schemas now share the same validator, including stricter **`tag:`** key checks.
> 
> **Create** and **update** tools stop joining `groupings` into a comma-separated string before `callVantageApi`; payloads stay as arrays. Tool descriptions are shortened accordingly.
> 
> Adds **promptfoo** eval cases for the full financial-commitment-reports tool set (plus refreshed expectations for **query-financial-commitment-report-costs** groupings), commits passing **gpt-5.6-luna** result JSON, and marks `evals/results/**` as linguist-generated. Unit tests are updated for the new validation messages and API param shapes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60aee612ac8895501786cb701bd4e69f10df9557. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->